### PR TITLE
fix(pws): bundle #16 #17 #18 #24 — schema url + form dedupe + private-link removal + H1 shape

### DIFF
--- a/data/claude-code-skills.json
+++ b/data/claude-code-skills.json
@@ -46,8 +46,7 @@
       },
       {
         "author": "Bryan Collins",
-        "repo": "bryancollins99/claude-config",
-        "url": "https://github.com/bryancollins99/claude-config",
+        "repo": "Personal pattern — not distributed publicly",
         "licence": "MIT"
       }
     ],

--- a/pages/chatgpt-prompts-for/[modifier].js
+++ b/pages/chatgpt-prompts-for/[modifier].js
@@ -108,9 +108,12 @@ export default function ModifierPage({ modifierData }) {
         <div className="container mx-auto px-4 md:px-6">
           <div className="max-w-3xl mx-auto text-center">
             <span className="bg-white/20 text-white px-4 py-1 rounded-full text-sm font-medium mb-4 inline-block">Claude + ChatGPT Prompts</span>
-            <h1 className="text-4xl md:text-5xl font-bold mb-6">
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">
               {promptTemplates.length}+ Claude &amp; ChatGPT Prompts for {modifierName}
             </h1>
+            <h2 className="text-xl font-semibold mb-3 text-white/90">
+              What are the best ChatGPT prompts for {modifierName}?
+            </h2>
             <p className="text-xl mb-8">
               Tested prompt templates for {modifierName.toLowerCase()} — work in Claude, ChatGPT, and other major AI chat models.
               Copy, paste, and adapt.


### PR DESCRIPTION
## Summary

- **#16 generateArticleSchema url undefined** — `lib/schemaGenerator.js:192` already resolves `slug` via `resolvedUrl = url || (slug ? \`https://promptwritingstudio.com/${slug}\` : undefined)`. Bug was pre-fixed; confirmed no callers broken.
- **#17 Two email capture forms on /ai-prompt-quiz** — `pages/ai-prompt-quiz.js` already has a single `<EmailCapture>` component (line 299). Bespoke form was pre-removed; no duplicate remains.
- **#18 Skill detail pages link to private repo** — `data/claude-code-skills.json:49-50` had `bryancollins99/claude-config` URL in `_meta.sources`. Stripped the private `url` field; replaced `repo` with `"Personal pattern — not distributed publicly"`. No individual skill `source.repoUrl` pointed to the private repo (already clean).
- **#24 H1 not question-shaped on /chatgpt-prompts-for/***  — `pages/chatgpt-prompts-for/[modifier].js:112` — kept noun H1 intact (ranking safety), added `<h2>` immediately below: *"What are the best ChatGPT prompts for {modifierName}?"* — signals AEO answer intent without risking established rankings.

## Test plan

- [x] `npm run build` passes clean (pre-existing large-page warning on `/chatgpt-prompt-templates` only)
- [x] No new lint errors
- [ ] Verify `/chatgpt-prompts-for/writing` renders H2 question below H1
- [ ] Verify `/claude-code-skills` hub and skill detail pages show no link to `bryancollins99/claude-config`

Closes #16 Closes #17 Closes #18 Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)