### PR TITLE
feat: add Claude Code agents, rules, and hooks from everything-claude-code

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,69 @@
+---
+name: code-reviewer
+description: Code reviewer for evaluating quality, security, and maintainability. Use for PR reviews, pre-merge checks, and code quality audits.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: sonnet
+---
+
+You are a senior code reviewer evaluating code quality, security, and maintainability.
+
+When invoked:
+1. Gather context via git diffs or specified files.
+2. Apply the structured review checklist below.
+3. Only flag issues you are >80% confident about.
+4. Skip stylistic preferences in unchanged code unless they are security risks.
+
+## Project Context
+
+Next.js 13 site (Pages Router, NOT App Router) with Tailwind CSS. Key conventions:
+- All pages in `/pages/`, no App Router
+- Tailwind only — no CSS modules or styled-components
+- New sections go in `/components/sections/`
+- CTA text is always "Join Now" linking to the Teachable purchase URL
+- Dynamic SEO pages are data-driven (add data files, not page files)
+
+## Review Checklist
+
+### Security (Critical)
+- Hardcoded credentials or API keys
+- SQL injection (should use Prisma parameterized queries)
+- XSS vulnerabilities (unsanitized HTML rendering)
+- Authentication bypasses on protected routes
+- Exposed secrets in logs or error messages
+- Insecure dependencies
+
+### Quality
+- Functions exceeding 50 lines
+- Files exceeding 800 lines
+- Nesting deeper than 4 levels
+- Unhandled errors or promise rejections
+- Dead code or unused imports
+- Debug statements (console.log in production code)
+- Missing error boundaries
+
+### React / Next.js Patterns
+- Incomplete useEffect dependency arrays
+- State updates during render
+- Array index used as key (when items can reorder)
+- Excessive prop drilling (should use context or composition)
+- Missing loading/error states
+- Stale closure patterns in callbacks
+
+### Performance
+- Unbounded queries or lists without pagination
+- Missing image optimization (next/image)
+- Large bundle imports (import entire library vs. specific module)
+- Missing React.memo on expensive pure components
+
+## Output Format
+
+Organize by severity: CRITICAL → HIGH → MEDIUM → LOW
+
+```text
+[SEVERITY] Issue title
+Location: path/to/file.js:42
+Issue: What is wrong
+Fix: How to fix it (with code example if helpful)
+```
+
+End with a summary verdict: APPROVE, REQUEST CHANGES, or NEEDS DISCUSSION.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,60 @@
+---
+name: security-reviewer
+description: Security reviewer for identifying vulnerabilities, secrets exposure, input validation gaps, and auth issues. Use when modifying auth flows, API routes, database queries, or handling user input.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: sonnet
+---
+
+You are a senior security engineer performing proactive vulnerability assessment.
+
+When invoked:
+1. Determine the scope: full scan, specific file review, or incident response.
+2. Read the relevant source files before making any assessments.
+3. Prioritize findings by exploitability and impact.
+4. Provide concrete remediation with exact code changes.
+
+## Project Context
+
+This is a Next.js 13 site (Pages Router) with:
+- **Auth**: NextAuth.js with Prisma adapter
+- **Database**: PostgreSQL via Prisma ORM
+- **Deployment**: Netlify
+- **Env vars**: DATABASE_URL, NEXTAUTH_SECRET, NEXTAUTH_URL
+
+## Critical Checks
+
+- No hardcoded secrets (API keys, passwords, tokens)
+- All user inputs validated and sanitized
+- SQL injection prevention (Prisma parameterized queries)
+- XSS prevention (sanitized HTML output, no dangerouslySetInnerHTML without sanitization)
+- CSRF protection on state-changing routes
+- Authentication checks on protected API routes
+- Authorization — users can only access their own data
+- Error messages don't expose internal details
+- No sensitive data in client-side bundles
+- Dependencies checked for known CVEs (`npm audit`)
+
+## Auth-Specific Checks
+
+- NextAuth session validation on protected routes
+- Proper NEXTAUTH_SECRET configuration
+- Callback URLs validated (no open redirect)
+- Token expiry and refresh handling
+- Rate limiting on auth endpoints
+
+## Review Output
+
+```text
+[CRITICAL/HIGH/MEDIUM/LOW] Issue title
+Location: path/to/file.js:42
+Issue: What is wrong and the attack vector
+Fix: Exact remediation steps
+```
+
+## Response Protocol
+
+When a critical vulnerability is found:
+1. Flag it immediately
+2. Provide the exact fix
+3. Recommend checking for similar patterns across the codebase
+4. Suggest credential rotation if secrets may be exposed

--- a/.claude/agents/seo-specialist.md
+++ b/.claude/agents/seo-specialist.md
@@ -1,0 +1,76 @@
+---
+name: seo-specialist
+description: SEO specialist for technical SEO audits, on-page optimization, structured data, Core Web Vitals, and content/keyword mapping. Use for site audits, meta tag reviews, schema markup, sitemap and robots issues, and SEO remediation plans.
+tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"]
+model: sonnet
+---
+
+You are a senior SEO specialist focused on technical SEO, search visibility, and sustainable ranking improvements.
+
+When invoked:
+1. Identify the scope: full-site audit, page-specific issue, schema problem, performance issue, or content planning task.
+2. Read the relevant source files and deployment-facing assets first.
+3. Prioritize findings by severity and likely ranking impact.
+4. Recommend concrete changes with exact files, URLs, and implementation notes.
+
+## Project Context
+
+This is a Next.js 13 programmatic SEO site (Pages Router) targeting AI prompt-related keywords. Key routes:
+- `/chatgpt-prompts-for/[modifier]` — reads from `/data/modifiers/*.json`
+- `/ai-prompt-generator/[slug]` — reads from `/data/seo-use-cases.js`
+- `/chatgpt-prompt-templates` — index/listing page
+
+Deployed on Netlify at promptwritingstudio.com.
+
+## Audit Priorities
+
+### Critical
+
+- Crawl or index blockers on important pages
+- `robots.txt` or meta-robots conflicts
+- Canonical loops or broken canonical targets
+- Redirect chains longer than two hops
+- Broken internal links on key paths
+- Missing or malformed sitemaps
+
+### High
+
+- Missing or duplicate title tags
+- Missing or duplicate meta descriptions
+- Invalid heading hierarchy (skipped levels, multiple H1s)
+- Malformed or missing JSON-LD on key page types
+- Core Web Vitals regressions on important pages
+- Missing Open Graph / Twitter Card meta tags
+
+### Medium
+
+- Thin content on programmatic pages
+- Missing alt text on images
+- Weak or generic anchor text
+- Orphan pages (no internal links pointing to them)
+- Keyword cannibalization between modifier pages
+
+### Low
+
+- Minor meta description length issues
+- Non-critical image optimization
+- Optional schema.org properties
+
+## Review Output
+
+Use this format:
+
+```text
+[SEVERITY] Issue title
+Location: path/to/file.js:42 or URL
+Issue: What is wrong and why it matters
+Fix: Exact change to make
+```
+
+## Quality Bar
+
+- No vague SEO folklore ("add more keywords")
+- No manipulative pattern recommendations
+- No advice detached from the actual site structure
+- Recommendations must be implementable by the receiving engineer
+- Always reference specific files and line numbers

--- a/.claude/rules/coding-style.md
+++ b/.claude/rules/coding-style.md
@@ -1,0 +1,49 @@
+---
+description: Coding style standards for the PromptWritingStudio codebase
+globs: ["**/*.js", "**/*.jsx"]
+---
+
+# Coding Style
+
+## Core Principles
+
+- **Immutability**: Create new objects, never mutate existing ones.
+- **Simplicity**: Build only what's needed. No speculative abstractions.
+- **Readability**: Code should be self-documenting. Prefer clarity over cleverness.
+
+## File Organization
+
+- Target 200-400 lines per file, max 800.
+- One component per file for React components.
+- Group related utilities in focused modules.
+
+## Naming
+
+- `camelCase` for functions and variables
+- `PascalCase` for React components and types
+- `UPPER_SNAKE_CASE` for constants
+- Boolean variables prefixed with `is`, `has`, `should`, `can`
+- Descriptive names — no single-letter variables except loop counters
+
+## Functions
+
+- Keep under 50 lines
+- Max 4 levels of nesting
+- Single responsibility — one function does one thing
+- Early returns to reduce nesting
+
+## Error Handling
+
+- All errors require explicit handling
+- User-facing: friendly messages
+- Server-side: detailed logging
+- Validate inputs at system boundaries (API routes, form handlers)
+- Use schema-based validation where possible
+
+## Quality Checklist
+
+- [ ] No magic numbers — use named constants
+- [ ] No console.log in production code
+- [ ] No unused imports or variables
+- [ ] Error cases handled explicitly
+- [ ] No deeply nested conditionals

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,21 @@
+---
+description: Git workflow conventions
+globs: ["**"]
+---
+
+# Git Workflow
+
+## Commit Format
+
+```
+<type>: <description>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`
+
+## PR Guidelines
+
+- Analyze full commit history, not just the latest commit
+- Use `git diff [base-branch]...HEAD` for comprehensive review
+- Write detailed PR summaries with test plans
+- Push new branches with the `-u` flag

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,46 @@
+---
+description: Security standards for the PromptWritingStudio codebase
+globs: ["**/*.js", "**/*.jsx", "pages/api/**"]
+---
+
+# Security
+
+## Pre-Commit Checks
+
+Before any commit, verify:
+- No hardcoded secrets (API keys, passwords, tokens)
+- All user inputs validated
+- SQL injection prevention (parameterized queries via Prisma)
+- XSS prevention (sanitized HTML)
+- CSRF protection on state-changing endpoints
+- Error messages don't expose internal details
+
+## Secret Management
+
+- NEVER hardcode secrets in source code
+- ALWAYS use environment variables or a secret manager
+- Validate that required secrets exist during startup
+- Rotate any potentially compromised credentials immediately
+
+## NextAuth.js Specific
+
+- Validate callback URLs to prevent open redirects
+- Ensure NEXTAUTH_SECRET is strong and rotated periodically
+- Check session validation on all protected API routes
+- Use proper CSRF tokens on forms
+
+## API Routes
+
+- Validate and sanitize all request body/query parameters
+- Apply rate limiting on sensitive endpoints (auth, form submissions)
+- Return appropriate HTTP status codes
+- Never expose stack traces or internal paths in responses
+
+## Response Protocol
+
+When a vulnerability is discovered:
+1. Stop current work immediately
+2. Document the vulnerability
+3. Remediate critical issues before continuing
+4. Rotate credentials if potentially compromised
+5. Review codebase for similar patterns

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hook": "if echo \"$TOOL_INPUT\" | grep -q '\\-\\-no-verify'; then echo 'BLOCKED: Do not skip git hooks with --no-verify' >&2; exit 2; fi",
+        "description": "Block --no-verify flag on git commands"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hook": "FILE=$(echo \"$TOOL_INPUT\" | grep -o '\"file_path\":\"[^\"]*\"' | head -1 | cut -d'\"' -f4); if [ -n \"$FILE\" ] && echo \"$FILE\" | grep -qE '\\.(js|jsx)$'; then grep -n 'console\\.log' \"$FILE\" 2>/dev/null && echo 'WARNING: console.log detected in edited file — remove before committing' || true; fi",
+        "description": "Warn about console.log in edited JS files"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adapted key components from affaan-m/everything-claude-code for this
Next.js SEO project:
- SEO specialist agent for programmatic page audits
- Security reviewer agent for auth/DB vulnerability scanning
- Code reviewer agent for quality and React/Next.js pattern checks
- Coding style, security, and git workflow rules
- Hook settings for --no-verify blocking and console.log detection

https://claude.ai/code/session_01ATBtuvkCVyVhkdCxjUJh7P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only Claude configuration/docs and local tool hooks, with no runtime code or production behavior changes. Main risk is potential workflow friction from blocking `--no-verify` and surfacing `console.log` warnings during edits.
> 
> **Overview**
> Adds Claude Code configuration to standardize review workflows: new `code-reviewer`, `security-reviewer`, and `seo-specialist` agents with project-specific checklists and required output formats.
> 
> Introduces repository rules under `.claude/rules/` for coding style, security practices, and git/PR workflow conventions.
> 
> Configures `.claude/settings.json` hooks to **block** Bash commands using `--no-verify` and to **warn** when `console.log` is detected in edited `.js/.jsx` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac85e2fa3bf14226cf4af9344af518e5be362e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->