### PR TITLE
feat(observatory): C1 data layer — seed 5 prompts + loader + validator

### DIFF
--- a/data/observatory/prompts/analysis-financial-summary.json
+++ b/data/observatory/prompts/analysis-financial-summary.json
@@ -1,0 +1,38 @@
+{
+  "id": "analysis-financial-summary",
+  "category": "analysis",
+  "title": "Summarise quarterly revenue data and surface key insights",
+  "prompt": "You are a financial analyst. Review the following quarterly revenue data and produce a summary that includes: (1) overall trend direction, (2) the single largest growth driver, (3) the single biggest risk, and (4) one actionable recommendation.\n\nData:\n{{raw_data}}\n\nKeep your response under 200 words. Use plain language, not financial jargon.",
+  "test_inputs": [
+    {
+      "id": "saas-q1-q4-2025",
+      "vars": {
+        "raw_data": "Q1 2025: $820k ARR, 210 customers, churn 2.1%, new logos 38\nQ2 2025: $910k ARR, 230 customers, churn 1.8%, new logos 42\nQ3 2025: $970k ARR, 245 customers, churn 2.4%, new logos 35\nQ4 2025: $1.05M ARR, 258 customers, churn 1.9%, new logos 29"
+      }
+    }
+  ],
+  "rubric": {
+    "criteria": [
+      "Correctly identifies the overall trend as positive growth and notes the churn spike in Q3",
+      "Surfaces a specific, evidence-backed growth driver or risk rather than a generic statement",
+      "Provides one concrete actionable recommendation tied to the data"
+    ],
+    "scoring_per_criterion": "0-3",
+    "pass_threshold": 7,
+    "judge_prompt_template": "default"
+  },
+  "models": [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "llama-3.3-70b"
+  ],
+  "affiliate_tool_default": "claude",
+  "needs_premium_verification": false,
+  "added_date": "2026-05-23",
+  "schema_version": 1
+}

--- a/data/observatory/prompts/code-explain-recursive.json
+++ b/data/observatory/prompts/code-explain-recursive.json
@@ -1,0 +1,38 @@
+{
+  "id": "code-explain-recursive",
+  "category": "code",
+  "title": "Explain a recursive function in plain English",
+  "prompt": "Here is a recursive function:\n```\n{{code}}\n```\nExplain in plain English what it does, what its base case is, and what happens when the base case is not met.",
+  "test_inputs": [
+    {
+      "id": "fibonacci-python",
+      "vars": {
+        "code": "def fib(n): return n if n<2 else fib(n-1)+fib(n-2)"
+      }
+    }
+  ],
+  "rubric": {
+    "criteria": [
+      "Identifies the base case (n < 2) correctly and explains its purpose",
+      "Explains what the function computes without using the word 'recursion' unnecessarily",
+      "Response is plain English with no code blocks in the answer"
+    ],
+    "scoring_per_criterion": "0-3",
+    "pass_threshold": 7,
+    "judge_prompt_template": "default"
+  },
+  "models": [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "llama-3.3-70b"
+  ],
+  "affiliate_tool_default": "claude",
+  "needs_premium_verification": false,
+  "added_date": "2026-05-23",
+  "schema_version": 1
+}

--- a/data/observatory/prompts/legal-clause-rewrite.json
+++ b/data/observatory/prompts/legal-clause-rewrite.json
@@ -1,0 +1,38 @@
+{
+  "id": "legal-clause-rewrite",
+  "category": "legal",
+  "title": "Rewrite a legal clause in plain English without losing meaning",
+  "prompt": "Rewrite the following legal clause in plain English so that a non-lawyer can understand it. Preserve the legal intent exactly — do not omit any obligations, rights, or limitations. Do not give legal advice.\n\nClause:\n{{clause}}\n\nOutput format: (1) Plain-English version, (2) a one-sentence note on anything you simplified that a reader should verify with a lawyer.",
+  "test_inputs": [
+    {
+      "id": "limitation-of-liability",
+      "vars": {
+        "clause": "IN NO EVENT SHALL EITHER PARTY BE LIABLE TO THE OTHER FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING OUT OF OR RELATED TO THIS AGREEMENT, EVEN IF SUCH PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, AND NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY, WITH THE EXCEPTION OF CLAIMS ARISING FROM GROSS NEGLIGENCE OR WILLFUL MISCONDUCT."
+      }
+    }
+  ],
+  "rubric": {
+    "criteria": [
+      "Plain-English version accurately reflects the limitation on indirect/consequential damages and the gross negligence/wilful misconduct carve-out",
+      "Does not give legal advice (no 'you should', 'this means you are safe', or equivalent advisory statements)",
+      "Includes a one-sentence verification note flagging what was simplified"
+    ],
+    "scoring_per_criterion": "0-3",
+    "pass_threshold": 7,
+    "judge_prompt_template": "default"
+  },
+  "models": [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "llama-3.3-70b"
+  ],
+  "affiliate_tool_default": "claude",
+  "needs_premium_verification": false,
+  "added_date": "2026-05-23",
+  "schema_version": 1
+}

--- a/data/observatory/prompts/sales-objection-handler.json
+++ b/data/observatory/prompts/sales-objection-handler.json
@@ -1,0 +1,39 @@
+{
+  "id": "sales-objection-handler",
+  "category": "sales",
+  "title": "Handle a common sales objection without being pushy",
+  "prompt": "You are a sales rep. A prospect just said: \"{{objection}}\"\n\nThe product is: {{product}}\n\nWrite a response that acknowledges the concern, reframes it with one concrete benefit, and ends with a low-pressure next step. Keep it under 80 words. Do not promise discounts or make claims you cannot verify.",
+  "test_inputs": [
+    {
+      "id": "too-expensive-crm",
+      "vars": {
+        "objection": "This is too expensive. We already pay for three tools that overlap with what you do.",
+        "product": "A CRM that consolidates contact management, email sequences, and deal tracking into one platform"
+      }
+    }
+  ],
+  "rubric": {
+    "criteria": [
+      "Explicitly acknowledges the cost concern rather than dismissing or ignoring it",
+      "Reframes with a specific benefit (e.g. consolidation saving tool costs) rather than a vague value claim",
+      "Ends with a low-pressure next step (e.g. a short call, a trial, a cost comparison) without pressuring or offering unverified discounts"
+    ],
+    "scoring_per_criterion": "0-3",
+    "pass_threshold": 7,
+    "judge_prompt_template": "default"
+  },
+  "models": [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "llama-3.3-70b"
+  ],
+  "affiliate_tool_default": "claude",
+  "needs_premium_verification": false,
+  "added_date": "2026-05-23",
+  "schema_version": 1
+}

--- a/data/observatory/prompts/writing-cold-email-saas-founder.json
+++ b/data/observatory/prompts/writing-cold-email-saas-founder.json
@@ -1,0 +1,40 @@
+{
+  "id": "writing-cold-email-saas-founder",
+  "category": "writing",
+  "title": "Write a cold outreach email for a SaaS founder",
+  "prompt": "Write a cold outreach email for a SaaS founder.\n\nProduct: {{product_name}}\nProspect role: {{prospect_role}}\nPain point to address: {{pain_point}}\n\nRequirements: under 120 words, one clear CTA, no buzzwords, personalised opening line.",
+  "test_inputs": [
+    {
+      "id": "project-management-to-eng-head",
+      "vars": {
+        "product_name": "Taskline — async project tracking for remote engineering teams",
+        "prospect_role": "Head of Engineering at a 40-person startup",
+        "pain_point": "Sprint reviews are blocked by status updates scattered across Slack threads"
+      }
+    }
+  ],
+  "rubric": {
+    "criteria": [
+      "Email is under 120 words and includes exactly one clear call to action",
+      "Opening line references the prospect's role or context specifically rather than using a generic greeting",
+      "No buzzwords (e.g. synergy, leverage, game-changer) and tone is conversational not salesy"
+    ],
+    "scoring_per_criterion": "0-3",
+    "pass_threshold": 7,
+    "judge_prompt_template": "default"
+  },
+  "models": [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "llama-3.3-70b"
+  ],
+  "affiliate_tool_default": "claude",
+  "needs_premium_verification": false,
+  "added_date": "2026-05-23",
+  "schema_version": 1
+}

--- a/lib/observatory/load_corpus.ts
+++ b/lib/observatory/load_corpus.ts
@@ -1,0 +1,158 @@
+import fs from "fs";
+import path from "path";
+
+export interface TestInput {
+  id: string;
+  vars: Record<string, string>;
+}
+
+export interface Rubric {
+  criteria: string[];
+  scoring_per_criterion: "0-3";
+  pass_threshold: number;
+  judge_prompt_template: string;
+}
+
+export type ModelId =
+  | "claude-opus-4-7"
+  | "claude-sonnet-4-6"
+  | "claude-haiku-4-5"
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  | "gemini-2.5-pro"
+  | "gemini-2.5-flash"
+  | "llama-3.3-70b";
+
+export type Category = "code" | "writing" | "analysis" | "sales" | "legal" | "image" | "ops";
+
+export interface Prompt {
+  id: string;
+  category: Category;
+  title: string;
+  prompt: string;
+  test_inputs: TestInput[];
+  rubric: Rubric;
+  models: ModelId[];
+  affiliate_tool_default: string;
+  needs_premium_verification?: boolean;
+  added_date: string;
+  schema_version: 1;
+}
+
+const VALID_CATEGORIES = new Set<string>(["code", "writing", "analysis", "sales", "legal", "image", "ops"]);
+const VALID_MODELS = new Set<string>([
+  "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
+  "gpt-4o", "gpt-4o-mini", "gemini-2.5-pro", "gemini-2.5-flash", "llama-3.3-70b",
+]);
+const KEBAB_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const DATE_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+
+function validatePrompt(data: unknown, filename: string): Prompt {
+  if (!data || typeof data !== "object") {
+    throw new Error(`${filename}: root must be an object`);
+  }
+  const p = data as Record<string, unknown>;
+
+  const required = ["id", "category", "title", "prompt", "test_inputs", "rubric", "models", "affiliate_tool_default", "added_date", "schema_version"] as const;
+  for (const field of required) {
+    if (!(field in p)) {
+      throw new Error(`${filename}: missing required field "${field}"`);
+    }
+  }
+
+  if (p.schema_version !== 1) {
+    throw new Error(`${filename}: schema_version must be 1, got ${p.schema_version}`);
+  }
+  if (typeof p.id !== "string" || !KEBAB_RE.test(p.id)) {
+    throw new Error(`${filename}: id must be kebab-case, got "${p.id}"`);
+  }
+  if (typeof p.category !== "string" || !VALID_CATEGORIES.has(p.category)) {
+    throw new Error(`${filename}: category "${p.category}" is not in the allowed enum`);
+  }
+  if (typeof p.title !== "string" || p.title.length < 4) {
+    throw new Error(`${filename}: title must be a string of at least 4 characters`);
+  }
+  if (typeof p.prompt !== "string" || p.prompt.length < 4) {
+    throw new Error(`${filename}: prompt must be a string of at least 4 characters`);
+  }
+  if (!Array.isArray(p.test_inputs) || p.test_inputs.length < 1) {
+    throw new Error(`${filename}: test_inputs must be a non-empty array`);
+  }
+  for (const ti of p.test_inputs as unknown[]) {
+    if (!ti || typeof ti !== "object") throw new Error(`${filename}: test_inputs items must be objects`);
+    const t = ti as Record<string, unknown>;
+    if (typeof t.id !== "string" || !KEBAB_RE.test(t.id)) {
+      throw new Error(`${filename}: test_inputs[].id must be kebab-case`);
+    }
+    if (!t.vars || typeof t.vars !== "object") {
+      throw new Error(`${filename}: test_inputs[].vars must be an object`);
+    }
+  }
+  if (!p.rubric || typeof p.rubric !== "object") {
+    throw new Error(`${filename}: rubric must be an object`);
+  }
+  const r = p.rubric as Record<string, unknown>;
+  if (!Array.isArray(r.criteria) || r.criteria.length < 1) {
+    throw new Error(`${filename}: rubric.criteria must be a non-empty array`);
+  }
+  if (r.scoring_per_criterion !== "0-3") {
+    throw new Error(`${filename}: rubric.scoring_per_criterion must be "0-3"`);
+  }
+  if (typeof r.pass_threshold !== "number" || !Number.isInteger(r.pass_threshold) || r.pass_threshold < 1) {
+    throw new Error(`${filename}: rubric.pass_threshold must be a positive integer`);
+  }
+  if (typeof r.judge_prompt_template !== "string") {
+    throw new Error(`${filename}: rubric.judge_prompt_template must be a string`);
+  }
+  if (!Array.isArray(p.models) || p.models.length < 1) {
+    throw new Error(`${filename}: models must be a non-empty array`);
+  }
+  for (const m of p.models as unknown[]) {
+    if (typeof m !== "string" || !VALID_MODELS.has(m)) {
+      throw new Error(`${filename}: unknown model "${m}"`);
+    }
+  }
+  if (typeof p.affiliate_tool_default !== "string" || p.affiliate_tool_default.length < 2) {
+    throw new Error(`${filename}: affiliate_tool_default must be a string of at least 2 characters`);
+  }
+  if (typeof p.added_date !== "string" || !DATE_RE.test(p.added_date)) {
+    throw new Error(`${filename}: added_date must be YYYY-MM-DD, got "${p.added_date}"`);
+  }
+
+  return p as unknown as Prompt;
+}
+
+export function loadCorpus(promptsDir?: string): Prompt[] {
+  const dir = promptsDir ?? path.join(process.cwd(), "data", "observatory", "prompts");
+
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Observatory prompts directory not found: ${dir}`);
+  }
+
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith(".json")).sort();
+  if (files.length === 0) {
+    throw new Error(`No prompt JSON files found in ${dir}`);
+  }
+
+  const corpus: Prompt[] = [];
+  const errors: string[] = [];
+
+  for (const file of files) {
+    const filepath = path.join(dir, file);
+    try {
+      const raw = fs.readFileSync(filepath, "utf-8");
+      const data: unknown = JSON.parse(raw);
+      corpus.push(validatePrompt(data, file));
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Observatory corpus validation failed:\n${errors.map((e) => `  - ${e}`).join("\n")}`
+    );
+  }
+
+  return corpus;
+}

--- a/scripts/observatory/README.md
+++ b/scripts/observatory/README.md
@@ -1,0 +1,38 @@
+# Observatory scripts
+
+Scripts for the PWS Prompt Observatory pipeline. See `~/.claude/support/prompt-observatory-contract.md` for the full contract.
+
+## validate_corpus.py
+
+Standalone CLI validator. Reads every `*.json` in `data/observatory/prompts/` and validates each against the `$defs/prompt` subschema in `data/observatory/schema.json`.
+
+**Requires:** `pip install jsonschema`
+
+**Usage:**
+
+```bash
+# From repo root
+python3 scripts/observatory/validate_corpus.py
+
+# Custom paths
+python3 scripts/observatory/validate_corpus.py \
+  --prompts-dir data/observatory/prompts \
+  --schema data/observatory/schema.json
+```
+
+**Exit codes:** `0` = all valid, `1` = one or more failures, `2` = jsonschema not installed.
+
+Used in CI (`observatory-weekly.yml` step [1]) and as a pre-flight before any manual corpus edit.
+
+## lib/observatory/load_corpus.ts
+
+Build-time corpus loader for Next.js. Call `loadCorpus()` inside `getStaticProps`; it reads and validates the corpus on every build, throwing on any schema violation so bad prompts never reach production.
+
+```ts
+import { loadCorpus } from "../../lib/observatory/load_corpus";
+
+export async function getStaticProps() {
+  const corpus = loadCorpus(); // throws if any prompt is invalid
+  return { props: { corpus } };
+}
+```

--- a/scripts/observatory/validate_corpus.py
+++ b/scripts/observatory/validate_corpus.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+CLI validator for the PWS Prompt Observatory corpus.
+Validates every JSON file in data/observatory/prompts/ against the
+prompt subschema in data/observatory/schema.json.
+
+Exit 0 = all prompts valid.
+Exit 1 = one or more validation errors (details printed to stderr).
+
+Usage:
+    python3 scripts/observatory/validate_corpus.py
+    python3 scripts/observatory/validate_corpus.py --prompts-dir path/to/prompts
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    import jsonschema
+    from jsonschema import Draft202012Validator
+except ImportError:
+    print(
+        "ERROR: jsonschema is not installed. Run: pip install jsonschema",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def load_schema(schema_path: Path) -> dict:
+    with open(schema_path) as f:
+        return json.load(f)
+
+
+def build_prompt_validator(schema: dict) -> Draft202012Validator:
+    """Wrap the $defs.prompt subschema so refs resolve correctly."""
+    prompt_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": schema["$defs"],
+        "$ref": "#/$defs/prompt",
+    }
+    return Draft202012Validator(prompt_schema)
+
+
+def validate_file(path: Path, validator: Draft202012Validator) -> list[str]:
+    """Return list of error messages for a single prompt file."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        return [f"Invalid JSON: {e}"]
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    return [f"{'.'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}" for e in errors]
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+
+    parser = argparse.ArgumentParser(description="Validate PWS Observatory prompt corpus")
+    parser.add_argument(
+        "--prompts-dir",
+        type=Path,
+        default=repo_root / "data" / "observatory" / "prompts",
+        help="Directory containing prompt JSON files",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=repo_root / "data" / "observatory" / "schema.json",
+        help="Path to the observatory schema.json",
+    )
+    args = parser.parse_args()
+
+    if not args.schema.exists():
+        print(f"ERROR: schema not found at {args.schema}", file=sys.stderr)
+        return 1
+
+    if not args.prompts_dir.exists():
+        print(f"ERROR: prompts directory not found at {args.prompts_dir}", file=sys.stderr)
+        return 1
+
+    schema = load_schema(args.schema)
+    validator = build_prompt_validator(schema)
+
+    prompt_files = sorted(args.prompts_dir.glob("*.json"))
+    if not prompt_files:
+        print(f"ERROR: no prompt JSON files found in {args.prompts_dir}", file=sys.stderr)
+        return 1
+
+    failed = 0
+    for path in prompt_files:
+        errors = validate_file(path, validator)
+        if errors:
+            failed += 1
+            print(f"FAIL  {path.name}", file=sys.stderr)
+            for err in errors:
+                print(f"      {err}", file=sys.stderr)
+        else:
+            print(f"OK    {path.name}")
+
+    total = len(prompt_files)
+    passed = total - failed
+    print(f"\n{passed}/{total} prompts valid", file=sys.stderr if failed else sys.stdout)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Seeds `data/observatory/prompts/` with 5 diverse v1 prompts (code, writing, analysis, sales, legal), each validating against `data/observatory/schema.json`
- Adds `lib/observatory/load_corpus.ts` — build-time corpus loader with hand-rolled structural validation; throws on any invalid prompt
- Adds `scripts/observatory/validate_corpus.py` — standalone CLI pre-flight using `jsonschema.Draft202012Validator` against `$defs/prompt`; exits non-zero with field-level errors
- Adds `scripts/observatory/README.md` — usage docs for both tools

Schema locked: `data/observatory/schema.json` was not modified (C0 contract).

## Test plan

- [x] `python3 scripts/observatory/validate_corpus.py` exits 0 — `5/5 prompts valid`
- [x] All 5 prompt files have no additional properties beyond the schema's `additionalProperties: false` constraint
- [x] `schema_version: 1`, `scoring_per_criterion: "0-3"` constants present in all prompts
- [x] All model IDs are from the v1 enum in `data/observatory/schema.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)