### PR TITLE
feat(glossary): scaffold data-driven /glossary hub + per-term pages

### DIFF
--- a/data/glossary.js
+++ b/data/glossary.js
@@ -1,0 +1,258 @@
+/**
+ * Site glossary — data-driven source of truth.
+ *
+ * Add a term: append an entry below. Slug = URL segment under /glossary/<slug>.
+ * Categories are defined in `categories`; use their `id` on each term.
+ *
+ * NOTE: Seeded with ~20 representative terms across all categories. The full
+ * 170-term dataset lives in /pages/ai-glossary.js and should be migrated here.
+ * See TODO in the PR description.
+ */
+
+export const categories = [
+  { id: 'basics', label: 'AI Basics', badge: 'bg-blue-100 text-blue-800' },
+  { id: 'business', label: 'Business Applications', badge: 'bg-green-100 text-green-800' },
+  { id: 'technology', label: 'Technology', badge: 'bg-purple-100 text-purple-800' },
+  { id: 'ethics', label: 'Ethics & Safety', badge: 'bg-orange-100 text-orange-800' },
+  { id: 'prompting', label: 'Prompting', badge: 'bg-yellow-100 text-yellow-800' },
+  { id: 'rag', label: 'RAG', badge: 'bg-pink-100 text-pink-800' },
+  { id: 'agents', label: 'Agents & Tools', badge: 'bg-indigo-100 text-indigo-800' },
+]
+
+export const glossaryTerms = [
+  {
+    slug: 'artificial-intelligence',
+    term: 'Artificial Intelligence (AI)',
+    aliases: ['AI'],
+    category: 'basics',
+    shortDefinition: 'Computer systems that perform tasks typically requiring human intelligence.',
+    definition:
+      'Computer systems designed to perform tasks that typically require human intelligence, such as recognizing speech, making decisions, or solving problems. In business, AI helps automate processes and gain insights from data.',
+    businessExample: 'Customer service chatbots that can answer common questions 24/7.',
+    relatedTerms: ['machine-learning', 'large-language-model', 'generative-ai'],
+  },
+  {
+    slug: 'machine-learning',
+    term: 'Machine Learning (ML)',
+    aliases: ['ML'],
+    category: 'technology',
+    shortDefinition: 'A subset of AI where systems learn patterns from data instead of explicit rules.',
+    definition:
+      'A subset of AI where computers learn patterns from data without being explicitly programmed for each task. The system improves its performance as it processes more information.',
+    businessExample: 'Email spam filters that get better at detecting unwanted messages over time.',
+    relatedTerms: ['deep-learning', 'supervised-learning', 'training-data'],
+  },
+  {
+    slug: 'large-language-model',
+    term: 'Large Language Model (LLM)',
+    aliases: ['LLM'],
+    category: 'technology',
+    shortDefinition: 'AI trained on vast text data to understand and generate human-like language.',
+    definition:
+      'AI systems trained on vast amounts of text data to understand and generate human-like language. These models can write, summarize, translate, and answer questions.',
+    businessExample: 'ChatGPT helping writers create marketing copy or customer support responses.',
+    relatedTerms: ['generative-ai', 'prompt-engineering', 'foundation-model'],
+    relatedPages: [
+      { href: '/ai-models', label: 'Compare AI Models' },
+      { href: '/claude-vs-chatgpt', label: 'Claude vs ChatGPT' },
+    ],
+  },
+  {
+    slug: 'generative-ai',
+    term: 'Generative AI',
+    category: 'basics',
+    shortDefinition: 'AI that creates new content — text, images, audio, or code.',
+    definition:
+      'AI that creates new content such as text, images, audio, or code based on patterns learned from data.',
+    businessExample: 'Automatically drafting blog outlines or product descriptions from a short brief.',
+    relatedTerms: ['large-language-model', 'prompt-engineering', 'diffusion-model'],
+  },
+  {
+    slug: 'prompt-engineering',
+    term: 'Prompt Engineering',
+    aliases: ['prompt design', 'prompting'],
+    category: 'prompting',
+    shortDefinition: 'Crafting effective instructions for AI systems to get desired outputs.',
+    definition:
+      'The practice of crafting effective instructions or questions for AI systems to get desired outputs. Essential skill for maximizing AI tool effectiveness.',
+    businessExample:
+      'Writing specific prompts to generate targeted marketing content that matches your brand voice.',
+    relatedTerms: ['system-prompt', 'few-shot-learning', 'prompt-template'],
+    relatedPages: [
+      { href: '/chatgpt-prompt-templates', label: 'ChatGPT Prompt Templates' },
+      { href: '/ai-prompt-generator', label: 'AI Prompt Generator' },
+    ],
+  },
+  {
+    slug: 'system-prompt',
+    term: 'System Prompt',
+    category: 'prompting',
+    shortDefinition: "A hidden instruction that sets the assistant's overall behavior and constraints.",
+    definition:
+      "A hidden instruction that sets the assistant's overall behavior and constraints.",
+    businessExample: 'Configuring an HR assistant to always prioritize compliance and confidentiality.',
+    relatedTerms: ['prompt-engineering', 'guardrails'],
+  },
+  {
+    slug: 'few-shot-learning',
+    term: 'Few-shot Learning',
+    category: 'prompting',
+    shortDefinition: "Guiding a model's behavior with a handful of examples in the prompt.",
+    definition:
+      "Guiding a model's behavior by providing a handful of examples in the prompt.",
+    businessExample: 'Showing three compliant headlines and asking the model to generate ten more.',
+    relatedTerms: ['zero-shot-learning', 'prompt-engineering'],
+  },
+  {
+    slug: 'zero-shot-learning',
+    term: 'Zero-shot Learning',
+    category: 'prompting',
+    shortDefinition: 'Getting models to perform tasks from instructions alone, no examples.',
+    definition:
+      'Getting models to perform tasks using clear instructions without providing examples.',
+    businessExample: 'Categorizing customer feedback with only well-written guidelines in the prompt.',
+    relatedTerms: ['few-shot-learning', 'prompt-engineering'],
+  },
+  {
+    slug: 'prompt-template',
+    term: 'Prompt Template',
+    category: 'prompting',
+    shortDefinition: 'A reusable, parameterized instruction that produces consistent outputs.',
+    definition:
+      'A reusable, parameterized instruction that produces consistent outputs.',
+    businessExample: 'Generating consistent product descriptions from SKU data using a standard template.',
+    relatedTerms: ['prompt-engineering', 'prompt-chaining'],
+    relatedPages: [{ href: '/chatgpt-prompt-templates', label: 'ChatGPT Prompt Templates' }],
+  },
+  {
+    slug: 'retrieval-augmented-generation',
+    term: 'Retrieval-Augmented Generation (RAG)',
+    aliases: ['RAG'],
+    category: 'rag',
+    shortDefinition: 'Combining document retrieval with generation so answers are grounded in your data.',
+    definition:
+      'An approach that combines information retrieval from your documents with a generative model so answers are grounded in trusted sources.',
+    businessExample: 'A support assistant that answers questions using your help center and policy docs.',
+    relatedTerms: ['embeddings', 'vector-database', 'grounding'],
+    relatedPages: [{ href: '/what-is-rag', label: 'What is RAG?' }],
+  },
+  {
+    slug: 'embeddings',
+    term: 'Embeddings',
+    category: 'technology',
+    shortDefinition: 'Numeric vector representations of data that capture meaning.',
+    definition:
+      'Numeric vector representations of text, images, or other data that capture meaning for search and clustering.',
+    businessExample: 'Finding similar support tickets by meaning rather than exact keywords.',
+    relatedTerms: ['vector-database', 'retrieval-augmented-generation'],
+    relatedPages: [{ href: '/what-are-embeddings', label: 'What are Embeddings?' }],
+  },
+  {
+    slug: 'vector-database',
+    term: 'Vector Database',
+    category: 'technology',
+    shortDefinition: 'A database optimized to search embeddings by similarity.',
+    definition: 'A database optimized to store and search embeddings using similarity queries.',
+    businessExample: 'Retrieving the most relevant knowledge base articles to answer a customer question.',
+    relatedTerms: ['embeddings', 'retrieval-augmented-generation'],
+    relatedPages: [{ href: '/what-is-a-vector-database', label: 'What is a Vector Database?' }],
+  },
+  {
+    slug: 'fine-tuning',
+    term: 'Fine-tuning',
+    category: 'technology',
+    shortDefinition: 'Further training a pre-trained model on your domain data.',
+    definition:
+      'Further training a pre-trained model on your domain data to specialize behavior and tone.',
+    businessExample: 'Adapting a writing model to match your brand voice across marketing channels.',
+    relatedTerms: ['foundation-model', 'rlhf'],
+    relatedPages: [{ href: '/what-is-fine-tuning', label: 'What is Fine-tuning?' }],
+  },
+  {
+    slug: 'token',
+    term: 'Token',
+    category: 'technology',
+    shortDefinition: 'A chunk of text used for pricing, limits, and processing in LLMs.',
+    definition:
+      'A small chunk of text used for pricing, limits, and processing in language models.',
+    businessExample: 'Estimating monthly API costs based on the number of tokens processed.',
+    relatedTerms: ['context-window', 'cost-per-token'],
+  },
+  {
+    slug: 'context-window',
+    term: 'Context Window',
+    category: 'technology',
+    shortDefinition: 'The maximum tokens a model can consider at once.',
+    definition:
+      'The maximum number of tokens a model can consider at once when generating an answer.',
+    businessExample: 'Splitting long PDFs into sections so the model can summarize each chapter accurately.',
+    relatedTerms: ['token'],
+  },
+  {
+    slug: 'hallucination',
+    term: 'AI Hallucination',
+    category: 'ethics',
+    shortDefinition: 'When AI generates false or misleading information presented as fact.',
+    definition:
+      'When AI systems generate false or misleading information presented as fact. Important to understand when using AI for business content creation.',
+    businessExample: 'An AI writing assistant creating fake statistics for a marketing report that need human verification.',
+    relatedTerms: ['guardrails', 'grounding', 'human-in-the-loop'],
+  },
+  {
+    slug: 'guardrails',
+    term: 'Guardrails',
+    category: 'ethics',
+    shortDefinition: 'Policies and filters that keep AI outputs safe, compliant, and on-brand.',
+    definition:
+      'Policies, filters, and constraints that keep AI outputs safe, compliant, and on-brand.',
+    businessExample: 'Blocking medical or investment advice in a consumer chatbot.',
+    relatedTerms: ['hallucination', 'prompt-injection'],
+  },
+  {
+    slug: 'human-in-the-loop',
+    term: 'Human-in-the-Loop',
+    category: 'business',
+    shortDefinition: 'Humans review, correct, or guide AI outputs to ensure quality.',
+    definition:
+      'A process where humans review, correct, or guide AI outputs to ensure quality and compliance.',
+    businessExample: 'Editors approving AI-generated ad copy before publishing.',
+    relatedTerms: ['guardrails', 'quality-assurance'],
+  },
+  {
+    slug: 'agent',
+    term: 'Agent',
+    category: 'agents',
+    shortDefinition: 'An AI system that plans and executes steps toward a goal, often using tools.',
+    definition:
+      'An AI system that plans and executes steps toward a goal, often using tools autonomously.',
+    businessExample: 'An AI assistant that researches prospects, drafts outreach, and schedules meetings.',
+    relatedTerms: ['function-calling', 'multi-agent-orchestration'],
+  },
+  {
+    slug: 'function-calling',
+    term: 'Function Calling (Tool Use)',
+    aliases: ['tool use'],
+    category: 'agents',
+    shortDefinition: 'Letting models call structured tools or APIs to fetch data or take actions.',
+    definition:
+      'Allowing models to call structured tools or APIs to retrieve data or take actions.',
+    businessExample: 'A chatbot booking meetings through your calendar API when asked.',
+    relatedTerms: ['agent', 'json-mode'],
+  },
+  {
+    slug: 'prompt-injection',
+    term: 'Prompt Injection',
+    category: 'ethics',
+    shortDefinition: 'A security attack embedding malicious instructions to hijack model behavior.',
+    definition:
+      'A security attack where malicious instructions are embedded in content to override or hijack model behavior.',
+    businessExample: 'A pasted email tries to make the assistant reveal system prompts or credentials.',
+    relatedTerms: ['guardrails', 'jailbreaking'],
+  },
+]
+
+export const glossaryTermsBySlug = Object.fromEntries(
+  glossaryTerms.map((t) => [t.slug, t])
+)
+
+export const categoriesById = Object.fromEntries(categories.map((c) => [c.id, c]))

--- a/docs/glossary-spec.md
+++ b/docs/glossary-spec.md
@@ -1,0 +1,136 @@
+# Site Glossary — Spec & Migration Plan
+
+Status: **scaffold landed, data migration pending.**
+
+Branch: `claude/create-site-glossary-7sQAf`
+
+## Why
+
+The existing `/ai-glossary` page is a 1,026-line monolith with 170 terms inlined. It gets no per-term search traffic and the "Learn more" links to deeper pages are a hardcoded if-ladder. This spec replaces it with a data-driven `/glossary` hub plus per-term pages at `/glossary/[slug]` — same pattern used for `/ai-prompt-generator/[slug]` and `/chatgpt-prompts-for/[modifier]`.
+
+## Goals
+
+1. Capture long-tail "what is X" traffic with one indexable page per term.
+2. Keep a single browseable hub at `/glossary`.
+3. Be data-driven so new terms = one entry in `/data/glossary.js`.
+4. Interlink terms to each other and to deeper explainers (RAG pages, course CTA).
+
+## URL structure
+
+- `/glossary` — hub: search, category filters, A–Z index.
+- `/glossary/[slug]` — one page per term (e.g. `/glossary/prompt-engineering`).
+- `/ai-glossary` → 301 to `/glossary` (preserve backlinks).
+
+## Data model
+
+Single source of truth: `/data/glossary.js`.
+
+```js
+{
+  slug: 'prompt-engineering',
+  term: 'Prompt Engineering',
+  aliases: ['prompt design', 'prompting'],
+  category: 'prompting',
+  shortDefinition: '...',             // 1 sentence, used in meta + cards
+  definition: '...',                  // 2–4 sentences
+  businessExample: '...',
+  relatedTerms: ['few-shot-learning', 'system-prompt'],
+  relatedPages: [
+    { href: '/chatgpt-prompt-templates', label: 'ChatGPT Prompt Templates' }
+  ],
+}
+```
+
+## Categories
+
+- `basics` — AI, ML, deep learning, neural network
+- `business` — use case, ROI, human-in-the-loop
+- `technology` — architectures, training methods, infra
+- `ethics` — bias, hallucination, guardrails, privacy
+- `prompting` — prompt engineering, few-shot, system prompt, prompt templates
+- `rag` — RAG and all variants (Auto-RAG, GraphRAG, HybridRAG, etc.)
+- `agents` — agents, function calling, multi-agent orchestration
+
+## Schema.org
+
+- Hub: `DefinedTermSet` wrapping all entries.
+- Detail: `DefinedTerm` + `BreadcrumbList`.
+
+## What's landed in this PR
+
+- `/data/glossary.js` — data model + categories + **20 seed terms** covering all categories.
+- `/pages/glossary/index.js` — working hub with search, category filter, A–Z index, schema.org.
+- `/pages/glossary/[slug].js` — working per-term page with related terms, related pages, schema.org, Join Now CTA.
+
+## TODO for the local agent picking this up
+
+### 1. Migrate the remaining ~150 terms from `/pages/ai-glossary.js`
+
+Source is the `glossaryTerms` array in `pages/ai-glossary.js` (lines ~32–513). For each term:
+
+- Assign a `slug` (URL-safe, lowercased, strip parenthetical abbreviations — e.g. `Top-p (Nucleus Sampling)` → `top-p`).
+- Write a 1-sentence `shortDefinition` (existing entries only have `definition`).
+- Carry over `category`, `definition`, `businessExample`.
+- Wire `relatedTerms` to other slugs (2–4 per entry).
+- Copy `relatedPages` from the hardcoded if-ladder in `ai-glossary.js` (lines ~796–856). Mappings:
+
+  | term                              | relatedPage           |
+  | --------------------------------- | --------------------- |
+  | Retrieval-Augmented Generation    | /what-is-rag          |
+  | Fine-tuning                       | /what-is-fine-tuning  |
+  | Embeddings                        | /what-are-embeddings  |
+  | Vector Database                   | /what-is-a-vector-database |
+  | Auto-RAG                          | /auto-rag             |
+  | Self-RAG                          | /self-rag             |
+  | FLARE / Active RAG                | /flare-active-rag     |
+  | R^2AG                             | /r2ag                 |
+  | GraphRAG                          | /graphrag             |
+  | InFO-RAG                          | /info-rag             |
+  | HybridRAG                         | /hybridrag            |
+  | Corrective RAG                    | /corrective-rag       |
+  | Speculative RAG                   | /speculative-rag      |
+  | Reliability-Aware RAG (RA-RAG)    | /ra-rag               |
+  | MoRAG                             | /morag                |
+
+- Reclassify RAG-family terms from `technology` → `rag`, prompting terms → `prompting`, agent terms → `agents`.
+
+### 2. Add the 301 redirect
+
+In `next.config.js`, extend `redirects()`:
+
+```js
+{ source: '/ai-glossary', destination: '/glossary', permanent: true },
+```
+
+### 3. Delete `pages/ai-glossary.js`
+
+Once the redirect is in and data migration is complete.
+
+### 4. Update internal links
+
+Replace `/ai-glossary` with `/glossary` across:
+
+- `components/layout/Header.js`
+- `components/layout/Footer.js`
+- `components/ui/RelatedCalculators.js`
+- `pages/what-is-rag.js`, `pages/what-are-embeddings.js`, `pages/what-is-fine-tuning.js`
+- `pages/ai-history.js`, `pages/ai-models.js`
+
+Find all with: `grep -rn "ai-glossary" . --include="*.js"`
+
+### 5. Sitemap
+
+Ensure `/glossary` and every `/glossary/[slug]` is emitted by the sitemap generator.
+
+### 6. New terms worth seeding beyond the existing 170
+
+Gaps for site-specific SEO:
+
+- **Claude-family**: Opus, Sonnet, Haiku, Claude Code, CLAUDE.md, MCP, skill, hook, slash command (pages already exist — link out via `relatedPages`).
+- **Prompting primitives**: stop sequence, chain-of-thought.
+
+## Open questions
+
+1. One file vs. split JSON? Recommend: one file until ~300 terms, then split to `/data/glossary/*.json`.
+2. Category landing pages (`/glossary/category/[category]`)? Phase 2.
+3. Autolinking plugin that converts term mentions across the site into `/glossary/[slug]` links? Phase 2.

--- a/pages/glossary/[slug].js
+++ b/pages/glossary/[slug].js
@@ -1,0 +1,198 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import EnhancedMeta from '../../components/ui/EnhancedMeta'
+import OrganizationSchema from '../../components/ui/OrganizationSchema'
+import {
+  glossaryTerms,
+  glossaryTermsBySlug,
+  categoriesById,
+} from '../../data/glossary'
+
+export async function getStaticPaths() {
+  return {
+    paths: glossaryTerms.map((t) => ({ params: { slug: t.slug } })),
+    fallback: false,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const term = glossaryTermsBySlug[params.slug] || null
+  if (!term) return { notFound: true }
+  const related = (term.relatedTerms || [])
+    .map((slug) => glossaryTermsBySlug[slug])
+    .filter(Boolean)
+    .map((t) => ({ slug: t.slug, term: t.term, shortDefinition: t.shortDefinition || '' }))
+  return { props: { term, related } }
+}
+
+export default function GlossaryTermPage({ term, related }) {
+  const cat = categoriesById[term.category]
+  const url = `https://promptwritingstudio.com/glossary/${term.slug}`
+
+  const definedTerm = {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTerm',
+    name: term.term,
+    description: term.shortDefinition || term.definition,
+    url,
+    inDefinedTermSet: 'https://promptwritingstudio.com/glossary',
+  }
+
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://promptwritingstudio.com/' },
+      { '@type': 'ListItem', position: 2, name: 'Glossary', item: 'https://promptwritingstudio.com/glossary' },
+      { '@type': 'ListItem', position: 3, name: term.term, item: url },
+    ],
+  }
+
+  return (
+    <Layout
+      title={`What is ${term.term}? | PromptWritingStudio Glossary`}
+      description={term.shortDefinition || term.definition.slice(0, 155)}
+    >
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTerm) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+        />
+      </Head>
+      <EnhancedMeta
+        title={`What is ${term.term}?`}
+        description={term.shortDefinition || term.definition.slice(0, 155)}
+        url={url}
+        image="https://promptwritingstudio.com/images/ai-glossary-preview.jpg"
+        type="article"
+      />
+      <OrganizationSchema />
+
+      <section className="py-10 border-b border-[#E5E5E5] bg-white">
+        <div className="container mx-auto px-4 md:px-6">
+          <nav className="max-w-3xl mx-auto text-sm text-gray-500 mb-4">
+            <Link href="/" className="hover:text-gray-700">Home</Link>
+            <span className="mx-2">/</span>
+            <Link href="/glossary" className="hover:text-gray-700">Glossary</Link>
+            <span className="mx-2">/</span>
+            <span className="text-gray-700">{term.term}</span>
+          </nav>
+          <div className="max-w-3xl mx-auto">
+            <div className="flex items-center gap-3 mb-4">
+              {cat && (
+                <span className={`px-3 py-1 rounded-full text-xs font-semibold ${cat.badge}`}>
+                  {cat.label}
+                </span>
+              )}
+            </div>
+            <h1 className="text-4xl md:text-5xl font-bold text-[#1A1A1A] mb-4">
+              {term.term}
+            </h1>
+            {term.shortDefinition && (
+              <p className="text-xl text-gray-600">{term.shortDefinition}</p>
+            )}
+            {term.aliases && term.aliases.length > 0 && (
+              <p className="text-sm text-gray-500 mt-3">
+                Also known as: {term.aliases.join(', ')}
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-white">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-3xl mx-auto prose prose-lg">
+            <h2 className="text-2xl font-bold text-[#1A1A1A] mb-4">Definition</h2>
+            <p className="text-gray-700">{term.definition}</p>
+
+            {term.businessExample && (
+              <div className="bg-blue-50 border-l-4 border-blue-500 p-5 mt-6 not-prose">
+                <h3 className="font-semibold text-blue-800 text-sm mb-2">
+                  Business Example
+                </h3>
+                <p className="text-blue-700 text-sm">{term.businessExample}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {(related.length > 0 || (term.relatedPages && term.relatedPages.length > 0)) && (
+        <section className="py-12 bg-[#F9F9F9] border-t border-[#E5E5E5]">
+          <div className="container mx-auto px-4 md:px-6">
+            <div className="max-w-3xl mx-auto">
+              {related.length > 0 && (
+                <>
+                  <h2 className="text-2xl font-bold text-[#1A1A1A] mb-6">Related terms</h2>
+                  <div className="grid md:grid-cols-2 gap-4 mb-10">
+                    {related.map((r) => (
+                      <Link
+                        key={r.slug}
+                        href={`/glossary/${r.slug}`}
+                        className="block bg-white rounded-lg p-4 border border-[#E5E5E5] hover:border-blue-300 hover:shadow-sm transition"
+                      >
+                        <div className="font-semibold text-blue-700">{r.term}</div>
+                        {r.shortDefinition && (
+                          <div className="text-sm text-gray-600 mt-1">{r.shortDefinition}</div>
+                        )}
+                      </Link>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {term.relatedPages && term.relatedPages.length > 0 && (
+                <>
+                  <h2 className="text-2xl font-bold text-[#1A1A1A] mb-6">Learn more</h2>
+                  <ul className="space-y-3">
+                    {term.relatedPages.map((p) => (
+                      <li key={p.href}>
+                        <Link
+                          href={p.href}
+                          className="text-blue-600 hover:text-blue-800 font-medium"
+                        >
+                          {p.label} →
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="py-16 bg-white border-t border-[#E5E5E5]">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">
+              Turn this term into results
+            </h2>
+            <p className="text-lg text-gray-600 mb-6">
+              PromptWritingStudio shows you how to apply concepts like{' '}
+              <span className="font-semibold">{term.term}</span> to real marketing and content work.
+            </p>
+            <a
+              href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+              className="inline-block bg-[#FFDE59] text-black font-bold px-8 py-4 rounded-lg hover:bg-yellow-400 transition"
+            >
+              Join Now
+            </a>
+            <div className="mt-8">
+              <Link href="/glossary" className="text-blue-600 hover:text-blue-800 font-medium">
+                ← Back to glossary
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}

--- a/pages/glossary/index.js
+++ b/pages/glossary/index.js
@@ -1,0 +1,277 @@
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import Head from 'next/head'
+import Layout from '../../components/layout/Layout'
+import EnhancedMeta from '../../components/ui/EnhancedMeta'
+import OrganizationSchema from '../../components/ui/OrganizationSchema'
+import EmailCapture from '../../components/ui/EmailCapture'
+import { glossaryTerms, categories, categoriesById } from '../../data/glossary'
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+
+export default function GlossaryIndex() {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState('all')
+  const [isIndexOpen, setIsIndexOpen] = useState(false)
+  const [showScrollButtons, setShowScrollButtons] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setShowScrollButtons(window.scrollY > 500)
+    onScroll()
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  const matchesSearch = (t, q) => {
+    if (!q) return true
+    const needle = q.toLowerCase()
+    return (
+      t.term.toLowerCase().includes(needle) ||
+      t.definition.toLowerCase().includes(needle) ||
+      (t.aliases || []).some((a) => a.toLowerCase().includes(needle))
+    )
+  }
+
+  const filteredTerms = glossaryTerms
+    .filter((t) => matchesSearch(t, searchTerm))
+    .filter((t) => selectedCategory === 'all' || t.category === selectedCategory)
+    .sort((a, b) => a.term.localeCompare(b.term))
+
+  const lettersPresent = Array.from(
+    new Set(filteredTerms.map((t) => t.term[0].toUpperCase()).filter((ch) => /[A-Z]/.test(ch)))
+  ).sort()
+
+  const definedTermSet = {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTermSet',
+    name: 'PromptWritingStudio Glossary',
+    url: 'https://promptwritingstudio.com/glossary',
+    hasDefinedTerm: glossaryTerms.map((t) => ({
+      '@type': 'DefinedTerm',
+      name: t.term,
+      description: t.shortDefinition || t.definition,
+      url: `https://promptwritingstudio.com/glossary/${t.slug}`,
+      inDefinedTermSet: 'https://promptwritingstudio.com/glossary',
+    })),
+  }
+
+  let previousLetter = ''
+
+  return (
+    <Layout
+      title="AI & Prompting Glossary — Clear Definitions for Business Owners | PromptWritingStudio"
+      description="Browse every key AI, prompting, RAG, and agents term with plain-English definitions and business examples. Searchable, filterable, A–Z indexed."
+    >
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(definedTermSet) }}
+        />
+      </Head>
+      <EnhancedMeta
+        title="AI & Prompting Glossary — Clear Definitions for Business Owners"
+        description="Every key AI, prompting, RAG, and agents term explained in plain English with business examples."
+        url="https://promptwritingstudio.com/glossary"
+        image="https://promptwritingstudio.com/images/ai-glossary-preview.jpg"
+        type="article"
+      />
+      <OrganizationSchema />
+
+      <section className="bg-gradient-to-r from-green-600 to-blue-600 py-16 md:py-24">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-4xl mx-auto text-center text-white">
+            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6">Glossary</h1>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              AI, prompting, RAG, and agents — explained in plain English
+            </p>
+            <div className="bg-white bg-opacity-20 rounded-lg p-6 max-w-2xl mx-auto">
+              <p className="text-lg">
+                Search {glossaryTerms.length}+ terms, filter by category, or jump straight to a
+                letter. Every entry includes a business example.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-gray-50">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-4xl mx-auto">
+            <div className="flex flex-col md:flex-row gap-4 mb-8">
+              <div className="flex-1">
+                <input
+                  type="text"
+                  placeholder="Search glossary..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+              <div className="md:w-56">
+                <select
+                  value={selectedCategory}
+                  onChange={(e) => setSelectedCategory(e.target.value)}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="all">All Categories</option>
+                  {categories.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <p className="text-sm text-gray-600 mb-6">
+              Showing {filteredTerms.length} of {glossaryTerms.length} terms
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-white">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-4xl mx-auto">
+            <div id="a-z-index" className="h-0" />
+            <div className="md:hidden sticky top-0 z-20 bg-white/90 backdrop-blur border-b mb-6">
+              <button
+                type="button"
+                aria-expanded={isIndexOpen}
+                onClick={() => setIsIndexOpen((open) => !open)}
+                className="w-full flex items-center justify-between px-3 py-3 text-sm font-semibold text-[#1A1A1A]"
+              >
+                <span>A–Z Index</span>
+                <span className="text-gray-500">{isIndexOpen ? 'Hide' : 'Show'}</span>
+              </button>
+              {isIndexOpen && (
+                <div className="flex gap-2 overflow-x-auto whitespace-nowrap no-scrollbar px-3 pb-3">
+                  {ALPHABET.map((ch) =>
+                    lettersPresent.includes(ch) ? (
+                      <a
+                        key={ch}
+                        href={`#letter-${ch}`}
+                        onClick={() => setIsIndexOpen(false)}
+                        className="px-2 py-1 text-xs font-semibold text-blue-700 hover:text-blue-900 hover:underline"
+                      >
+                        {ch}
+                      </a>
+                    ) : (
+                      <span key={ch} className="px-2 py-1 text-xs font-semibold text-gray-300">
+                        {ch}
+                      </span>
+                    )
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="hidden md:block sticky top-0 z-20 bg-white/90 backdrop-blur border-b py-2 mb-6">
+              <div className="flex gap-2 overflow-x-auto whitespace-nowrap no-scrollbar">
+                {ALPHABET.map((ch) =>
+                  lettersPresent.includes(ch) ? (
+                    <a
+                      key={ch}
+                      href={`#letter-${ch}`}
+                      className="px-2 py-1 text-xs font-semibold text-blue-700 hover:text-blue-900 hover:underline"
+                    >
+                      {ch}
+                    </a>
+                  ) : (
+                    <span key={ch} className="px-2 py-1 text-xs font-semibold text-gray-300">
+                      {ch}
+                    </span>
+                  )
+                )}
+              </div>
+            </div>
+
+            {showScrollButtons && (
+              <div className="fixed bottom-6 right-4 z-30 flex flex-col gap-2">
+                <button
+                  type="button"
+                  aria-label="Back to top"
+                  onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                  className="bg-white/90 backdrop-blur border border-gray-300 shadow-sm hover:shadow px-3 py-2 rounded-md text-xs font-semibold text-gray-700"
+                >
+                  Top
+                </button>
+              </div>
+            )}
+
+            <div className="space-y-6">
+              {filteredTerms.map((item) => {
+                const currentLetter = item.term[0].toUpperCase()
+                const showLetterAnchor = currentLetter !== previousLetter
+                if (showLetterAnchor) previousLetter = currentLetter
+                const cat = categoriesById[item.category]
+                return (
+                  <div key={item.slug}>
+                    {showLetterAnchor && (
+                      <div id={`letter-${currentLetter}`} className="mb-2">
+                        <div className="text-xs uppercase tracking-wider text-gray-400">
+                          {currentLetter}
+                        </div>
+                      </div>
+                    )}
+                    <Link
+                      href={`/glossary/${item.slug}`}
+                      className="block border border-gray-200 rounded-lg p-6 hover:shadow-md hover:border-blue-300 transition"
+                    >
+                      <div className="flex flex-col md:flex-row md:items-start md:justify-between mb-3">
+                        <h3 className="text-2xl font-bold text-[#1A1A1A] mb-2 md:mb-0">
+                          {item.term}
+                        </h3>
+                        {cat && (
+                          <span className={`px-3 py-1 rounded-full text-xs font-semibold inline-block ${cat.badge}`}>
+                            {cat.label}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-gray-600">
+                        {item.shortDefinition || item.definition}
+                      </p>
+                      <span className="text-blue-600 text-sm font-medium mt-3 inline-block">
+                        Read more →
+                      </span>
+                    </Link>
+                  </div>
+                )
+              })}
+            </div>
+
+            {filteredTerms.length === 0 && (
+              <div className="text-center py-12">
+                <p className="text-gray-500 text-lg">
+                  No terms found. Try different keywords or clear the filter.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 md:py-20 bg-[#F9F9F9] border-t border-[#E5E5E5]">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#1A1A1A]">
+              Put these ideas to work
+            </h2>
+            <p className="text-lg text-gray-600 mb-8">
+              The PromptWritingStudio course turns glossary knowledge into repeatable workflows
+              for content, marketing, and support.
+            </p>
+            <a
+              href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+              className="inline-block bg-[#FFDE59] text-black font-bold px-8 py-4 rounded-lg hover:bg-yellow-400 transition"
+            >
+              Join Now
+            </a>
+            <div className="mt-10">
+              <EmailCapture source="glossary" theme="light" />
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Summary

Scaffolds a data-driven glossary at `/glossary` + `/glossary/[slug]`, replacing the pattern used by the current 1,026-line monolithic `/ai-glossary` page. **Opened early so a local agent can pick up the data migration and link cleanup** — see TODO below and `docs/glossary-spec.md` for the full plan.

- `data/glossary.js` — data model, 7 categories, 20 seed terms across all categories with `relatedTerms` + `relatedPages`.
- `pages/glossary/index.js` — hub with search, category filter, sticky A–Z index, `DefinedTermSet` schema, Join Now CTA.
- `pages/glossary/[slug].js` — per-term page with `DefinedTerm` + `BreadcrumbList` schema, related-terms grid, learn-more links, Join Now CTA.
- `docs/glossary-spec.md` — spec + migration TODO.

The existing `/ai-glossary` page is untouched in this PR; both routes coexist until the migration below is complete.

## TODO (for local agent)

1. **Migrate the remaining ~150 terms** from `pages/ai-glossary.js` (the `glossaryTerms` array, lines ~32–513) into `data/glossary.js`. For each: assign a slug, write a 1-sentence `shortDefinition`, wire `relatedTerms`, carry over `relatedPages` from the hardcoded if-ladder (lines ~796–856 — mapping table in `docs/glossary-spec.md`). Reclassify RAG-family terms from `technology` → `rag`, prompting → `prompting`, agents → `agents`.
2. **Add the 301 redirect** `/ai-glossary → /glossary` in `next.config.js` `redirects()`.
3. **Delete `pages/ai-glossary.js`** once redirect + migration are in.
4. **Update internal links** — `grep -rn "ai-glossary" . --include="*.js"` — across `components/layout/Header.js`, `components/layout/Footer.js`, `components/ui/RelatedCalculators.js`, `pages/ai-history.js`, `pages/ai-models.js`, and the `/what-is-*` RAG pages.
5. **Sitemap** — confirm `/glossary` and every `/glossary/[slug]` are emitted.

## Test plan

- [ ] `npm run build` succeeds; `getStaticPaths` emits all seed slugs.
- [ ] `/glossary` renders: search filters by term + alias + definition; category dropdown filters; A–Z index jumps; Join Now CTA points to Teachable URL.
- [ ] `/glossary/prompt-engineering`, `/glossary/retrieval-augmented-generation`, `/glossary/agent` render with correct breadcrumb, related terms, and learn-more links.
- [ ] View source shows `DefinedTermSet` JSON-LD on hub and `DefinedTerm` + `BreadcrumbList` on detail pages.
- [ ] After migration: old `/ai-glossary` 301s to `/glossary`; no broken internal links.

https://claude.ai/code/session_01Pz8rMugkGuqwCQ3SBznsgd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz8rMugkGuqwCQ3SBznsgd)_