### PR TITLE
feat: add Skills hub meta pages + wire cross-links across Claude hubs

### DIFF
--- a/data/claude-code-skills.json
+++ b/data/claude-code-skills.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "lastVerified": "2026-04-20",
+    "lastVerified": "2026-04-21",
     "curationPolicy": "Only skills/subagents/slash-commands from repos with explicit permissive licences (MIT, Apache-2.0, BSD, CC0, Unlicense). Originals attributed to author. Anything unclear or NC/ND → excluded.",
     "notes": "Single source of truth for the Claude Code Skills hub at /claude-code-skills. Every page reads from this file. Drift check in /pws-health should flag entries older than 90 days since lastChecked.",
     "sources": [

--- a/pages/calculators/claude-plan-picker.js
+++ b/pages/calculators/claude-plan-picker.js
@@ -260,11 +260,12 @@ export default function ClaudePlanPicker() {
         </section>
 
         <section className="py-16 bg-[#1A1A1A] text-center">
-          <div className="container mx-auto px-4 md:px-6 max-w-2xl">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
             <h2 className="text-3xl font-bold text-white mb-4">Read the full comparison</h2>
-            <p className="text-gray-300 mb-6">The companion article walks through Pro, Max, API, and Team scenarios with verdicts for each — including the three most common mistakes people make when picking.</p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <p className="text-gray-300 mb-6">The companion article walks through Pro, Max, API, and Team scenarios with verdicts for each — including the three most common mistakes people make when picking. Once you've chosen a plan, the Skills catalogue shows which reusable slash commands get the most out of it.</p>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-4 justify-center">
               <Link href="/claude-pro-vs-max-vs-api" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Claude Pro vs Max vs API</Link>
+              <Link href="/claude-code-skills" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Claude Code Skills catalogue</Link>
               <Link href="/calculators/claude-code-vs-cursor-cost" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Claude Code vs Cursor cost</Link>
             </div>
           </div>

--- a/pages/claude-code-mcp-stack.js
+++ b/pages/claude-code-mcp-stack.js
@@ -391,11 +391,12 @@ export default function ClaudeCodeMcpStack() {
         </section>
 
         <section className="py-16 bg-[#1A1A1A] text-center">
-          <div className="container mx-auto px-4 md:px-6 max-w-2xl">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
             <h2 className="text-3xl font-bold text-white mb-4">Related reading</h2>
-            <p className="text-gray-300 mb-6">Hooks complement MCP — MCP adds capabilities, hooks enforce rules about how Claude uses them. The decision tree explains when each extension type fits.</p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <p className="text-gray-300 mb-6">MCP adds capabilities. Hooks enforce rules about how Claude uses them. Skills package repeatable workflows on top. The links below cover the full extension stack.</p>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-4 justify-center">
               <Link href="/claude-code-hooks-recipes" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Claude Code hooks: 7 recipes</Link>
+              <Link href="/claude-code-skills" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Claude Code Skills catalogue</Link>
               <Link href="/skills-vs-mcp-vs-hooks" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Skills vs MCP vs Hooks</Link>
             </div>
           </div>

--- a/pages/claude-code-skills/build-your-own.js
+++ b/pages/claude-code-skills/build-your-own.js
@@ -1,0 +1,304 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import LastVerified from '../../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../../lib/schemaGenerator'
+import skillsData from '../../data/claude-code-skills.json'
+
+const faqs = [
+  {
+    question: "When should I write a skill versus just re-prompting?",
+    answer: "Rule of three: once you've typed the same instructions three times, it's a skill. Until then, just prompt. Skills are cheap to write but non-zero — they add files to maintain, slash commands to remember, and review overhead. The break-even is usually around task #3 or #4 of the same kind."
+  },
+  {
+    question: "Slash command, subagent, or bundled skill — which one?",
+    answer: "Slash command (~/.claude/commands/) for a named prompt you invoke manually — 80% of skills fit here. Subagent (~/.claude/agents/) when you want Claude to delegate to a specialist with a fresh context window and narrow tools. Bundled skill (~/.claude/skills/<name>/) when the workflow needs scripts, helper files, or multi-file templates. Start as a slash command; graduate later."
+  },
+  {
+    question: "What goes in the frontmatter?",
+    answer: "Minimum: description (what the skill does, in one sentence). Optional: allowed-tools (restrict which tools the skill can use), model (force a specific Claude model, useful for Haiku-only light tasks), and name (defaults to filename). Keep frontmatter tight — everything the skill's body can say, let it say."
+  },
+  {
+    question: "How long should a skill be?",
+    answer: "Shorter than you think. 20-80 lines of markdown covers most real skills. If yours hits 200 lines, it's probably doing two jobs — split it. The best skills read like instructions to a competent colleague: 'run X, check Y, if Z then do W, report back in this format.'"
+  },
+  {
+    question: "How do I test a skill before trusting it?",
+    answer: "Three-pass test: dry-run (tell Claude to describe what it would do without executing), happy-path run, edge-case run. For each, check the output format and that Claude didn't skip steps. A skill that silently drops steps 3-5 when the input is unusual is worse than no skill."
+  },
+  {
+    question: "Should I version-control my skills?",
+    answer: "Yes — keep ~/.claude/ or a mirror repo under git. It's rare to regret pushing, common to lose skills to an accidental rm. For shareable skills, publish to a public GitHub repo with an MIT licence and link-friendly frontmatter. For stack-specific ones, commit them into the project's .claude/ directory so the team inherits them."
+  },
+  {
+    question: "Can I ship a skill to this catalogue?",
+    answer: "Not via form submission yet — this is a curated directory. If you want your skill considered: publish it on GitHub with an MIT or Apache-2.0 licence, let it mature for 30+ days with at least one real-world use case, and mention @bryanjcollins on X with a link. Criteria: clear licence, real workflow (not a stub), not a duplicate."
+  }
+]
+
+const frontmatterFields = [
+  { field: "description", required: true, desc: "One-line plain-English summary of what the skill does. Claude Code shows this in autocomplete." },
+  { field: "allowed-tools", required: false, desc: "Array of tool names the skill can use (e.g. [Bash, Read, Edit]). Omit to allow all tools." },
+  { field: "model", required: false, desc: "Force a specific Claude model — 'claude-haiku-4-5' for lightweight tasks, 'claude-opus-4-7' for deep reasoning." },
+  { field: "argument-hint", required: false, desc: "What input, if any, the skill expects. Shown in autocomplete after the slash command." }
+]
+
+const bodySections = [
+  { title: "Purpose (1 sentence)", desc: "What this skill does, not how. Skip to step 2 if the description frontmatter already covers it." },
+  { title: "When to use", desc: "Two or three sentences on the trigger conditions — what problem does this solve, and when does it NOT apply." },
+  { title: "Steps", desc: "Numbered, specific, and skippable. Each step should produce a checkable outcome. Think 'run git status, check branch, if dirty then stage'." },
+  { title: "Output format", desc: "Tell Claude the shape of the reply — a table? bullet list? commit message? Without this, output wanders." },
+  { title: "Failure modes", desc: "What the skill should do when it encounters unexpected state. 'If tests fail, report the failure and stop — do not --no-verify.'" }
+]
+
+export default function BuildYourOwnSkill() {
+  const faqSchema = generateFAQSchema(faqs)
+  const article = generateArticleSchema({
+    title: "Build your own Claude Code skill — SKILL.md template walkthrough",
+    description: "A walkthrough of the frontmatter, body structure, and testing loop for writing your own Claude Code skill. Copy-paste SKILL.md template included.",
+    slug: "claude-code-skills/build-your-own",
+    datePublished: skillsData._meta.lastVerified
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Build Your Own Claude Code Skill — SKILL.md Template Walkthrough | PromptWritingStudio</title>
+        <meta name="description" content="How to write a Claude Code skill from scratch: frontmatter, body structure, testing loop, licence. Copy-paste SKILL.md template included." />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-skills/build-your-own" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-14">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <nav className="text-sm text-gray-300 mb-4">
+              <Link href="/claude-code-skills" className="hover:text-white">Claude Code Skills</Link>
+              <span className="mx-2">/</span>
+              <span className="text-gray-400">Build your own</span>
+            </nav>
+            <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">SKILL.md walkthrough</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 leading-tight">
+              Build your own Claude Code skill
+            </h1>
+            <p className="text-xl text-gray-200 max-w-3xl">
+              A skill is a 20-80 line markdown file with YAML frontmatter. Here's how to write one that doesn't need rewriting two weeks later.
+            </p>
+            <div className="mt-5">
+              <LastVerified date={skillsData._meta.lastVerified} label="Walkthrough verified" className="!text-white/70" />
+            </div>
+          </div>
+        </section>
+
+        <section className="py-10 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
+              <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                A Claude Code skill is a markdown file with YAML frontmatter (<code className="bg-gray-100 px-1.5 py-0.5 rounded">description:</code> is the only required field) and a body of plain-English instructions. Write it like a playbook for a competent colleague: purpose, when-to-use, numbered steps, output format, failure modes. Test with three passes — dry-run, happy path, edge case — then ship.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Rule of three</h2>
+            <p className="text-[#333333] mb-4">Skills are cheap but not free. They add files to maintain and slash commands to remember. Only write a skill when you've typed the same instructions three times.</p>
+            <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-5 rounded-r">
+              <p className="text-[#1A1A1A] font-semibold mb-2">The pattern:</p>
+              <ul className="text-[#333333] space-y-1">
+                <li>• <strong>Once:</strong> just prompt it.</li>
+                <li>• <strong>Twice:</strong> maybe copy the prompt into a note.</li>
+                <li>• <strong>Three times:</strong> write the skill.</li>
+                <li>• <strong>Five times in a week:</strong> promote to a subagent with its own tools.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Frontmatter fields</h2>
+            <p className="text-[#333333] mb-6">Only <code className="bg-gray-100 px-1.5 py-0.5 rounded">description</code> is required. Every other field is a tool, not a tax.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left border border-gray-200 rounded-lg overflow-hidden bg-white">
+                <thead className="bg-[#F9F9F9]">
+                  <tr>
+                    <th className="p-3 border-b border-gray-200 text-sm font-semibold text-[#1A1A1A]">Field</th>
+                    <th className="p-3 border-b border-gray-200 text-sm font-semibold text-[#1A1A1A]">Required</th>
+                    <th className="p-3 border-b border-gray-200 text-sm font-semibold text-[#1A1A1A]">What it does</th>
+                  </tr>
+                </thead>
+                <tbody className="text-sm text-[#333333]">
+                  {frontmatterFields.map(f => (
+                    <tr key={f.field}>
+                      <td className="p-3 border-b border-gray-100 font-mono text-xs">{f.field}</td>
+                      <td className="p-3 border-b border-gray-100">{f.required ? <span className="text-red-600 font-semibold">Required</span> : 'Optional'}</td>
+                      <td className="p-3 border-b border-gray-100">{f.desc}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Body structure</h2>
+            <p className="text-[#333333] mb-6">Five sections, in this order. Most skills don't need all five — but the ones that earn their keep have at least three.</p>
+            <ol className="space-y-4">
+              {bodySections.map((s, i) => (
+                <li key={i} className="bg-[#F9F9F9] border border-gray-200 rounded-lg p-5">
+                  <div className="flex gap-4">
+                    <span className="flex-shrink-0 w-8 h-8 rounded-full bg-[#FFDE59] text-[#1A1A1A] font-bold flex items-center justify-center text-sm">{i + 1}</span>
+                    <div>
+                      <h3 className="font-bold text-[#1A1A1A] mb-1">{s.title}</h3>
+                      <p className="text-[#333333]">{s.desc}</p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="py-12 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Copy-paste template</h2>
+            <p className="text-[#333333] mb-6">Drop this into <code className="bg-gray-100 px-1.5 py-0.5 rounded">~/.claude/commands/&lt;your-skill&gt;.md</code> and fill in the blanks. The comments show what each block does.</p>
+            <pre className="bg-[#1A1A1A] text-green-400 p-5 rounded-lg overflow-x-auto text-xs leading-relaxed whitespace-pre-wrap">{`---
+description: One-line summary of what this skill does (shown in autocomplete).
+allowed-tools: [Bash, Read, Edit, Grep]  # optional — restrict tool access
+argument-hint: <file-path>                # optional — shown after /<name> in UI
+---
+
+# <Skill Name>
+
+## Purpose
+
+One sentence on what this skill does. Skip if the frontmatter description already covers it.
+
+## When to use it
+
+Two or three sentences on the trigger conditions. What problem does this solve?
+When does this NOT apply?
+
+## Steps
+
+1. Run <command A>. If output is X, stop and report.
+2. Read <file>. Extract <specific thing>.
+3. Run <command B> with <extracted thing>.
+4. If <condition>, do <action>. Otherwise, do <other action>.
+
+## Output format
+
+Report back in this shape:
+
+\`\`\`
+Finding 1: <summary>
+Finding 2: <summary>
+Recommendation: <single sentence>
+\`\`\`
+
+## Failure modes
+
+- If <tool> is not installed, report the missing dependency and stop.
+- If <file> does not exist, report and stop — do not create it.
+- Do not use --no-verify or skip steps silently.
+`}</pre>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Testing loop</h2>
+            <p className="text-[#333333] mb-6">Three passes before you trust a new skill with real work.</p>
+            <div className="space-y-4">
+              <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-5 rounded-r">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Pass 1 — Dry-run</h3>
+                <p className="text-[#333333]">Run the skill with a note: <em>&quot;describe what you&apos;d do without running anything&quot;</em>. Check the steps match your intent. Catches wrong order, missing checks, skipped validation.</p>
+              </div>
+              <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-5 rounded-r">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Pass 2 — Happy path</h3>
+                <p className="text-[#333333]">Run on a normal input. Compare output format against what you specified. Common issue: Claude drops the output-format section when the input is simple.</p>
+              </div>
+              <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-5 rounded-r">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Pass 3 — Edge case</h3>
+                <p className="text-[#333333]">Feed it something weird — empty file, huge file, missing dependency, conflicting state. The skill should fail loudly, not silently skip steps. If it papers over the problem, add an explicit failure-mode instruction.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Checklist before you save</h2>
+            <ul className="space-y-2 text-[#333333]">
+              <li className="flex gap-3"><span>☐</span><span><strong>Frontmatter valid YAML?</strong> A broken <code className="bg-gray-100 px-1 py-0.5 rounded">description:</code> silently drops the skill from autocomplete.</span></li>
+              <li className="flex gap-3"><span>☐</span><span><strong>Description under 100 chars?</strong> Longer and it wraps in autocomplete.</span></li>
+              <li className="flex gap-3"><span>☐</span><span><strong>Steps numbered and specific?</strong> 'Run tests' is a bug; 'run <code className="bg-gray-100 px-1 py-0.5 rounded">npm test -- --coverage</code> and report failures by file' is a skill.</span></li>
+              <li className="flex gap-3"><span>☐</span><span><strong>Failure modes spelled out?</strong> Especially for anything that mutates state (commit, push, deploy, delete).</span></li>
+              <li className="flex gap-3"><span>☐</span><span><strong>Output format specified?</strong> 'Report back' is vague — pick a shape.</span></li>
+              <li className="flex gap-3"><span>☐</span><span><strong>No hardcoded secrets?</strong> Skills live in dotfiles that often get pushed. Read twice.</span></li>
+              <li className="flex gap-3"><span>☐</span><span><strong>Attribution preserved if forked?</strong> MIT and Apache-2.0 require the original copyright notice in redistributions.</span></li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Patterns worth copying</h2>
+            <p className="text-[#333333] mb-6">Skills in the catalogue that show these patterns well — open and read the source to pick up the style.</p>
+            <div className="grid md:grid-cols-2 gap-4">
+              {['skill-md-template', 'commit-helper', 'drift-check', 'legal-sweep'].map(slug => {
+                const skill = skillsData.skills.find(s => s.slug === slug)
+                if (!skill) return null
+                return (
+                  <Link
+                    key={slug}
+                    href={`/claude-code-skills/${slug}`}
+                    className="bg-[#F9F9F9] border border-gray-200 rounded-lg p-5 hover:border-[#FFDE59] hover:shadow-sm transition"
+                  >
+                    <h3 className="font-bold text-[#1A1A1A] mb-1">{skill.name}</h3>
+                    <p className="text-sm text-[#333333]">{skill.purpose}</p>
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">Frequently asked</h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-4 cursor-pointer hover:bg-gray-50 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-4 pb-4"><p className="text-gray-600 leading-relaxed">{faq.answer}</p></div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A] text-center">
+          <div className="container mx-auto px-4 md:px-6 max-w-2xl">
+            <h2 className="text-3xl font-bold text-white mb-4">Browse the catalogue for inspiration</h2>
+            <p className="text-gray-300 mb-6">{skillsData.skills.length} skills across {skillsData.categories.length} categories — all licence-verified, all open to forking and adapting.</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/claude-code-skills" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Browse {skillsData.skills.length} skills</Link>
+              <Link href="/claude-code-skills/install-guide" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Install guide</Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-skills/index.js
+++ b/pages/claude-code-skills/index.js
@@ -278,6 +278,25 @@ export default function ClaudeCodeSkillsHub() {
           </div>
         </section>
 
+        <section className="py-16 bg-white border-t border-gray-200">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2">Next steps</h2>
+            <p className="text-[#333333] mb-8">Two companion walkthroughs — one for installing, one for writing your own.</p>
+            <div className="grid md:grid-cols-2 gap-5">
+              <Link href="/claude-code-skills/install-guide" className="bg-[#F9F9F9] border border-gray-200 rounded-lg p-6 hover:border-[#FFDE59] hover:shadow-sm transition">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Install a skill in 60 seconds</h3>
+                <p className="text-sm text-[#333333] mb-3">Where each file lives (<code className="bg-gray-100 px-1 py-0.5 rounded">~/.claude/commands/</code>, <code className="bg-gray-100 px-1 py-0.5 rounded">agents/</code>, <code className="bg-gray-100 px-1 py-0.5 rounded">skills/</code>), how to invoke, and how to keep attribution clean.</p>
+                <span className="text-sm font-semibold text-[#1A1A1A]">Read the install guide →</span>
+              </Link>
+              <Link href="/claude-code-skills/build-your-own" className="bg-[#F9F9F9] border border-gray-200 rounded-lg p-6 hover:border-[#FFDE59] hover:shadow-sm transition">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Build your own skill</h3>
+                <p className="text-sm text-[#333333] mb-3">The SKILL.md walkthrough — frontmatter fields, body structure, copy-paste template, and the three-pass testing loop before you trust it with real work.</p>
+                <span className="text-sm font-semibold text-[#1A1A1A]">Read the template walkthrough →</span>
+              </Link>
+            </div>
+          </div>
+        </section>
+
         <section className="py-16 bg-[#1A1A1A] text-center">
           <div className="container mx-auto px-4 md:px-6 max-w-2xl">
             <h2 className="text-3xl font-bold text-white mb-4">Related reading</h2>

--- a/pages/claude-code-skills/install-guide.js
+++ b/pages/claude-code-skills/install-guide.js
@@ -1,0 +1,281 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import LastVerified from '../../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../../lib/schemaGenerator'
+import skillsData from '../../data/claude-code-skills.json'
+
+const faqs = [
+  {
+    question: "Where do skills live on my machine?",
+    answer: "Slash commands go in ~/.claude/commands/<name>.md — one file per command. Subagents go in ~/.claude/agents/<name>.md. Bundled skills (with scripts or additional files) go in ~/.claude/skills/<name>/SKILL.md. All three are picked up automatically by Claude Code when it starts. Per-project versions live at .claude/commands/ (etc.) inside the repo and override the global ones for that project."
+  },
+  {
+    question: "Do I need to restart Claude Code after adding a skill?",
+    answer: "Yes. Claude Code reads the commands, agents, and skills directories at session start. Quit (Ctrl+C twice) and run claude again. New skills appear when you type / — the autocomplete will include them. If a skill doesn't show up, check the file is .md, the frontmatter is valid YAML, and you saved to the right directory."
+  },
+  {
+    question: "How do I invoke a skill once it's installed?",
+    answer: "Slash commands and subagents both run by typing /<name> in Claude Code. Some skills auto-trigger based on context (set via the allowed-tools or description field in frontmatter) — those fire without being called directly. You can check a skill's trigger mode in its frontmatter. When in doubt, type / and browse the list."
+  },
+  {
+    question: "How do global skills differ from per-project skills?",
+    answer: "Global skills in ~/.claude/ apply everywhere you run Claude Code. Per-project skills in ./.claude/ (relative to the project root) only apply inside that project, and override global skills of the same name. Use global for personal defaults (commit style, review habits) and per-project for stack-specific workflows (Next.js lint, Prisma migrations, repo-specific CI rules)."
+  },
+  {
+    question: "What if the skill needs a dependency like gh CLI?",
+    answer: "Install the dependency first. Most of the skills in this catalogue require at least git and gh (GitHub CLI). Some need jq, rg (ripgrep), or specific MCP servers. The setup block on each skill page lists requirements. Claude Code will surface the error if a dependency is missing, but it's faster to pre-install rather than debug at runtime."
+  },
+  {
+    question: "Is it safe to install skills from GitHub strangers?",
+    answer: "Read the skill file first. A slash command is just a markdown prompt — low risk. A bundled skill may contain shell scripts that run with your permissions; read those carefully. This catalogue only includes skills from repos with permissive licences, but 'permissive licence' isn't the same as 'audited code'. Trust, but verify: open the file, read what it does, then save it."
+  },
+  {
+    question: "Can I edit a skill after I install it?",
+    answer: "Yes — skills are just markdown files. Edit in place to match your stack, conventions, or tone. Fork the file with a new slug if you want to preserve the original alongside your edit. Respect the licence: MIT and Apache-2.0 both require you keep the original author's copyright notice when you redistribute, but local edits in your own .claude/ are fine."
+  }
+]
+
+const steps = [
+  {
+    title: "Pick a skill from the catalogue",
+    body: "Browse /claude-code-skills and open the one you want. The High-signal tier is where to start — those skills earn their keep daily across many projects.",
+    code: null
+  },
+  {
+    title: "Copy the skill's content",
+    body: "On the skill's page, the setup block shows the exact filename and path. For most entries, you'll copy a markdown file from the source repo (link on the page) into your own .claude/ directory.",
+    code: null
+  },
+  {
+    title: "Save to the right directory",
+    body: "The path depends on what the skill is:",
+    code: "# Slash command (most skills)\n~/.claude/commands/<name>.md\n\n# Subagent (parallel specialist)\n~/.claude/agents/<name>.md\n\n# Bundled skill (with scripts / extra files)\n~/.claude/skills/<name>/SKILL.md\n\n# Per-project equivalents (override globals)\n<project-root>/.claude/commands/<name>.md\n<project-root>/.claude/agents/<name>.md\n<project-root>/.claude/skills/<name>/SKILL.md"
+  },
+  {
+    title: "Preserve attribution",
+    body: "If the skill came from a community repo (not your own work), keep a one-line comment at the top crediting the source. The catalogue's licence gate (MIT / Apache-2.0 / BSD / CC0 / Unlicense) permits reuse, but MIT and Apache require you keep the original copyright notice.",
+    code: "<!-- Source: <author> / <repo> — MIT -->\n<!-- https://github.com/<author>/<repo> -->"
+  },
+  {
+    title: "Restart Claude Code",
+    body: "Quit the current session (Ctrl+C twice) and run claude again. New skills are registered at session start, not mid-session.",
+    code: "claude"
+  },
+  {
+    title: "Invoke it",
+    body: "Type / in Claude Code — the skill appears in autocomplete. Some skills auto-trigger based on context (check the frontmatter's description field). Most fire when you type /<name> and press enter.",
+    code: "You: /commit\nClaude: [runs git status / diff / log, drafts message, commits, pushes]"
+  }
+]
+
+const howToSchema = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to install a Claude Code skill in 60 seconds",
+  "description": "Copy a skill file into ~/.claude/commands/, ~/.claude/agents/, or ~/.claude/skills/, restart Claude Code, and invoke with /<name>. Preserve attribution for permissive-licence skills.",
+  "totalTime": "PT1M",
+  "step": steps.map((s, i) => ({
+    "@type": "HowToStep",
+    "position": i + 1,
+    "name": s.title,
+    "text": s.body
+  }))
+}
+
+export default function InstallGuide() {
+  const faqSchema = generateFAQSchema(faqs)
+  const article = generateArticleSchema({
+    title: "How to install a Claude Code skill — the 60-second walkthrough",
+    description: "Step-by-step install for slash commands, subagents, and bundled skills. Where they live, how to invoke them, and how to keep attribution clean.",
+    slug: "claude-code-skills/install-guide",
+    datePublished: skillsData._meta.lastVerified
+  })
+
+  const signalCount = skillsData.skills.filter(s => s.tier === 'signal').length
+
+  return (
+    <>
+      <Head>
+        <title>How to Install a Claude Code Skill — The 60-Second Walkthrough | PromptWritingStudio</title>
+        <meta name="description" content="Step-by-step install guide for Claude Code skills, subagents, and slash commands. Where each file type lives, how to invoke them, and how to preserve attribution." />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-skills/install-guide" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-14">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <nav className="text-sm text-gray-300 mb-4">
+              <Link href="/claude-code-skills" className="hover:text-white">Claude Code Skills</Link>
+              <span className="mx-2">/</span>
+              <span className="text-gray-400">Install guide</span>
+            </nav>
+            <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">Install in 60 seconds</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 leading-tight">
+              How to install a Claude Code skill
+            </h1>
+            <p className="text-xl text-gray-200 max-w-3xl">
+              Copy a markdown file into <code className="bg-black/30 px-1.5 py-0.5 rounded text-sm">~/.claude/</code>, restart Claude Code, type <code className="bg-black/30 px-1.5 py-0.5 rounded text-sm">/&lt;name&gt;</code>. That's the whole thing.
+            </p>
+            <div className="mt-5">
+              <LastVerified date={skillsData._meta.lastVerified} label="Guide verified" className="!text-white/70" />
+            </div>
+          </div>
+        </section>
+
+        <section className="py-10 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
+              <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                Skills are plain markdown files. Save them to <code className="bg-gray-100 px-1.5 py-0.5 rounded">~/.claude/commands/</code> (slash commands), <code className="bg-gray-100 px-1.5 py-0.5 rounded">~/.claude/agents/</code> (subagents), or <code className="bg-gray-100 px-1.5 py-0.5 rounded">~/.claude/skills/&lt;name&gt;/SKILL.md</code> (bundled skills with scripts). Restart Claude Code. Invoke with <code className="bg-gray-100 px-1.5 py-0.5 rounded">/&lt;name&gt;</code>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2">Directory cheat sheet</h2>
+            <p className="text-[#333333] mb-6">Which directory does what — skim this once, bookmark if needed.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left border border-gray-200 rounded-lg overflow-hidden">
+                <thead className="bg-[#F9F9F9]">
+                  <tr>
+                    <th className="p-3 border-b border-gray-200 text-sm font-semibold text-[#1A1A1A]">Directory</th>
+                    <th className="p-3 border-b border-gray-200 text-sm font-semibold text-[#1A1A1A]">Holds</th>
+                    <th className="p-3 border-b border-gray-200 text-sm font-semibold text-[#1A1A1A]">Invoke with</th>
+                  </tr>
+                </thead>
+                <tbody className="text-sm text-[#333333]">
+                  <tr>
+                    <td className="p-3 border-b border-gray-100 font-mono text-xs">~/.claude/commands/</td>
+                    <td className="p-3 border-b border-gray-100">Slash commands — named prompts you run manually.</td>
+                    <td className="p-3 border-b border-gray-100 font-mono text-xs">/&lt;name&gt;</td>
+                  </tr>
+                  <tr>
+                    <td className="p-3 border-b border-gray-100 font-mono text-xs">~/.claude/agents/</td>
+                    <td className="p-3 border-b border-gray-100">Subagents — specialists Claude can delegate to.</td>
+                    <td className="p-3 border-b border-gray-100 font-mono text-xs">/&lt;name&gt; <span className="text-gray-400">or auto</span></td>
+                  </tr>
+                  <tr>
+                    <td className="p-3 border-b border-gray-100 font-mono text-xs">~/.claude/skills/&lt;name&gt;/</td>
+                    <td className="p-3 border-b border-gray-100">Bundled skills — SKILL.md plus supporting scripts or docs.</td>
+                    <td className="p-3 border-b border-gray-100 font-mono text-xs">auto <span className="text-gray-400">via frontmatter</span></td>
+                  </tr>
+                  <tr>
+                    <td className="p-3 font-mono text-xs">&lt;project&gt;/.claude/</td>
+                    <td className="p-3">Per-project overrides — same structure, project-scoped.</td>
+                    <td className="p-3 font-mono text-xs">same</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2">Step-by-step</h2>
+            <p className="text-[#333333] mb-8">From catalogue click to working skill in six steps.</p>
+            <ol className="space-y-6">
+              {steps.map((step, i) => (
+                <li key={i} className="bg-white rounded-lg border border-gray-200 p-5 md:p-6">
+                  <div className="flex items-start gap-4">
+                    <span className="flex-shrink-0 w-9 h-9 rounded-full bg-[#FFDE59] text-[#1A1A1A] font-bold flex items-center justify-center">{i + 1}</span>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-lg font-bold text-[#1A1A1A] mb-1">{step.title}</h3>
+                      <p className="text-[#333333] leading-relaxed mb-3">{step.body}</p>
+                      {step.code && (
+                        <pre className="bg-[#1A1A1A] text-green-400 p-4 rounded text-xs leading-relaxed overflow-x-auto whitespace-pre-wrap">{step.code}</pre>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">A realistic first five</h2>
+            <p className="text-[#333333] mb-6">Start here. These are the most-used High-signal skills from the catalogue — the ones most people keep forever once they install them.</p>
+            <div className="grid md:grid-cols-2 gap-4">
+              {['commit-helper', 'pr-open', 'review-pr', 'security-audit', 'site-health-check'].map(slug => {
+                const skill = skillsData.skills.find(s => s.slug === slug)
+                if (!skill) return null
+                return (
+                  <Link
+                    key={slug}
+                    href={`/claude-code-skills/${slug}`}
+                    className="bg-[#F9F9F9] border border-gray-200 rounded-lg p-5 hover:border-[#FFDE59] hover:shadow-sm transition"
+                  >
+                    <h3 className="font-bold text-[#1A1A1A] mb-1">{skill.name}</h3>
+                    <p className="text-sm text-[#333333]">{skill.purpose}</p>
+                  </Link>
+                )
+              })}
+            </div>
+            <p className="text-sm text-gray-500 mt-4">{signalCount} High-signal skills total · <Link href="/claude-code-skills" className="underline hover:text-[#1A1A1A]">browse all</Link></p>
+          </div>
+        </section>
+
+        <section className="py-12 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">Common mistakes</h2>
+            <div className="space-y-4">
+              <div className="bg-white border-l-4 border-red-400 p-5 rounded-r">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Saving the file with a .txt extension</h3>
+                <p className="text-[#333333]">Claude Code only reads .md files from these directories. If your editor adds .txt, rename before restart.</p>
+              </div>
+              <div className="bg-white border-l-4 border-red-400 p-5 rounded-r">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Forgetting to restart</h3>
+                <p className="text-[#333333]">Skills are loaded once at session start. A new file dropped mid-session won't appear until the next <code className="bg-gray-100 px-1 py-0.5 rounded">claude</code> invocation.</p>
+              </div>
+              <div className="bg-white border-l-4 border-red-400 p-5 rounded-r">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Skipping attribution</h3>
+                <p className="text-[#333333]">MIT and Apache-2.0 both require you keep the copyright notice when redistributing. For your own <code className="bg-gray-100 px-1 py-0.5 rounded">~/.claude/</code> that's a nicety; if you commit a skill into a project repo, it's a licence requirement.</p>
+              </div>
+              <div className="bg-white border-l-4 border-red-400 p-5 rounded-r">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Running a bundled skill without reading the scripts</h3>
+                <p className="text-[#333333]">Slash commands are just prompts — safe. Bundled skills can contain shell scripts that run with your permissions. Open the script before saving.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">Frequently asked</h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-4 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-4 pb-4"><p className="text-gray-600 leading-relaxed">{faq.answer}</p></div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A] text-center">
+          <div className="container mx-auto px-4 md:px-6 max-w-2xl">
+            <h2 className="text-3xl font-bold text-white mb-4">Ready to write your own?</h2>
+            <p className="text-gray-300 mb-6">Once you've installed a few and spotted a repeat pattern in your own work, it's time to build one. The template walkthrough covers the frontmatter, body structure, and testing loop.</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/claude-code-skills/build-your-own" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Build your own skill</Link>
+              <Link href="/claude-code-skills" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Back to catalogue</Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-pro-vs-max-vs-api.js
+++ b/pages/claude-pro-vs-max-vs-api.js
@@ -280,11 +280,12 @@ export default function ClaudeProVsMaxVsApi() {
         </section>
 
         <section className="py-16 bg-[#1A1A1A] text-center">
-          <div className="container mx-auto px-4 md:px-6 max-w-2xl">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
             <h2 className="text-3xl font-bold text-white mb-4">Run the numbers on your workload</h2>
-            <p className="text-gray-300 mb-6">The plan picker calculator takes your actual hours-per-day and model mix and recommends Pro, Max 5x, Max 20x, or API with the monthly cost for each.</p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <p className="text-gray-300 mb-6">The plan picker calculator takes your actual hours-per-day and model mix and recommends Pro, Max 5x, Max 20x, or API with the monthly cost for each. Once you've picked, the Claude Code Skills catalogue is the next stop — reusable slash commands that pay for themselves inside the first billing cycle.</p>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-4 justify-center">
               <Link href="/calculators/claude-plan-picker" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Open the plan picker</Link>
+              <Link href="/claude-code-skills" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Claude Code Skills catalogue</Link>
               <Link href="/calculators/claude-code-vs-cursor-cost" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Claude Code vs Cursor cost</Link>
             </div>
           </div>

--- a/pages/sitemap.js
+++ b/pages/sitemap.js
@@ -73,7 +73,9 @@ export default function Sitemap() {
   // Claude Code Hub pages - primary site focus
   const claudeCodePages = [
     { title: 'Claude Code Guide', url: '/claude-code-guide', description: 'Complete beginner-to-pro guide for Claude Code — install, config, sub-agents, hooks, MCP' },
-    { title: 'Claude Code Skills Catalogue', url: '/claude-code-skills', description: '45+ Claude Code skills, subagents and slash commands — every entry from a permissive-licence repo' },
+    { title: 'Claude Code Skills Catalogue', url: '/claude-code-skills', description: 'Claude Code skills, subagents and slash commands — every entry from a permissive-licence repo' },
+    { title: 'Install a Claude Code Skill', url: '/claude-code-skills/install-guide', description: 'The 60-second install walkthrough for slash commands, subagents, and bundled skills' },
+    { title: 'Build Your Own Claude Code Skill', url: '/claude-code-skills/build-your-own', description: 'SKILL.md template walkthrough — frontmatter, body structure, testing loop' },
     { title: 'Claude Code MCP Stack', url: '/claude-code-mcp-stack', description: 'The MCP servers worth installing — with working configs' },
     { title: 'Claude Pro vs Max vs API', url: '/claude-pro-vs-max-vs-api', description: 'Which Claude plan fits your usage — with real numbers' },
     { title: 'CLAUDE.md Playbook', url: '/claude-md-playbook', description: 'Project-level instructions that actually change Claude Code behaviour' },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -21,7 +21,9 @@
 ## Core Claude Code Pages
 
 - [Claude Code Guide](https://promptwritingstudio.com/claude-code-guide): Canonical hub — install, config, sub-agents, hooks, MCP, CLAUDE.md
-- [Claude Code Skills Catalogue](https://promptwritingstudio.com/claude-code-skills): 45+ skills, subagents, and slash commands curated from permissive-licence repos (MIT / Apache-2.0 / BSD / CC0). Filter by category, tier, and licence.
+- [Claude Code Skills Catalogue](https://promptwritingstudio.com/claude-code-skills): Skills, subagents, and slash commands curated from permissive-licence repos (MIT / Apache-2.0 / BSD / CC0). Filter by category, tier, and licence.
+- [Install a Claude Code Skill (60-second walkthrough)](https://promptwritingstudio.com/claude-code-skills/install-guide): Where each file type lives, how to invoke them, how to preserve attribution.
+- [Build Your Own Claude Code Skill](https://promptwritingstudio.com/claude-code-skills/build-your-own): SKILL.md template walkthrough — frontmatter, body structure, testing loop.
 - [Claude Code MCP Stack](https://promptwritingstudio.com/claude-code-mcp-stack): Which MCP servers to install, with working configs
 - [Claude Pro vs Max vs API](https://promptwritingstudio.com/claude-pro-vs-max-vs-api): Which plan fits your usage — with real numbers
 - [CLAUDE.md Playbook](https://promptwritingstudio.com/claude-md-playbook): Project-level instructions that actually change Claude Code behaviour

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -145,9 +145,21 @@
   </url>
   <url>
     <loc>https://promptwritingstudio.com/claude-code-skills</loc>
-    <lastmod>2026-04-20</lastmod>
+    <lastmod>2026-04-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://promptwritingstudio.com/claude-code-skills/install-guide</loc>
+    <lastmod>2026-04-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://promptwritingstudio.com/claude-code-skills/build-your-own</loc>
+    <lastmod>2026-04-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://promptwritingstudio.com/claude-code-mcp-stack</loc>


### PR DESCRIPTION
- New /claude-code-skills/install-guide — 60-second walkthrough with directory cheat sheet, 6-step install, common mistakes, HowTo schema
- New /claude-code-skills/build-your-own — SKILL.md template walkthrough, rule-of-three, frontmatter reference, 5-section body structure, copy-paste template, 3-pass testing loop, pre-save checklist
- Wire both meta pages into hub index footer (previously orphaned per HANDOFF-2026-04-20)
- Add hub cross-links from /claude-code-mcp-stack, /claude-pro-vs-max-vs-api, and /calculators/claude-plan-picker to /claude-code-skills (closes HUB-LINK gap #4 from handoff)
- Update sitemap.js, sitemap.xml, llms.txt to include both meta pages
- Bump skills catalogue lastVerified to 2026-04-21