### PR TITLE
feat(learn): AI workforce defensive-literacy track (5-7 modules)

### DIFF
--- a/data/ai-workforce.js
+++ b/data/ai-workforce.js
@@ -258,11 +258,11 @@ export const AI_WORKFORCE_MODULES = [
     shortTitle: 'Augmented Roles',
     description: 'What the accountant, marketer, writer, customer support specialist, and designer role looks like when AI handles the pattern work -- and where human judgment becomes the bottleneck.',
     lastUpdated: '2026-05-25',
-    readingTime: '10 min',
+    readingTime: '15 min',
     content: [
       {
         type: 'lead',
-        text: 'The augmented version of a role is not a reduced version. It typically involves less volume work and more judgment, communication, and taste -- the things AI cannot reliably do. This module maps five common roles through that transition.',
+        text: 'The augmented version of a role is not a reduced version. It typically involves less volume work and more judgment, communication, and taste -- the things AI cannot reliably do. This module maps five common roles through that transition. McKinsey\'s 2023 work on AI and the future of work estimated that 60-70% of employee time across all occupations is currently spent on activities that could be partially automated; the World Economic Forum Future of Jobs Report 2023 estimated that 44% of worker skills will be disrupted over five years. Both ranges are aggregate. What follows is what those numbers actually mean at the desk level, role by role.',
       },
       {
         type: 'h2',
@@ -270,12 +270,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Routine data extraction, reconciliation, and standard report formatting are high AI-exposure tasks. The augmented version shifts time toward: interpreting anomalies, advising on tax strategy for novel situations, communicating financial risk to non-finance stakeholders, and managing relationships with auditors and regulators. Technical accounting knowledge stays essential -- the AI produces outputs that still need a qualified professional to validate.',
+        text: 'Routine data extraction, reconciliation, transaction categorisation, variance commentary, and standard report formatting are high AI-exposure tasks. Tools like Excel\'s Copilot, Microsoft 365 Copilot, and finance-specific platforms now produce useable first drafts of monthly management accounts from structured ledger data. The augmented version of the role shifts time toward interpreting anomalies, advising on tax strategy for novel situations, communicating financial risk to non-finance stakeholders, and managing relationships with auditors and regulators. Technical accounting knowledge stays essential -- the AI produces outputs that a qualified professional still has to validate, and in regulated contexts the human review is non-negotiable.',
+      },
+      {
+        type: 'p',
+        text: 'The augmented accountant is increasingly an internal advisor, not a producer of reports. The reports get produced anyway; the value is what gets said about them in the room. That requires presenting financial information in plain language to non-finance colleagues and helping them make better operational decisions.',
       },
       {
         type: 'example',
-        label: 'What changes',
-        text: 'Pulling quarterly numbers from the ERP and formatting them into board templates: mostly automated. Explaining why margin compressed despite revenue growth, and recommending a specific response: still human. The ratio of "format and assemble" to "interpret and advise" shifts dramatically.',
+        label: 'What changes -- monthly close',
+        text: 'Pulling quarterly numbers from the ERP and formatting them into board templates: mostly automated. Explaining why margin compressed despite revenue growth, and recommending a specific response: still human. The ratio of "format and assemble" to "interpret and advise" shifts dramatically. A finance analyst who spent 70% of the week on assembly and 30% on interpretation may move toward 25% assembly and 75% interpretation -- but only if they actively claim the interpretation work.',
+      },
+      {
+        type: 'example',
+        label: 'What changes -- audit preparation',
+        text: 'Pulling supporting documentation, sampling transactions for testing, generating audit trail summaries: these are AI-augmentable. Negotiating audit scope with the auditor, deciding which judgmental areas (revenue recognition, asset impairment, going-concern assessment) to defend with what evidence: human. The augmented audit prep team is leaner on documentation labour and heavier on partner-level conversations earlier in the cycle.',
       },
       {
         type: 'h2',
@@ -283,12 +292,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'First-draft copy, A/B test variants, audience segmentation from structured data, and campaign performance summaries are high exposure. The augmented role concentrates on: brand judgment (what is on-brand when an AI can only produce plausible-sounding copy), strategy (which channels and messages for which audience at which stage), and relationships with agencies, media partners, and sales teams.',
+        text: 'First-draft copy, A/B test variants, audience segmentation from structured data, campaign performance summaries, social-post variations, and ad-creative iterations are high exposure. Almost every modern marketing stack now has AI features generating exactly these outputs. The augmented role concentrates on brand judgement -- what is on-brand when an AI can produce plausible-sounding copy in any voice -- strategy (which channels and messages for which audience at which stage), and relationships with agencies, media partners, and sales teams.',
+      },
+      {
+        type: 'p',
+        text: 'The harder shift is in measurement. AI tools make it easy to run more experiments, generate more variants, and produce more reports. That increases the volume of data but not necessarily the volume of insight. The augmented marketer becomes better at choosing what not to measure, what experiments not to run, and which channel results to ignore as noise. Strategic restraint becomes more valuable as production becomes cheaper.',
       },
       {
         type: 'example',
-        label: 'What changes',
-        text: 'Writing ten variations of an email subject line: AI does this in seconds. Deciding which one reflects the brand accurately and will land with the specific audience segment at this moment in the campaign: human judgment. The marketer role moves toward creative direction and strategic orchestration.',
+        label: 'What changes -- a campaign launch',
+        text: 'Writing ten variations of an email subject line: AI does this in seconds. Deciding which one reflects the brand accurately, will land with the specific audience segment at this moment in the campaign, and will not erode trust with the long-term list: human judgement. The marketer role moves toward creative direction and strategic orchestration, with the team running smaller and the agency relationships getting more strategic.',
+      },
+      {
+        type: 'example',
+        label: 'What changes -- B2B account-based marketing',
+        text: 'AI tools can identify look-alike companies, surface intent signals from web data, and draft initial outreach at scale. They cannot judge whether the named contact at the prospect company is the right entry point given the political map of that organisation, or whether the timing is right relative to their fiscal year and recent leadership changes. The marketer\'s value is the political read on a specific account, supported by AI that handles the volume layer underneath.',
       },
       {
         type: 'h2',
@@ -296,12 +314,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Formulaic content (product descriptions, FAQs, templated articles on known topics) has high AI exposure. The augmented writer concentrates on: original research and reporting, distinctive voice and point of view, editorial judgment about what to cover and how, and structured persuasion that requires understanding a specific reader\'s situation.',
+        text: 'Formulaic content -- product descriptions, FAQs, templated articles on known topics, transcript-based summaries -- has high AI exposure. The augmented writer concentrates on original research and reporting (going to the source, not paraphrasing existing content), distinctive voice and point of view, editorial judgement about what to cover and how, and structured persuasion that requires understanding a specific reader\'s situation. SEO-driven content that exists only to capture queries is increasingly produced and ranked by AI on both sides; that whole layer is collapsing toward zero margin.',
+      },
+      {
+        type: 'p',
+        text: 'A different shift in publishing: AI Overviews on Google and answer engines on ChatGPT, Perplexity, and Claude are reducing the click-through rate on commodity informational content. The writer who survives the next two years is one whose work is being cited as the source by those engines, not paraphrased into them. That requires either original reporting, named expertise, or a position the engine cannot derive from scraping existing content.',
       },
       {
         type: 'example',
-        label: 'What changes',
-        text: 'A first draft of a blog post from a detailed brief: AI can produce this faster than any human. Whether the post says something true and interesting that the reader will act on: that depends on research, editorial judgment, and voice that the AI cannot supply from a brief alone. The writer role shifts toward the judgment and editorial layer.',
+        label: 'What changes -- a how-to article',
+        text: 'A first draft of a how-to article from a detailed brief: AI produces this faster than any human. Whether the article says something true and useful that the reader will act on, includes specific worked examples from real practice, and reflects a point of view the reader respects: this depends on research, editorial judgement, and voice that the AI cannot supply from a brief alone. The writer role shifts toward the judgement, sourcing, and editorial layer -- closer to the work of an editor with reporting skill than a producer of templated text.',
+      },
+      {
+        type: 'example',
+        label: 'What changes -- thought leadership for an executive',
+        text: 'AI can ghost-write a plausible LinkedIn post in any executive\'s past voice given enough samples. It cannot know what the executive actually thinks about a specific market event that happened this morning, what they want to be associated with strategically, or which of three positions they should take given what their CEO said last week. The ghost-writer role moves from producer to interviewer-strategist -- much more time in conversation with the executive, much less time at the keyboard.',
       },
       {
         type: 'h2',
@@ -309,12 +336,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'L1 ticket resolution, FAQ responses, and status updates on known issues are high exposure. The augmented support specialist handles: escalations that require empathy and de-escalation, complex product issues with no prior resolution path, internal escalation and coordination, and identifying systemic issues from patterns in customer feedback.',
+        text: 'L1 ticket resolution, FAQ responses, status updates on known issues, and standard refund processing are high exposure. Modern customer-support AI now resolves measurable shares of L1 volume without escalation -- Klarna publicly reported in 2024 that its AI assistant handled work equivalent to roughly 700 full-time agents on volume that was previously L1. The augmented support specialist handles escalations that require empathy and de-escalation, complex product issues with no prior resolution path, internal coordination with engineering, and identifying systemic issues from patterns in customer feedback that no individual ticket would surface.',
+      },
+      {
+        type: 'p',
+        text: 'A second shift: the augmented support function becomes a primary product-feedback loop. Specialists who can synthesise hundreds of conversations into a clear "here is what customers are actually struggling with this month" become more valuable, because that synthesis is a judgement task that AI assists but does not replace. Routing that signal to product and engineering with credibility is the new value layer.',
       },
       {
         type: 'example',
-        label: 'What changes',
-        text: 'A customer whose subscription renewal failed due to a payment processor error: AI can identify the issue and trigger the fix. A customer who has been having problems for three months, is angry, and is about to cancel: AI can draft a response, but the specialist\'s judgment about what to say and offer is what saves the account.',
+        label: 'What changes -- a churning account',
+        text: 'A customer whose subscription renewal failed due to a payment processor error: AI identifies the issue and triggers the fix in seconds. A customer who has had problems for three months, is angry, and is about to cancel: AI drafts a response, but the specialist\'s judgement about what to say and offer is what saves the account. The compensation level, the tone of the apology, the choice between a one-off concession and a multi-month account-management commitment -- these are decisions where the AI is wrong as often as right and the cost of being wrong is the account.',
+      },
+      {
+        type: 'example',
+        label: 'What changes -- a complex multi-product issue',
+        text: 'A B2B customer reporting an issue that spans authentication, billing, and the API: AI can quickly diagnose which subsystem is failing if the issue matches known patterns. When it does not, the specialist has to coordinate engineers across three teams, manage the customer\'s expectations through a multi-day investigation, and decide when to escalate to engineering leadership. Coordination under uncertainty across internal teams is high-trust work that the AI does not do.',
       },
       {
         type: 'h2',
@@ -322,27 +358,56 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Generating visual variations, resizing assets for multiple formats, and producing stock-style imagery are high exposure. The augmented designer focuses on: concept development and creative direction, understanding a brief well enough to evaluate AI output against it, brand consistency judgment, and communication with stakeholders who cannot evaluate AI output themselves.',
-      },
-      {
-        type: 'example',
-        label: 'What changes',
-        text: 'Producing 20 logo variations from a brief: AI tools can do this. Deciding which one captures what the client actually meant -- and presenting that choice with a clear rationale -- is design judgment. The designer becomes more of a director of AI-generated options and less a producer of individual assets.',
-      },
-      {
-        type: 'h2',
-        text: 'The common pattern',
+        text: 'Generating visual variations, resizing assets for multiple formats, producing stock-style imagery, drafting wireframes from a brief, and producing variations of a known layout are high exposure. The augmented designer focuses on concept development and creative direction, understanding a brief well enough to evaluate AI output against it, brand consistency judgement, and communication with stakeholders who cannot evaluate AI output themselves. Senior designers are spending more time on prompt-and-curate workflows and less time on production.',
       },
       {
         type: 'p',
-        text: 'Across all five roles, the shift is similar: volume work and pattern work moves toward AI; judgment, communication, and taste become the primary value. That does not make roles easier -- those skills are harder to develop and less commoditised. It does mean the skills worth investing in are different from the ones that got most of the professional development attention in the pre-AI era.',
+        text: 'A second shift specific to product designers: as AI lowers the cost of producing UI variations, the bottleneck moves to deciding which variation to ship based on user research, accessibility constraints, business logic, and engineering cost. Designers who pair tightly with PM and engineering on that decision become more central; designers whose value was production speed lose ground.',
+      },
+      {
+        type: 'example',
+        label: 'What changes -- brand identity work',
+        text: 'Producing 20 logo variations from a brief: AI tools do this. Deciding which one captures what the client actually meant, presenting that choice with a clear rationale, and defending it through three rounds of stakeholder feedback: design judgement. The designer becomes more of a director of AI-generated options and a defender of strategic choices, and less of a producer of individual assets.',
+      },
+      {
+        type: 'example',
+        label: 'What changes -- a product feature design',
+        text: 'AI can suggest layout patterns and produce variations against a design system. It cannot weigh the accessibility implications for screen-reader users against the business stakeholder\'s preference for a denser layout, or know that the engineering team is constrained on this sprint and the simpler pattern is the only realistically shippable one. The designer who can hold all three constraints in mind and make a defensible call is the one whose role survives.',
+      },
+      {
+        type: 'h2',
+        text: 'The common pattern across all five roles',
+      },
+      {
+        type: 'p',
+        text: 'Volume work and pattern work moves toward AI. Judgement, communication, and taste become the primary value. That does not make roles easier -- those skills are harder to develop, take longer to acquire, and are less commoditised. The skills worth investing in are different from the ones that got most of the professional development attention in the pre-AI era. The next module unpacks that skill stack in detail; the practice block below gets you started on the version specific to your role.',
+      },
+      {
+        type: 'action',
+        label: 'What to do this week',
+        text: [
+          'Identify the role on this list closest to yours (or the nearest analogue if yours is not here -- legal, engineering, operations, HR all follow similar patterns).',
+          'List three tasks you do that match the "high exposure" descriptions above. Pick one and try doing it with AI assistance this week -- log time saved and quality.',
+          'List three tasks that match the "augmented" descriptions (judgement, communication, coordination) and that you currently spend less than 20% of your time on. Pick one and book a 90-minute block to do it deliberately.',
+          'After two weeks of this, your task mix should already look more like the augmented version.',
+        ],
+      },
+      {
+        type: 'links',
+        label: 'Next in this track',
+        items: [
+          { text: 'The Defensive Skill Stack', url: '/ai-workforce/defensive-skill-stack', note: 'the skills that compound when production becomes cheap' },
+          { text: 'Conversations With Your Employer', url: '/ai-workforce/conversations-with-your-employer', note: 'how to make the augmented version of your role visible' },
+          { text: 'AI tools in Ireland', url: 'https://vendors.ie/ai-tools-ireland', note: 'compared by use case -- meetings, drafting, research, support' },
+        ],
       },
       {
         type: 'sources',
         items: [
-          'McKinsey Global Institute: "A new future of work: The race to deploy AI and raise skills" (2023)',
-          'World Economic Forum: "Future of Jobs Report 2023"',
-          'HBR: "In the Age of AI, You Need Both Artificial Intelligence and Human Intelligence" (2023)',
+          { text: 'McKinsey Global Institute: A new future of work -- the race to deploy AI and raise skills (2023)', url: 'https://www.mckinsey.com/mgi/our-research/a-new-future-of-work-the-race-to-deploy-ai-and-raise-skills-in-an-unequal-world' },
+          { text: 'World Economic Forum: Future of Jobs Report 2023', url: 'https://www.weforum.org/reports/the-future-of-jobs-report-2023/' },
+          { text: 'HBR: In the Age of AI, You Need Both Artificial Intelligence and Human Intelligence (2023)', url: 'https://hbr.org/' },
+          { text: 'Stanford HAI AI Index Report 2024 -- occupational impact section', url: 'https://aiindex.stanford.edu/report/' },
         ],
       },
     ],

--- a/data/ai-workforce.js
+++ b/data/ai-workforce.js
@@ -421,11 +421,11 @@ export const AI_WORKFORCE_MODULES = [
     shortTitle: 'Defensive Skills',
     description: 'The skills that compound in an AI-augmented workplace -- judgment, communication, taste, and context -- and why they are durable compared to technical skills.',
     lastUpdated: '2026-05-25',
-    readingTime: '8 min',
+    readingTime: '13 min',
     content: [
       {
         type: 'lead',
-        text: 'If you have read the previous modules, a pattern is visible: the skills most protected from AI substitution are judgment, communication, taste, and real-world context. This module explains what those mean in practice and how to develop them deliberately.',
+        text: 'If you have read the previous modules, a pattern is visible: the skills most protected from AI substitution are judgement, communication, taste, and real-world context. This module explains what each of those means in practice, why they compound over time rather than depreciate, and how to develop them deliberately. The World Economic Forum Future of Jobs Report 2023 ranks analytical thinking, creative thinking, and resilience as the top three skills employers are prioritising; the LinkedIn Workforce Report and McKinsey skills research consistently surface a similar list. These are not abstract qualities -- they are practiceable.',
       },
       {
         type: 'h2',
@@ -433,24 +433,29 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Technical skills have a predictable decay curve: a skill tied to a specific tool or format loses value when the tool is superseded. Judgment, communication, and taste compound differently. They improve with experience, transfer across contexts, and become more valuable as the volume and quality of AI output rises -- because someone has to evaluate and direct that output.',
+        text: 'Technical skills have a predictable decay curve: a skill tied to a specific tool, framework, or format loses value when the tool is superseded. The half-life of named technical skills in the Stanford HAI 2024 data appears to be shortening across multiple categories, particularly anything tied to a particular software product. Judgement, communication, taste, and context compound differently. They improve with experience, transfer across contexts, and become more valuable as the volume and quality of AI output rises -- because someone still has to evaluate and direct that output. The person who can reliably tell a good output from a plausible-but-wrong one is more valuable when AI produces ten outputs an hour than when a colleague produces one.',
       },
       {
         type: 'p',
-        text: 'As AI produces more first drafts, more summaries, more options, the bottleneck shifts from production to evaluation. The person who can reliably tell a good output from a plausible-but-wrong one becomes more valuable, not less.',
+        text: 'A second reason these skills compound: they are difficult to transfer in a prompt. A new hire takes months or years to acquire judgement about your industry; an AI tool takes zero. If you have judgement and the AI does not, that gap holds while the AI gets cheaper and your value rises with it.',
       },
       {
         type: 'h2',
-        text: 'Judgment: making decisions with incomplete information',
+        text: 'Judgement: making decisions with incomplete information',
       },
       {
         type: 'p',
-        text: 'Judgment is the ability to reach a good decision when the information is ambiguous, incomplete, or contested. AI systems optimise for plausibility; they do not have a stake in the outcome and cannot hold the full context of a specific situation. Developing judgment means deliberately taking on decisions, tracking what happened, and updating your model of how similar situations play out.',
+        text: 'Judgement is the ability to reach a good decision when the information is ambiguous, incomplete, or contested. AI systems optimise for plausibility; they do not have a stake in the outcome and cannot hold the full context of a specific situation. They are also calibrated on what most people would say rather than what is true in this case, which is a structurally different objective. Developing judgement means deliberately taking on decisions, tracking what happened, and updating your model of how similar situations play out.',
       },
       {
         type: 'example',
-        label: 'How to develop it',
-        text: 'Ask to own decisions rather than execute on them. After each significant decision, note what you expected and what happened. Over time this builds a calibrated sense of where your intuitions are reliable and where they need more information. That is a skill an AI cannot acquire for you.',
+        label: 'How to develop judgement -- decision journal',
+        text: 'Keep a one-page decision journal. For each significant decision (every two weeks is a reasonable cadence), write: what I am deciding, what I expect to happen, what would change my mind, and what I will treat as evidence either way in 30/90/180 days. Review entries at those intervals. Over a year this builds a calibrated sense of where your intuitions are reliable and where they need more information. That is a skill an AI cannot acquire for you, and it is the input to almost every other defensive skill on this list.',
+      },
+      {
+        type: 'example',
+        label: 'How to develop judgement -- own the call',
+        text: 'In meetings, distinguish between contributing analysis and owning a decision. Ask explicitly to own one decision per quarter that you would normally only inform. Track what happened. The most common career trap is being technically excellent at analysis without ever taking the on-the-record positions that build judgement. AI is fine at analysis; it cannot make a call you are accountable for.',
       },
       {
         type: 'h2',
@@ -458,12 +463,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'AI can produce grammatically correct, reasonably well-structured text. It cannot know your audience -- their priorities, their blind spots, what they said in last week\'s meeting, what framing will land and what will trigger defensiveness. Communication as a skill is not about grammar; it is about understanding a specific person or group and choosing the words, sequence, and emphasis that work for them.',
+        text: 'AI can produce grammatically correct, reasonably well-structured text in almost any register. It cannot know your audience -- their priorities, blind spots, what they said in last week\'s meeting, what framing will land and what will trigger defensiveness, what they actually care about versus what they say they care about. Communication as a skill is not about grammar; it is about understanding a specific person or group and choosing the words, sequence, and emphasis that work for them.',
+      },
+      {
+        type: 'p',
+        text: 'The shift worth noting: as AI makes the average quality of written output rise, the differentiating skill becomes the strategic shape of communication, not the prose. What you choose to say, what you leave out, what order you put it in, what you put in the subject line and what you bury -- these matter more than sentence-level craft. The augmented communicator spends less time on drafting and more time on the architecture of the message.',
       },
       {
         type: 'example',
-        label: 'How to develop it',
-        text: 'After each important communication (presentation, negotiation, difficult conversation), assess what landed and what did not. Explicitly build a mental model of the people you communicate with regularly: what they care about, what they react poorly to, how they process information. AI can help you draft; it cannot build that model.',
+        label: 'How to develop communication -- the audience map',
+        text: 'For the five to ten people you most need to influence at work, write a one-paragraph profile of each: what they prioritise, what they react badly to, how they process information (slides? prose? numbers? stories?), what their boss measures them on. Update quarterly. Before any important communication, read the relevant profile. This explicit modelling is what good communicators do unconsciously; building it deliberately accelerates the skill by years.',
+      },
+      {
+        type: 'example',
+        label: 'How to develop communication -- the after-action review',
+        text: 'After each important communication (presentation, negotiation, difficult conversation, important email), assess what landed, what did not, and why. The two-minute reflection in your notebook compounds. AI can help you draft; it cannot tell you why your CFO went quiet after slide four.',
       },
       {
         type: 'h2',
@@ -471,11 +485,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Taste is the ability to distinguish between an output that is technically adequate and one that is genuinely good. As AI makes technically adequate output cheap, taste becomes the scarce resource. It applies to writing, design, product decisions, customer interactions, and strategy.',
+        text: 'Taste is the ability to distinguish between an output that is technically adequate and one that is genuinely good. As AI makes technically adequate output cheap, taste becomes the scarce resource. It applies to writing, design, product decisions, code, customer interactions, hiring, and strategy. Taste is hardest to define precisely -- which is part of why it is durable. Anything you can write down as a checklist, AI can be trained on; anything you can only demonstrate through choices is yours.',
       },
       {
         type: 'p',
-        text: 'Taste is developed by exposure to high-quality examples across a domain and by the discipline of asking "why is this better than that" rather than just noting a preference. It is slow to develop and difficult to transfer -- which is exactly what makes it durable.',
+        text: 'Taste is developed by sustained exposure to high-quality examples across a domain and by the discipline of asking "why is this better than that" rather than just noting a preference. It is slow to develop and difficult to transfer between domains, which is exactly what makes it durable. The designer with twenty years of taste in B2B SaaS interfaces does not have transferable taste in consumer fashion; the editor with sharp taste in long-form journalism may have blunt taste in technical documentation.',
+      },
+      {
+        type: 'example',
+        label: 'How to develop taste -- the comparison practice',
+        text: 'Pick two examples in your domain, one excellent and one mediocre, every week. Write 100-200 words on why one is better than the other. The act of articulating preference forces the implicit model to become explicit, which is what accelerates calibration. After a year you will see things in your domain that newer colleagues cannot, and you will be able to direct AI output more precisely because you have a clearer target.',
+      },
+      {
+        type: 'example',
+        label: 'How to develop taste -- learn from people whose taste you trust',
+        text: 'Identify the two or three people in your field whose judgement you most respect. Read what they read, watch what they choose to share, ask them why they liked a particular thing. Taste accretes through proximity to people who already have it. AI does not yet replace that mechanism; if anything, it makes the gap between people with calibrated taste and people without it more visible.',
       },
       {
         type: 'h2',
@@ -483,11 +507,15 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'AI systems can process data but they do not have the lived context of a specific organisation, client, or market. Context means knowing that the margin drop in Q3 is because of a contract renegotiation you were in the room for; that the client\'s apparent resistance is because of a failed implementation three years ago; that this market reacts differently to price changes than the category average suggests.',
+        text: 'AI systems can process data but they do not have the lived context of a specific organisation, client, or market. Context means knowing that the margin drop in Q3 was driven by a contract renegotiation you were in the room for; that the client\'s apparent resistance is because of a failed implementation three years ago that nobody mentions out loud; that this market reacts differently to price changes than the category average suggests because of a 2019 regulatory change that still distorts behaviour.',
       },
       {
         type: 'p',
-        text: 'Context is accumulated through sustained attention to one domain or relationship over time. It cannot be transferred to an AI in a prompt.',
+        text: 'Context is accumulated through sustained attention to one domain or relationship over time. It cannot be transferred to an AI in a prompt, and it usually cannot be transferred to a new hire either. That is why long tenure in one domain, which used to be considered low-status in fast-moving industries, is now visibly more valuable -- the institutional memory that lives in your head is structurally hard for the AI to replicate.',
+      },
+      {
+        type: 'p',
+        text: 'A practical warning: context only compounds if you stay engaged with it. Long tenure where you have stopped paying attention does not generate context; it generates rigidity. The defensive value is in active institutional knowledge, not seat-time.',
       },
       {
         type: 'h2',
@@ -495,14 +523,35 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Deliberate practice looks different for each skill. For judgment: own more decisions and track outcomes. For communication: study the specific people you need to influence, not communication in general. For taste: read and study excellent examples in your domain, not just your own outputs. For context: stay in one domain long enough to accumulate the situational knowledge that is invisible to outsiders.',
+        text: 'Deliberate practice looks different for each skill. For judgement: own more decisions, keep a decision journal, review at fixed intervals. For communication: build the audience map, do after-action reviews, focus on the architecture of messages rather than sentence craft. For taste: do weekly comparison writing, stay close to people with calibrated taste in your domain. For context: stay in one domain long enough to accumulate the situational knowledge that is invisible to outsiders, and stay actively engaged with it. Across all four: write things down. The unwritten version of these skills is harder to develop deliberately because the feedback loop is too slow.',
+      },
+      {
+        type: 'action',
+        label: 'What to do this week',
+        text: [
+          'Start a decision journal. One A4 page is enough. Write your first entry today on a decision you currently face.',
+          'Pick three people on your audience map (most-need-to-influence list). Write a one-paragraph profile of each.',
+          'Choose two examples in your domain -- one excellent, one mediocre -- and write 100-200 words on why one is better than the other.',
+          'Identify one place in the next month where you can ask to own a decision rather than just inform it. Put it in the calendar.',
+        ],
+      },
+      {
+        type: 'links',
+        label: 'Next in this track',
+        items: [
+          { text: 'Conversations With Your Employer', url: '/ai-workforce/conversations-with-your-employer', note: 'positioning the skill stack visibly without making yourself redundant' },
+          { text: 'When to Retrain, When to Switch, When to Stay', url: '/ai-workforce/retrain-switch-stay', note: 'using the skill audit to choose a path' },
+          { text: 'AI tools in Ireland', url: 'https://vendors.ie/ai-tools-ireland', note: 'tools that pair well with each skill -- not replacements' },
+        ],
       },
       {
         type: 'sources',
         items: [
-          'HBR: "The Skills That Will Help You Thrive in the Age of AI" (2023)',
-          'MIT Sloan Management Review: "Rethinking the Human-Machine Collaboration" (2024)',
-          'OECD: "AI and the Future of Skills" (2023)',
+          { text: 'World Economic Forum: Future of Jobs Report 2023 -- core skills ranking', url: 'https://www.weforum.org/reports/the-future-of-jobs-report-2023/' },
+          { text: 'HBR: The Skills That Will Help You Thrive in the Age of AI (2023)', url: 'https://hbr.org/' },
+          { text: 'MIT Sloan Management Review: Rethinking the Human-Machine Collaboration (2024)', url: 'https://sloanreview.mit.edu/' },
+          { text: 'OECD: AI and the Future of Skills (2023)', url: 'https://www.oecd.org/employment-outlook/' },
+          { text: 'Stanford HAI AI Index Report 2024 -- skills and labour market section', url: 'https://aiindex.stanford.edu/report/' },
         ],
       },
     ],

--- a/data/ai-workforce.js
+++ b/data/ai-workforce.js
@@ -684,4 +684,295 @@ export const AI_WORKFORCE_MODULES = [
     next: 'tool-of-the-month',
     prev: 'defensive-skill-stack',
   },
+
+  {
+    slug: 'tool-of-the-month',
+    title: 'Tool of the Month: Practical AI in Your Workflow',
+    shortTitle: 'Practical Tools',
+    description: 'Practical, category-by-category guidance on which AI tools to try in your week -- meetings, drafting, research, support -- with anti-hype framing and what to look for.',
+    lastUpdated: '2026-05-25',
+    readingTime: '13 min',
+    content: [
+      {
+        type: 'lead',
+        text: 'There are too many AI tools, every week brings a new one, and the marketing language is largely interchangeable. This module is a category-first guide rather than a brand-first one: here are the four or five workflow categories where AI tools deliver real value for working professionals, what to look for in each category, two or three options worth trying, and the failure modes that the demos do not show. No category here requires a paid subscription to test honestly; all of them have free tiers good enough to evaluate.',
+      },
+      {
+        type: 'h2',
+        text: 'The honest framing before you pick anything',
+      },
+      {
+        type: 'p',
+        text: 'A useful AI tool meets three criteria: it sits at a real bottleneck in your week (not a small annoyance); the output is verifiable in less time than producing it from scratch; and the failure modes are understood and survivable. A tool that satisfies all three is worth integrating. A tool that fails on any one of them is usually a waste of attention even if the demo is impressive.',
+      },
+      {
+        type: 'p',
+        text: 'A second filter: prefer tools that integrate with what you already use over tools that demand a new workflow. The integration tax of a separate dashboard, a new login, and a separate inbox is usually higher than the productivity gain. The MIT Sloan / BCG 2024 study on how people actually use generative AI found that adoption sticks where the tool sits inside existing surfaces (the email client, the document editor, the meeting platform) and falls off where it requires switching contexts.',
+      },
+      {
+        type: 'h2',
+        text: 'Category 1: Meeting capture and follow-up',
+      },
+      {
+        type: 'p',
+        text: 'This is the highest-leverage category for most knowledge workers. AI meeting assistants record, transcribe, summarise, and surface action items from your video calls. The realistic time saving is 30-60 minutes per meeting-heavy day across status meetings, customer calls, and internal planning sessions. The verifiable failure mode is that summaries occasionally hallucinate action items that nobody actually agreed to; check action lists against your own notes before sending them on.',
+      },
+      {
+        type: 'p',
+        text: 'Options worth testing (free tiers exist for each): Otter.ai, Fireflies.ai, Microsoft Teams Premium\'s built-in copilot, Zoom AI Companion, Granola. Otter and Fireflies are stand-alone and work across platforms. Microsoft and Zoom integrate natively with the meeting platform you may already use. Granola is a more recent entrant focused on letting you take live notes while the AI fills in around them. Test two against a normal meeting day and pick the one whose summary you would actually send to a colleague.',
+      },
+      {
+        type: 'p',
+        text: 'Privacy note worth taking seriously: if the meeting includes confidential or personal data, your organisation may have policies about which tools can record. Check before testing on customer calls. In some EU/UK contexts, recording requires explicit consent from all participants.',
+      },
+      {
+        type: 'h2',
+        text: 'Category 2: Drafting and editing',
+      },
+      {
+        type: 'p',
+        text: 'General-purpose chat assistants (Claude, ChatGPT, Gemini, Copilot) handle drafting tasks well across emails, documents, slide outlines, and structured plans. The realistic productivity claim is not 10x or 100x; it is closer to 30-50% on first-draft tasks where you have a clear brief and the output style is conventional. Tasks where you do not have a clear brief, or where the style is genuinely yours, see much less gain.',
+      },
+      {
+        type: 'p',
+        text: 'A practical pattern: use the assistant for the first draft only, then edit substantially. Drafts from these tools tend to be plausible but generic. The editing step is where your taste, context, and audience knowledge gets injected, and is what makes the output actually yours. Skipping the edit step is how AI-generated work develops the bland sameness that experienced readers can spot in under a paragraph.',
+      },
+      {
+        type: 'p',
+        text: 'Options: Claude (Anthropic) is widely considered strongest at long-document work, coding, and nuanced instruction-following. ChatGPT (OpenAI) has the largest plugin ecosystem and the most familiar UX. Gemini (Google) integrates natively with Google Workspace. Microsoft 365 Copilot is the obvious choice if your organisation runs Microsoft. Pick the one that integrates with your existing document workflow rather than the one with the best benchmark scores; the integration gain dominates the model gap at this point in the market.',
+      },
+      {
+        type: 'h2',
+        text: 'Category 3: Research and synthesis',
+      },
+      {
+        type: 'p',
+        text: 'This category covers asking specific questions, summarising long documents, and pulling structured information from messy sources. The category has two distinct sub-tools: answer engines (live web-grounded answers with citations) and document-synthesis tools (you supply the sources, the tool summarises them).',
+      },
+      {
+        type: 'p',
+        text: 'For answer engines, Perplexity and ChatGPT Search are the main options; both cite their sources, which is non-negotiable for any research use case. Treat citations as a starting point for verification, not as a finishing point -- AI answer engines still occasionally cite real-looking sources that turn out to be lightly wrong or out of date.',
+      },
+      {
+        type: 'p',
+        text: 'For document synthesis, NotebookLM (Google) is a strong free option that takes your uploaded sources and answers questions only from those sources, with explicit citations back to the source document. The constraint -- it will not invent material from outside your sources -- is the feature, not a limitation, and it makes the tool genuinely useful for analysing reports, policy documents, or research papers. Claude with Projects performs a similar function with broader file support.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example',
+        text: 'A pricing manager needs to understand how five competitors have moved on pricing in the last six months. Approach: gather the five public pricing pages and any press releases, upload to NotebookLM, ask structured questions ("which competitors moved on enterprise tier pricing"). The tool answers with direct citation to each pricing page. The work that used to be three hours of manual reading is now 30 minutes of structured questioning, and the citation trail makes verification fast.',
+      },
+      {
+        type: 'h2',
+        text: 'Category 4: Code and data automation',
+      },
+      {
+        type: 'p',
+        text: 'For non-developers, this category mostly means writing small scripts to automate repetitive tasks: extracting data from a spreadsheet into a different shape, scraping a known website on a schedule, reformatting a CSV. GitHub Copilot, Cursor, and Claude (via chat) all do this well and the threshold to use them is much lower than the equivalent skill of writing code from scratch. If your week has any meaningful share of "I do the same fiddly thing in Excel every Monday", this category has real value for you.',
+      },
+      {
+        type: 'p',
+        text: 'A grounded caveat: code that an AI writes works often enough to be useful and not often enough to be trusted blindly. Treat anything safety-critical, financial, or customer-facing as requiring the same review as code you wrote yourself. The tool removes the typing, not the thinking.',
+      },
+      {
+        type: 'h2',
+        text: 'Category 5: Internal knowledge and search',
+      },
+      {
+        type: 'p',
+        text: 'This is the slow-burn category that delivers value six months in rather than next week. AI tools that index your organisation\'s internal documents (Glean, Notion AI, Microsoft Copilot for SharePoint, Slack AI search) make it possible to ask "what was the decision on X" or "who worked on Y" and get a usable answer. The deployment is usually decided at organisation level rather than by individual users, so this is mostly a question of using what is offered well rather than picking a tool yourself.',
+      },
+      {
+        type: 'h2',
+        text: 'What to ignore',
+      },
+      {
+        type: 'p',
+        text: 'Three categories worth deprioritising at the working-professional level. (1) AI agents that promise full task autonomy: the failure modes are still too frequent for production work, and the time saved on the happy path is lost three times over when the agent goes wrong silently. (2) AI image and video generation, unless your role specifically needs visual output: the quality is impressive for demos and middling for actual marketing or design work. (3) AI tools that promise to "personalise outreach at scale": these mostly produce the spam that recipients can now spot, and the trust cost outweighs the time saving.',
+      },
+      {
+        type: 'h2',
+        text: 'How to test before you commit',
+      },
+      {
+        type: 'p',
+        text: 'A four-week test cycle works well. Week one: use the free tier on real work, not demos. Week two: try the alternative leading option in the same category. Week three: pick the better one and integrate it fully into your workflow. Week four: review honestly -- is the time saved real, or has the tool added new busywork? Reject any tool that fails the week-four honesty test, even if the demo was impressive.',
+      },
+      {
+        type: 'action',
+        label: 'What to do this month',
+        text: [
+          'Pick one category from this module where you have a real bottleneck. Do not start in two categories.',
+          'Test two leading options on real work for one week each. Free tiers only.',
+          'Week three, integrate the winner into your workflow. Notice where it adds friction as well as where it saves time.',
+          'Week four, do the honest review. Keep the tool only if the answer to "did this save real time" is yes without qualification.',
+        ],
+      },
+      {
+        type: 'links',
+        label: 'Next in this track',
+        items: [
+          { text: 'When to Retrain, When to Switch, When to Stay', url: '/ai-workforce/retrain-switch-stay', note: 'the final module: the bigger decision' },
+          { text: 'The Defensive Skill Stack', url: '/ai-workforce/defensive-skill-stack', note: 'why tools alone are not a strategy' },
+          { text: 'AI tools in Ireland', url: 'https://vendors.ie/ai-tools-ireland', note: 'detailed tool comparisons on Vendors.ie' },
+        ],
+      },
+      {
+        type: 'sources',
+        items: [
+          { text: 'MIT Sloan Management Review / BCG: How People Are Really Using GenAI (2024)', url: 'https://www.bcg.com/publications' },
+          { text: 'Stanford HAI AI Index Report 2024 -- adoption and enterprise use', url: 'https://aiindex.stanford.edu/report/' },
+          { text: 'Anthropic Claude product documentation', url: 'https://docs.anthropic.com/' },
+          { text: 'OpenAI ChatGPT product documentation', url: 'https://platform.openai.com/docs' },
+          { text: 'Google NotebookLM documentation', url: 'https://support.google.com/notebooklm' },
+          { text: 'European Data Protection Board: AI and GDPR guidance', url: 'https://www.edpb.europa.eu/' },
+        ],
+      },
+    ],
+    next: 'retrain-switch-stay',
+    prev: 'conversations-with-your-employer',
+  },
+
+  {
+    slug: 'retrain-switch-stay',
+    title: 'When to Retrain, When to Switch, When to Stay',
+    shortTitle: 'Retrain / Switch / Stay',
+    description: 'A decision framework for the bigger career question this track raises -- when to invest in retraining, when to switch role or employer, and when to stay and reshape what you have.',
+    lastUpdated: '2026-05-25',
+    readingTime: '14 min',
+    content: [
+      {
+        type: 'lead',
+        text: 'The previous six modules cover the diagnostic: capability boundaries, role audit, augmented versions, defensive skills, conversations with your employer, practical tools. This final module covers the synthesis: given all of that, do you stay and reshape what you have, switch role or employer, or invest seriously in retraining toward something different? The honest answer is rarely obvious in either direction. What follows is a framework -- not a formula -- for working through it without panic and without complacency, both of which are common failure modes.',
+      },
+      {
+        type: 'h2',
+        text: 'The three paths, defined sharply',
+      },
+      {
+        type: 'p',
+        text: 'Stay: remain in your current role and current employer, deliberately shifting your task mix toward the augmented version of the role and visibly building the defensive skill stack. Cost: low-moderate (time investment in skill building, some political capital in the conversations with employer module). Risk: depends entirely on whether your employer will support the shift; if not, you are accumulating skills in a role that is closing under you.',
+      },
+      {
+        type: 'p',
+        text: 'Switch: move to a different role or different employer that is structurally better positioned -- either lower AI exposure, higher skill-stack relevance, or both. Cost: moderate (job search effort, possible short-term pay cost, restart on team standing). Risk: you trade known unknowns for unknown unknowns. Switches into roles you do not understand well are how people make the AI transition worse, not better.',
+      },
+      {
+        type: 'p',
+        text: 'Retrain: invest seriously (6-24 months of part-time study, or a shorter intensive programme) to acquire a substantially different skill base, with the intention of moving into a role that requires it. Cost: high (time, often money, opportunity cost). Risk: returns to retraining are deeply uneven -- some retraining paths deliver clear new roles, others produce credentials that the market does not actually value. Pick the path by the destination role, not by the credential.',
+      },
+      {
+        type: 'h2',
+        text: 'When staying is the right call',
+      },
+      {
+        type: 'p',
+        text: 'Staying is right when three things are true. (1) Your role audit shows there is a credible augmented version of the role -- enough low-exposure work to anchor a senior identity, and a clear path to spend more time there. (2) Your employer is willing to support the shift, evidenced by their response to the conversations module (not by their public messaging on AI, which is universally optimistic). (3) The defensive skill stack you would build in this role transfers to your likely next role anyway. If all three are true, staying is the lowest-risk path and you should commit to it visibly, not as a default.',
+      },
+      {
+        type: 'p',
+        text: 'Staying becomes wrong when you are still telling yourself the same three statements but the evidence has been telling a different story for six to twelve months. The pattern: the augmented work you proposed has not materialised, the conversations with your manager have been polite-but-non-committal, your time mix is still 80% in the high-exposure tasks. At that point staying has become inertia, not strategy.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: senior finance analyst, staying is right',
+        text: 'Twelve years in the role at a mid-sized industrial. Audit shows 30% of the week is high-exposure (variance reports, monthly close formatting) and 40% is genuinely low-exposure (CFO advisory work, audit relationship, scenario modelling for the board). Manager has explicitly asked for more time on the scenario modelling and welcomes the AI-augmented variance work. Skill stack here -- finance judgement, executive communication, sector context -- transfers to any senior finance role anywhere. Stay, ship the proposal, redirect time.',
+      },
+      {
+        type: 'h2',
+        text: 'When switching is the right call',
+      },
+      {
+        type: 'p',
+        text: 'Switching is right when your current role is structurally high-exposure with no clear path to the augmented version, OR when your employer\'s response to the AI transition is misaligned with how you want to work. The two situations have different urgency. Structural high-exposure with no augmented version means you have 12-36 months in the role; the switch can be planned. Misaligned employer means you should be in active job-search mode within weeks, because their values and trajectory are not yours.',
+      },
+      {
+        type: 'p',
+        text: 'A common switching pattern that works: from a role inside an organisation that is using AI badly to a similar role inside an organisation that is using AI well. The skill stack transfers; the working environment improves; the AI exposure does not necessarily change but the organisational capacity to redeploy savings productively does. This is a much easier switch to execute than a switch across role categories.',
+      },
+      {
+        type: 'p',
+        text: 'A harder pattern: switching from a structurally high-exposure category (junior content production, basic data analysis, L1 support) to a category where your skills do not transfer cleanly. This is where many transitions go wrong -- the switch is real but the new role is harder than the demo suggested. If the new category requires capabilities you do not yet have, you are actually retraining, not switching, and the framework below applies.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: marketing coordinator, switching is right',
+        text: 'Three years in role at an SME. Audit shows 70% high-exposure (campaign asset production, email drafting, social variants) and limited low-exposure work. Manager would like more strategic input but has assigned the strategy work to an external agency, signalling that the role is seen as production. The augmented version of this role does not exist here. Switch target: marketing coordinator at a company where strategy lives in-house, with explicit interview question on how the role is evolving with AI. Same job title, structurally different position.',
+      },
+      {
+        type: 'h2',
+        text: 'When retraining is the right call',
+      },
+      {
+        type: 'p',
+        text: 'Retraining is right when you have made an honest assessment that no realistic in-place shift, and no realistic switch within adjacent roles, gets you to a position you actually want over the next five years. The honest assessment is the hard part. Retraining is expensive in time and often money; the most common failure mode is retraining into a credential rather than into a role that exists and pays.',
+      },
+      {
+        type: 'p',
+        text: 'The OECD\'s research on adult skills programmes finds that retraining returns are highest when three conditions hold: the destination role is clearly defined and in demand, the new skills are practiced on real work (not just course completion), and the transition is supported by existing professional identity (e.g. an accountant retraining into data analytics for finance teams is on stronger ground than an accountant retraining into UX design from a standing start). Pick the retraining path with the destination in view, not the course.',
+      },
+      {
+        type: 'p',
+        text: 'Two retraining paths that have produced real role transitions in the past two years: from production-heavy creative roles into product or content strategy roles; from operational roles into roles that combine domain knowledge with AI tooling competence (the so-called "AI-augmented domain expert"). Both work because they extend an existing skill stack rather than discarding it. Pure "I will become an AI engineer" pivots from non-technical backgrounds rarely land where the marketing suggests they will.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: paralegal, retraining is right',
+        text: 'Eight years in role at a mid-sized firm. Audit shows the role is becoming heavily automated at exactly the level the paralegal currently sits -- document review, citation work, basic drafting. No augmented version in this firm or visible at peers. Switch target: paralegal at a firm where the role is evolving toward client-facing case management. But the structural exposure persists across firms. Retraining target: legal operations / legal technology consultant, drawing on the eight years of legal context that any AI tool lacks. 12-18 month part-time programme, real consulting work alongside study. Destination is a role that already exists, pays well, and that the paralegal\'s domain knowledge accelerates dramatically.',
+      },
+      {
+        type: 'h2',
+        text: 'The Stoic frame -- and why it matters here',
+      },
+      {
+        type: 'p',
+        text: 'Stoic practice distinguishes carefully between what is in your control and what is not. The pace and direction of AI capability change is not in your control. Your employer\'s strategic response is not in your control. The labour market\'s adjustment is not in your control. Your task audit, your skill investment, your decision framework, your communication with your manager, and your willingness to switch when the evidence demands it -- all of those are in your control. The work of this track is concentrating attention on the controllable inputs and refusing to spend energy on the uncontrollable ones.',
+      },
+      {
+        type: 'p',
+        text: 'Apply this here: do not catastrophise about job loss in the abstract. Run the audit, do the skill work, have the conversations, decide on the path. If circumstances change, repeat the process. The first time through, the framework takes a few weeks of attention; the second time through, it takes a weekend. The defensive position is built by repetition, not by any single decision.',
+      },
+      {
+        type: 'h2',
+        text: 'A decision template you can complete this weekend',
+      },
+      {
+        type: 'p',
+        text: 'Five questions, answered honestly in writing. (1) From my audit, what percentage of my week is currently high-exposure? Is there a realistic augmented version of the role for me? (2) Has my employer demonstrated, through actions not statements, that they will support a shift in my role? (3) If I assume my current role looks structurally the same in five years, am I still in a strong professional position? (4) What is the closest viable switch -- same role at a structurally better employer, or adjacent role at the same employer? (5) Is there a retraining path with a defined destination role that builds on what I already know? Compare answers. Honest answers usually surface the right path; pretending the answer is "stay" when the evidence is screaming "switch" is the most common avoidable mistake in this transition.',
+      },
+      {
+        type: 'action',
+        label: 'What to do this weekend',
+        text: [
+          'Sit down with the audit from module 2 and the skill plan from module 4. Block 90 minutes.',
+          'Answer the five questions above in writing. Resist the temptation to skip any.',
+          'Pick one path -- stay, switch, retrain -- as your working hypothesis. Commit to revisiting in 90 days.',
+          'For each path, identify the first concrete step. Put it in the calendar this month. The first step for stay is the conversation; for switch, it is updating the CV; for retrain, it is researching three destination roles.',
+        ],
+      },
+      {
+        type: 'links',
+        label: 'Going back through the track',
+        items: [
+          { text: 'Module 1 -- What AI Can and Cannot Do', url: '/ai-workforce/ai-capability-boundaries', note: 'the capability baseline' },
+          { text: 'Module 2 -- Audit Your Role', url: '/ai-workforce/audit-your-role', note: 'the input to this decision' },
+          { text: 'Module 4 -- Defensive Skill Stack', url: '/ai-workforce/defensive-skill-stack', note: 'the skill investment plan' },
+          { text: 'AI tools in Ireland', url: 'https://vendors.ie/ai-tools-ireland', note: 'tool comparisons referenced across modules' },
+        ],
+      },
+      {
+        type: 'sources',
+        items: [
+          { text: 'OECD: Getting Skills Right -- Engaging Low-Skilled Adults in Learning (2019, updated 2023)', url: 'https://www.oecd.org/skills/' },
+          { text: 'McKinsey Global Institute: A new future of work -- the race to deploy AI and raise skills (2023)', url: 'https://www.mckinsey.com/mgi/our-research/a-new-future-of-work-the-race-to-deploy-ai-and-raise-skills-in-an-unequal-world' },
+          { text: 'World Economic Forum: Future of Jobs Report 2023 -- reskilling section', url: 'https://www.weforum.org/reports/the-future-of-jobs-report-2023/' },
+          { text: 'HBR: Career Pivots and the Cost of Retraining (2024)', url: 'https://hbr.org/' },
+          { text: 'Stanford HAI AI Index Report 2024 -- labour market and skills', url: 'https://aiindex.stanford.edu/report/' },
+          { text: 'Marcus Aurelius, Meditations -- specifically the dichotomy of control as a working tool', url: 'https://classics.mit.edu/Antoninus/meditations.html' },
+        ],
+      },
+    ],
+    next: null,
+    prev: 'tool-of-the-month',
+  },
 ]

--- a/data/ai-workforce.js
+++ b/data/ai-workforce.js
@@ -137,11 +137,19 @@ export const AI_WORKFORCE_MODULES = [
     shortTitle: 'Role Audit',
     description: 'A structured method for mapping your daily tasks against AI capability -- so you can see what is genuinely at risk and where your value compounds.',
     lastUpdated: '2026-05-25',
-    readingTime: '9 min',
+    readingTime: '13 min',
     content: [
       {
         type: 'lead',
-        text: 'Job-level automation risk figures are less useful than task-level analysis. The same job title can have very different exposure depending on which tasks dominate your week. This module walks through a method for doing that analysis on your own role.',
+        text: 'Job-level automation risk figures are less useful than task-level analysis. The same job title can have very different exposure depending on which tasks dominate your week. A senior marketer running brand strategy has a different exposure profile to a coordinator producing campaign assets, even though both sit under "marketing". This module walks through a four-step method for doing that analysis on your own role, with two long worked examples that show how to apply it.',
+      },
+      {
+        type: 'h2',
+        text: 'Why task-level matters more than job-level',
+      },
+      {
+        type: 'p',
+        text: 'The OECD Employment Outlook 2023 chapter on AI and the labour market found that aggregate occupation-level risk scores hide enormous within-occupation variation. The OECD specifically warned that pre-LLM exposure indexes underestimate the exposure of cognitive and white-collar tasks, and overestimate exposure for manual work that requires physical adaptation. The practical implication: the index that says your job is "low exposure" may be wrong about your specific week, and vice versa. The only honest answer comes from auditing your own tasks.',
       },
       {
         type: 'h2',
@@ -149,7 +157,11 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Most job descriptions describe outcomes, not tasks. Start with a log of what you actually do in a typical week. Aim for 15-25 discrete task types. "Prepare monthly report" is too coarse -- break it into "pull data from system", "format into tables", "write narrative commentary", "present to stakeholders". Each of those has different AI exposure.',
+        text: 'Most job descriptions describe outcomes, not tasks. Start with a log of what you actually do in a typical week. Aim for 15-25 discrete task types. "Prepare monthly report" is too coarse -- break it into "pull data from system", "format into tables", "write narrative commentary", "answer follow-up questions from the FD", "present to stakeholders". Each of those has a different AI exposure score. If you started the task log in module 1, you already have most of this.',
+      },
+      {
+        type: 'p',
+        text: 'A good test: if a colleague could read your task list and predict roughly how you spend a week, the granularity is right. If it reads like a CV bullet list ("manage team", "deliver projects"), it is too coarse to audit.',
       },
       {
         type: 'h2',
@@ -157,24 +169,19 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'For each task, answer four questions: (1) Is there a large body of similar prior examples that an AI could have learned from? (2) Can the output be checked for correctness quickly by a non-expert? (3) Does the task require current information not available before mid-2024? (4) Does performance depend on real-time interpersonal context -- a specific person, their mood, the history of your relationship?',
+        text: 'For each task, answer four questions. (1) Pattern: is there a large body of similar prior examples that an AI could have learned from? (2) Verification: can the output be checked for correctness quickly by a non-expert, or by you in less time than producing it? (3) Currency: does the task require information that did not exist before the model\'s training cutoff -- this week\'s prices, today\'s call notes, last hour\'s ticket queue? (4) Interpersonal: does performance depend on the specific person you are working with -- their mood, history with you, internal politics, trust?',
       },
       {
         type: 'p',
-        text: 'Tasks that score yes on (1) and (2), and no on (3) and (4), are highest exposure. Tasks with yes on (3) or (4) are substantially protected, at current AI capability levels.',
-      },
-      {
-        type: 'example',
-        label: 'Worked example: Marketing Manager',
-        text: 'Task list excerpt: writing campaign briefs (high exposure -- pattern completion), reviewing agency creative (medium -- requires taste + brand knowledge), presenting results to board (low -- interpersonal, high-stakes, context-dependent), managing agency relationships (low -- relationship history, trust, negotiation).',
+        text: 'Tasks that score yes on pattern and verification, and no on currency and interpersonal, are highest exposure. Tasks with yes on currency or interpersonal are substantially protected at current capability levels. The diagonal cases -- yes on pattern but no on verification -- are the dangerous middle: AI can produce something plausible-looking that nobody can quickly check, which is where the most expensive errors live.',
       },
       {
         type: 'h2',
-        text: 'Step 3: Estimate time share',
+        text: 'Step 3: Estimate time share and value share',
       },
       {
         type: 'p',
-        text: 'Note what percentage of your working week each task type takes. High-exposure tasks that are also high time-share warrant the most attention -- they are both automatable and currently consuming significant effort. Low-exposure tasks that take most of your time are your current structural advantage.',
+        text: 'Two columns matter. Time share: what percentage of your working week each task type takes. Value share: how much of your perceived contribution each task represents in the eyes of your manager and skip-level. These are often misaligned, and the audit forces you to see it. High-exposure tasks that are also high time-share warrant the most attention -- they are both automatable and currently consuming significant effort. High-value tasks that are low exposure are your current structural advantage and deserve more time, not less.',
       },
       {
         type: 'h2',
@@ -182,12 +189,22 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'High exposure does not automatically mean job risk. It may mean the task will be augmented (you do it faster with AI help), delegated to a junior role, or genuinely automated away. The difference depends on whether your employer can redeploy the time savings productively and whether your role shifts toward higher-judgment work. The module on augmented roles covers this in more detail.',
+        text: 'High exposure does not automatically mean job risk. It may mean the task will be augmented (you do it faster with AI help), delegated to a junior role, batched and pushed off-shore, or genuinely automated away. The path depends on whether your employer can redeploy the time savings productively, whether your role can shift toward higher-judgment work, and whether the savings are big enough to justify reorganising. The module on augmented roles covers this in more detail; the module on conversations with your employer covers how to influence which path your role takes.',
       },
       {
         type: 'example',
-        label: 'Worked example: Customer Support',
-        text: 'A support specialist finds that 60% of tickets are L1 issues with well-known resolutions. That 60% is high AI exposure. But the remaining 40% involves escalations, unhappy customers, product edge cases, and internal coordination -- all low exposure. If the employer deploys AI on L1 tickets, the specialist role may shift almost entirely to the 40%. That is a different job, not necessarily a lost job.',
+        label: 'Worked example: Marketing Manager',
+        text: 'Task list excerpt with verdicts: writing campaign briefs (high exposure -- pattern + verifiable), drafting email subject lines (very high exposure), reviewing agency creative (medium -- needs brand judgement, but AI can suggest), presenting results to the board (low -- interpersonal, high-stakes, context-dependent), managing the agency relationship (low -- relationship history, trust, negotiation), competitive intelligence on new entrants (high exposure with currency caveat -- only useful if AI has access to current data via search), final sign-off on campaign launch (low -- you are accountable, the AI is not). Time share: 35% in the high-exposure tasks, 20% in low-exposure, the rest mixed. Verdict: the role is augmentable rather than replaceable, but the manager needs to redirect the freed time visibly toward the strategic and relationship layer.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: Customer Support Specialist',
+        text: 'A support specialist finds that 60% of tickets are L1 issues with well-known resolutions (password resets, billing queries, known product behaviours). That 60% is high AI exposure -- pattern and verifiable. The remaining 40% involves escalations, unhappy customers, product edge cases, and internal coordination with engineering -- all low exposure (interpersonal, novel, requires current context). If the employer deploys AI on L1 tickets, the specialist role may shift to almost entirely the 40%. That is a different job, not necessarily a lost job. But it does mean the specialist needs to be visibly competent at the harder 40% before the 60% goes away. Practical move: start working a small share of escalations now, before that becomes the only work.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: Project Coordinator in a consultancy',
+        text: 'Task audit: updating project plans (medium -- AI drafts, you adjust), formatting client status decks (high), drafting meeting minutes from transcripts (very high), chasing teams for status updates (low -- interpersonal, specific people), running weekly stand-ups (low -- live conversation), managing the change-request log (medium -- structured but currency-sensitive), preparing handover docs at project end (medium -- pattern-heavy). The role is heavily exposed at the document and formatting layer and lightly exposed at the coordination layer. The augmented version of this role spends much less time formatting and much more time spotting risks across projects, coaching less experienced PMs, and managing client relationships. Without that shift, the role is at structural risk; with it, the role becomes more senior.',
       },
       {
         type: 'h2',
@@ -195,14 +212,39 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Your audit gives you three outputs: a list of tasks to start automating yourself (capture the productivity gain before someone else does); a list of high-exposure tasks to actively skill away from as a primary value driver; and a clear picture of where your irreplaceable value currently sits, which informs how you position yourself in the module on conversations with your employer.',
+        text: 'Your audit gives you three outputs. First, a list of tasks to start automating yourself -- capture the productivity gain before someone else does, and use the freed time visibly. Second, a list of high-exposure tasks to actively skill away from as a primary value driver -- not by refusing to do them but by ensuring they are not the only thing you are known for. Third, a clear picture of where your irreplaceable value currently sits, which is the input to the module on conversations with your employer.',
+      },
+      {
+        type: 'p',
+        text: 'A common mistake at this point is to read the audit and panic. The audit is not a verdict; it is a map. The same map that shows where the risk is also shows where to invest your next twelve months of skill development. Use it that way.',
+      },
+      {
+        type: 'action',
+        label: 'What to do this week',
+        text: [
+          'Open a single document with two columns: Task | Verdict. Aim for 15-25 rows from your week.',
+          'For each row, apply the four filters (pattern / verification / currency / interpersonal) and assign a verdict: high / medium / low exposure.',
+          'Add two more columns: time share (rough percentage) and value share (perceived).',
+          'Mark three tasks you will automate yourself this month. Mark one task category you will move time toward.',
+          'Do not share this with your manager yet -- the conversations module covers framing. Sit with the audit for at least a week first.',
+        ],
+      },
+      {
+        type: 'links',
+        label: 'Next in this track',
+        items: [
+          { text: 'AI-Augmented Versions of Common Roles', url: '/ai-workforce/augmented-roles', note: 'see your role after the augmentation' },
+          { text: 'The Defensive Skill Stack', url: '/ai-workforce/defensive-skill-stack', note: 'the skills that compound when audit shows what to protect' },
+          { text: 'AI tools in Ireland', url: 'https://vendors.ie/ai-tools-ireland', note: 'tools mentioned in the worked examples, compared honestly' },
+        ],
       },
       {
         type: 'sources',
         items: [
-          'OECD: "OECD Employment Outlook 2023: Artificial Intelligence and the Labour Market"',
-          'Accenture: "A New Era of Generative AI for Everyone" (2023) -- task-level decomposition methodology',
-          'Harvard Business Review: "How to Protect Your Job in the Age of AI" (2023)',
+          { text: 'OECD Employment Outlook 2023: Artificial Intelligence and the Labour Market', url: 'https://www.oecd.org/employment-outlook/' },
+          { text: 'World Economic Forum: Future of Jobs Report 2023 -- task-level skill mix data', url: 'https://www.weforum.org/reports/the-future-of-jobs-report-2023/' },
+          { text: 'Harvard Business Review: How to Protect Your Job in the Age of AI (2023)', url: 'https://hbr.org/' },
+          { text: 'Accenture: A New Era of Generative AI for Everyone (2023) -- task decomposition methodology', url: 'https://www.accenture.com/us-en/insights/technology' },
         ],
       },
     ],

--- a/data/ai-workforce.js
+++ b/data/ai-workforce.js
@@ -1,0 +1,434 @@
+export const AI_WORKFORCE_META = {
+  lastUpdated: '2026-05-25',
+  sourceNote: 'Impact estimates drawn from published ranges: McKinsey Global Institute (2023-2025), OECD Employment Outlook (2023), Goldman Sachs Global Economics (2023). Ranges cited, not point estimates.',
+}
+
+export const AI_WORKFORCE_MODULES = [
+  {
+    slug: 'ai-capability-boundaries',
+    title: 'What AI Can and Cannot Do',
+    shortTitle: 'Capability Boundaries',
+    description: 'A plain-language map of where current AI systems perform reliably, where they struggle, and why those lines move over time.',
+    lastUpdated: '2026-05-25',
+    readingTime: '8 min',
+    content: [
+      {
+        type: 'lead',
+        text: 'Published ranges suggest that between 25% and 40% of current work tasks could be automated using AI at current capability levels (McKinsey, 2023; Goldman Sachs, 2023). That range matters: the difference between 25% and 40% is a different plan of action. This module explains what is driving that uncertainty and how to read it usefully.',
+      },
+      {
+        type: 'h2',
+        text: 'Where AI performs reliably today',
+      },
+      {
+        type: 'p',
+        text: 'Current AI systems (large language models, vision models, speech-to-text) are reliable for a specific class of task: pattern completion across language, image, and structured data. In practice this covers: summarising documents, drafting structured text from a brief, classifying inputs into predefined categories, extracting structured data from unstructured text, translating between languages, and generating code from a specification.',
+      },
+      {
+        type: 'p',
+        text: 'The common thread is that these tasks have a large amount of prior examples to learn from and the output can be checked by a human quickly. When both conditions hold, AI performance is high and error cost is manageable.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example',
+        text: 'A financial analyst receives 80 earnings call transcripts per quarter and needs key metrics from each. Extracting numbers and categorising management commentary is a pattern-completion task. An AI tool cuts that from 3 hours to 20 minutes. The analyst spends the freed time on the judgment layer: what do those numbers mean for the portfolio?',
+      },
+      {
+        type: 'h2',
+        text: 'Where AI struggles',
+      },
+      {
+        type: 'p',
+        text: 'AI systems fail in predictable ways. They struggle with tasks that require: maintaining a coherent plan over many steps without explicit tracking; genuine novelty (problems outside their training distribution); sensorimotor work that requires physical feedback; ethical judgment in novel situations; real-time information not present in training data; and interpersonal dynamics -- reading a room, negotiating under pressure, building long-term trust.',
+      },
+      {
+        type: 'p',
+        text: 'These are not temporary gaps that will close next quarter. Some reflect hard constraints in current architectures. Others may close, but on a multi-year timeline. Plan around the capabilities that exist now, not forecasts.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example',
+        text: 'A sales manager asks an AI tool to generate a strategy for recovering a key account after a service failure. The tool produces a plausible-looking plan. But it does not know the client contact\'s personality, the political dynamics inside the client organisation, the informal history of the relationship, or what the client actually said in the last call. The plan sounds reasonable and is missing the most important context. The manager needs to supply all of that and substantially rewrite the output.',
+      },
+      {
+        type: 'h2',
+        text: 'Why capability boundaries move -- and what to watch',
+      },
+      {
+        type: 'p',
+        text: 'AI capability is not static. Model releases in 2023-2025 expanded reliable performance on coding, multimodal tasks, and long-document reasoning. But progress is uneven. Some tasks that seemed close to automation (complex legal analysis, medical diagnosis) remain heavily human-dependent because error cost is high and edge cases are structurally important.',
+      },
+      {
+        type: 'p',
+        text: 'The most useful signal to watch is not "AI is getting smarter" in general but specific task-level claims from published evaluations: model cards from Anthropic, OpenAI, and Google; the Stanford HAI AI Index Report (annual); and OECD occupation-level analysis. These cite what changed, with evidence. Industry forecasts without specific task grounding are less useful for planning.',
+      },
+      {
+        type: 'h2',
+        text: 'How to use this',
+      },
+      {
+        type: 'p',
+        text: 'The practical question is not "will AI replace my job" but "which of my tasks fit the pattern-completion profile, and which require judgment, novelty, or interpersonal skill?" The next module walks through a structured way to answer that for your specific role.',
+      },
+      {
+        type: 'sources',
+        items: [
+          'McKinsey Global Institute: "The economic potential of generative AI" (2023)',
+          'Goldman Sachs Global Economics: "The Potentially Large Effects of Artificial Intelligence on Economic Growth" (2023)',
+          'Stanford HAI: AI Index Report 2024',
+          'Anthropic model cards: claude.ai/model-card',
+          'OECD Employment Outlook 2023: Chapter on AI and the labour market',
+        ],
+      },
+    ],
+    next: 'audit-your-role',
+    prev: null,
+  },
+
+  {
+    slug: 'audit-your-role',
+    title: 'Audit Your Role: Task-Level AI Exposure',
+    shortTitle: 'Role Audit',
+    description: 'A structured method for mapping your daily tasks against AI capability -- so you can see what is genuinely at risk and where your value compounds.',
+    lastUpdated: '2026-05-25',
+    readingTime: '9 min',
+    content: [
+      {
+        type: 'lead',
+        text: 'Job-level automation risk figures are less useful than task-level analysis. The same job title can have very different exposure depending on which tasks dominate your week. This module walks through a method for doing that analysis on your own role.',
+      },
+      {
+        type: 'h2',
+        text: 'Step 1: List your actual tasks (not your job description)',
+      },
+      {
+        type: 'p',
+        text: 'Most job descriptions describe outcomes, not tasks. Start with a log of what you actually do in a typical week. Aim for 15-25 discrete task types. "Prepare monthly report" is too coarse -- break it into "pull data from system", "format into tables", "write narrative commentary", "present to stakeholders". Each of those has different AI exposure.',
+      },
+      {
+        type: 'h2',
+        text: 'Step 2: Apply four filters to each task',
+      },
+      {
+        type: 'p',
+        text: 'For each task, answer four questions: (1) Is there a large body of similar prior examples that an AI could have learned from? (2) Can the output be checked for correctness quickly by a non-expert? (3) Does the task require current information not available before mid-2024? (4) Does performance depend on real-time interpersonal context -- a specific person, their mood, the history of your relationship?',
+      },
+      {
+        type: 'p',
+        text: 'Tasks that score yes on (1) and (2), and no on (3) and (4), are highest exposure. Tasks with yes on (3) or (4) are substantially protected, at current AI capability levels.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: Marketing Manager',
+        text: 'Task list excerpt: writing campaign briefs (high exposure -- pattern completion), reviewing agency creative (medium -- requires taste + brand knowledge), presenting results to board (low -- interpersonal, high-stakes, context-dependent), managing agency relationships (low -- relationship history, trust, negotiation).',
+      },
+      {
+        type: 'h2',
+        text: 'Step 3: Estimate time share',
+      },
+      {
+        type: 'p',
+        text: 'Note what percentage of your working week each task type takes. High-exposure tasks that are also high time-share warrant the most attention -- they are both automatable and currently consuming significant effort. Low-exposure tasks that take most of your time are your current structural advantage.',
+      },
+      {
+        type: 'h2',
+        text: 'Step 4: Separate exposure from risk',
+      },
+      {
+        type: 'p',
+        text: 'High exposure does not automatically mean job risk. It may mean the task will be augmented (you do it faster with AI help), delegated to a junior role, or genuinely automated away. The difference depends on whether your employer can redeploy the time savings productively and whether your role shifts toward higher-judgment work. The module on augmented roles covers this in more detail.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: Customer Support',
+        text: 'A support specialist finds that 60% of tickets are L1 issues with well-known resolutions. That 60% is high AI exposure. But the remaining 40% involves escalations, unhappy customers, product edge cases, and internal coordination -- all low exposure. If the employer deploys AI on L1 tickets, the specialist role may shift almost entirely to the 40%. That is a different job, not necessarily a lost job.',
+      },
+      {
+        type: 'h2',
+        text: 'What to do with your results',
+      },
+      {
+        type: 'p',
+        text: 'Your audit gives you three outputs: a list of tasks to start automating yourself (capture the productivity gain before someone else does); a list of high-exposure tasks to actively skill away from as a primary value driver; and a clear picture of where your irreplaceable value currently sits, which informs how you position yourself in the module on conversations with your employer.',
+      },
+      {
+        type: 'sources',
+        items: [
+          'OECD: "OECD Employment Outlook 2023: Artificial Intelligence and the Labour Market"',
+          'Accenture: "A New Era of Generative AI for Everyone" (2023) -- task-level decomposition methodology',
+          'Harvard Business Review: "How to Protect Your Job in the Age of AI" (2023)',
+        ],
+      },
+    ],
+    next: 'augmented-roles',
+    prev: 'ai-capability-boundaries',
+  },
+
+  {
+    slug: 'augmented-roles',
+    title: 'AI-Augmented Versions of Common Roles',
+    shortTitle: 'Augmented Roles',
+    description: 'What the accountant, marketer, writer, customer support specialist, and designer role looks like when AI handles the pattern work -- and where human judgment becomes the bottleneck.',
+    lastUpdated: '2026-05-25',
+    readingTime: '10 min',
+    content: [
+      {
+        type: 'lead',
+        text: 'The augmented version of a role is not a reduced version. It typically involves less volume work and more judgment, communication, and taste -- the things AI cannot reliably do. This module maps five common roles through that transition.',
+      },
+      {
+        type: 'h2',
+        text: 'Accountant / Finance Analyst',
+      },
+      {
+        type: 'p',
+        text: 'Routine data extraction, reconciliation, and standard report formatting are high AI-exposure tasks. The augmented version shifts time toward: interpreting anomalies, advising on tax strategy for novel situations, communicating financial risk to non-finance stakeholders, and managing relationships with auditors and regulators. Technical accounting knowledge stays essential -- the AI produces outputs that still need a qualified professional to validate.',
+      },
+      {
+        type: 'example',
+        label: 'What changes',
+        text: 'Pulling quarterly numbers from the ERP and formatting them into board templates: mostly automated. Explaining why margin compressed despite revenue growth, and recommending a specific response: still human. The ratio of "format and assemble" to "interpret and advise" shifts dramatically.',
+      },
+      {
+        type: 'h2',
+        text: 'Marketing Manager',
+      },
+      {
+        type: 'p',
+        text: 'First-draft copy, A/B test variants, audience segmentation from structured data, and campaign performance summaries are high exposure. The augmented role concentrates on: brand judgment (what is on-brand when an AI can only produce plausible-sounding copy), strategy (which channels and messages for which audience at which stage), and relationships with agencies, media partners, and sales teams.',
+      },
+      {
+        type: 'example',
+        label: 'What changes',
+        text: 'Writing ten variations of an email subject line: AI does this in seconds. Deciding which one reflects the brand accurately and will land with the specific audience segment at this moment in the campaign: human judgment. The marketer role moves toward creative direction and strategic orchestration.',
+      },
+      {
+        type: 'h2',
+        text: 'Writer / Content Strategist',
+      },
+      {
+        type: 'p',
+        text: 'Formulaic content (product descriptions, FAQs, templated articles on known topics) has high AI exposure. The augmented writer concentrates on: original research and reporting, distinctive voice and point of view, editorial judgment about what to cover and how, and structured persuasion that requires understanding a specific reader\'s situation.',
+      },
+      {
+        type: 'example',
+        label: 'What changes',
+        text: 'A first draft of a blog post from a detailed brief: AI can produce this faster than any human. Whether the post says something true and interesting that the reader will act on: that depends on research, editorial judgment, and voice that the AI cannot supply from a brief alone. The writer role shifts toward the judgment and editorial layer.',
+      },
+      {
+        type: 'h2',
+        text: 'Customer Support Specialist',
+      },
+      {
+        type: 'p',
+        text: 'L1 ticket resolution, FAQ responses, and status updates on known issues are high exposure. The augmented support specialist handles: escalations that require empathy and de-escalation, complex product issues with no prior resolution path, internal escalation and coordination, and identifying systemic issues from patterns in customer feedback.',
+      },
+      {
+        type: 'example',
+        label: 'What changes',
+        text: 'A customer whose subscription renewal failed due to a payment processor error: AI can identify the issue and trigger the fix. A customer who has been having problems for three months, is angry, and is about to cancel: AI can draft a response, but the specialist\'s judgment about what to say and offer is what saves the account.',
+      },
+      {
+        type: 'h2',
+        text: 'Designer',
+      },
+      {
+        type: 'p',
+        text: 'Generating visual variations, resizing assets for multiple formats, and producing stock-style imagery are high exposure. The augmented designer focuses on: concept development and creative direction, understanding a brief well enough to evaluate AI output against it, brand consistency judgment, and communication with stakeholders who cannot evaluate AI output themselves.',
+      },
+      {
+        type: 'example',
+        label: 'What changes',
+        text: 'Producing 20 logo variations from a brief: AI tools can do this. Deciding which one captures what the client actually meant -- and presenting that choice with a clear rationale -- is design judgment. The designer becomes more of a director of AI-generated options and less a producer of individual assets.',
+      },
+      {
+        type: 'h2',
+        text: 'The common pattern',
+      },
+      {
+        type: 'p',
+        text: 'Across all five roles, the shift is similar: volume work and pattern work moves toward AI; judgment, communication, and taste become the primary value. That does not make roles easier -- those skills are harder to develop and less commoditised. It does mean the skills worth investing in are different from the ones that got most of the professional development attention in the pre-AI era.',
+      },
+      {
+        type: 'sources',
+        items: [
+          'McKinsey Global Institute: "A new future of work: The race to deploy AI and raise skills" (2023)',
+          'World Economic Forum: "Future of Jobs Report 2023"',
+          'HBR: "In the Age of AI, You Need Both Artificial Intelligence and Human Intelligence" (2023)',
+        ],
+      },
+    ],
+    next: 'defensive-skill-stack',
+    prev: 'audit-your-role',
+  },
+
+  {
+    slug: 'defensive-skill-stack',
+    title: 'The Defensive Skill Stack',
+    shortTitle: 'Defensive Skills',
+    description: 'The skills that compound in an AI-augmented workplace -- judgment, communication, taste, and context -- and why they are durable compared to technical skills.',
+    lastUpdated: '2026-05-25',
+    readingTime: '8 min',
+    content: [
+      {
+        type: 'lead',
+        text: 'If you have read the previous modules, a pattern is visible: the skills most protected from AI substitution are judgment, communication, taste, and real-world context. This module explains what those mean in practice and how to develop them deliberately.',
+      },
+      {
+        type: 'h2',
+        text: 'Why these skills compound',
+      },
+      {
+        type: 'p',
+        text: 'Technical skills have a predictable decay curve: a skill tied to a specific tool or format loses value when the tool is superseded. Judgment, communication, and taste compound differently. They improve with experience, transfer across contexts, and become more valuable as the volume and quality of AI output rises -- because someone has to evaluate and direct that output.',
+      },
+      {
+        type: 'p',
+        text: 'As AI produces more first drafts, more summaries, more options, the bottleneck shifts from production to evaluation. The person who can reliably tell a good output from a plausible-but-wrong one becomes more valuable, not less.',
+      },
+      {
+        type: 'h2',
+        text: 'Judgment: making decisions with incomplete information',
+      },
+      {
+        type: 'p',
+        text: 'Judgment is the ability to reach a good decision when the information is ambiguous, incomplete, or contested. AI systems optimise for plausibility; they do not have a stake in the outcome and cannot hold the full context of a specific situation. Developing judgment means deliberately taking on decisions, tracking what happened, and updating your model of how similar situations play out.',
+      },
+      {
+        type: 'example',
+        label: 'How to develop it',
+        text: 'Ask to own decisions rather than execute on them. After each significant decision, note what you expected and what happened. Over time this builds a calibrated sense of where your intuitions are reliable and where they need more information. That is a skill an AI cannot acquire for you.',
+      },
+      {
+        type: 'h2',
+        text: 'Communication: being understood by specific people',
+      },
+      {
+        type: 'p',
+        text: 'AI can produce grammatically correct, reasonably well-structured text. It cannot know your audience -- their priorities, their blind spots, what they said in last week\'s meeting, what framing will land and what will trigger defensiveness. Communication as a skill is not about grammar; it is about understanding a specific person or group and choosing the words, sequence, and emphasis that work for them.',
+      },
+      {
+        type: 'example',
+        label: 'How to develop it',
+        text: 'After each important communication (presentation, negotiation, difficult conversation), assess what landed and what did not. Explicitly build a mental model of the people you communicate with regularly: what they care about, what they react poorly to, how they process information. AI can help you draft; it cannot build that model.',
+      },
+      {
+        type: 'h2',
+        text: 'Taste: knowing good from plausible',
+      },
+      {
+        type: 'p',
+        text: 'Taste is the ability to distinguish between an output that is technically adequate and one that is genuinely good. As AI makes technically adequate output cheap, taste becomes the scarce resource. It applies to writing, design, product decisions, customer interactions, and strategy.',
+      },
+      {
+        type: 'p',
+        text: 'Taste is developed by exposure to high-quality examples across a domain and by the discipline of asking "why is this better than that" rather than just noting a preference. It is slow to develop and difficult to transfer -- which is exactly what makes it durable.',
+      },
+      {
+        type: 'h2',
+        text: 'Context: knowing what the numbers mean in this specific situation',
+      },
+      {
+        type: 'p',
+        text: 'AI systems can process data but they do not have the lived context of a specific organisation, client, or market. Context means knowing that the margin drop in Q3 is because of a contract renegotiation you were in the room for; that the client\'s apparent resistance is because of a failed implementation three years ago; that this market reacts differently to price changes than the category average suggests.',
+      },
+      {
+        type: 'p',
+        text: 'Context is accumulated through sustained attention to one domain or relationship over time. It cannot be transferred to an AI in a prompt.',
+      },
+      {
+        type: 'h2',
+        text: 'How to invest in this stack',
+      },
+      {
+        type: 'p',
+        text: 'Deliberate practice looks different for each skill. For judgment: own more decisions and track outcomes. For communication: study the specific people you need to influence, not communication in general. For taste: read and study excellent examples in your domain, not just your own outputs. For context: stay in one domain long enough to accumulate the situational knowledge that is invisible to outsiders.',
+      },
+      {
+        type: 'sources',
+        items: [
+          'HBR: "The Skills That Will Help You Thrive in the Age of AI" (2023)',
+          'MIT Sloan Management Review: "Rethinking the Human-Machine Collaboration" (2024)',
+          'OECD: "AI and the Future of Skills" (2023)',
+        ],
+      },
+    ],
+    next: 'conversations-with-your-employer',
+    prev: 'augmented-roles',
+  },
+
+  {
+    slug: 'conversations-with-your-employer',
+    title: 'Conversations With Your Employer',
+    shortTitle: 'Positioning at Work',
+    description: 'How to position your AI skills usefully without inadvertently making yourself redundant -- what to say, what to avoid, and how to frame AI use as organisational value.',
+    lastUpdated: '2026-05-25',
+    readingTime: '7 min',
+    content: [
+      {
+        type: 'lead',
+        text: 'Demonstrating AI competence at work has a trap: if you show that AI can handle your tasks without making clear what you do with the freed time, you may accelerate the conversation about whether your role is still needed. This module covers how to frame AI use productively.',
+      },
+      {
+        type: 'h2',
+        text: 'The framing that works',
+      },
+      {
+        type: 'p',
+        text: 'The useful frame is not "I used AI to do X faster" but "I used AI to handle X, which freed me to do Y -- and here is the business result of Y." Y should be a higher-judgment activity: a decision you made, a relationship you developed, a problem you identified, an insight you surfaced. The argument is not speed, it is reallocation toward value.',
+      },
+      {
+        type: 'example',
+        label: 'Example conversation',
+        text: 'Weak: "I can produce the weekly report in half the time now that I\'m using AI." Stronger: "I have automated the data assembly on the weekly report, which means I have had time to build a more detailed model of our churn drivers. I found a segment pattern that the standard report was masking. Here is what it means and what I recommend."',
+      },
+      {
+        type: 'h2',
+        text: 'What to avoid',
+      },
+      {
+        type: 'p',
+        text: 'Avoid making productivity claims that invite the question "so we could have one person doing two jobs now?" Do not show that AI can replicate your entire role without describing what you contribute on top. Do not use AI output in client or stakeholder communications without reviewing it carefully -- if an error reaches a client, it came from you, not the tool.',
+      },
+      {
+        type: 'h2',
+        text: 'Proposing the augmented version of your role',
+      },
+      {
+        type: 'p',
+        text: 'The most direct approach is to use your role audit (module 2) to propose a revised role definition to your manager. Identify the tasks you can automate, describe what you will redirect that time toward, and show the business logic. This is more compelling than waiting for your employer to redesign roles and hoping the result works in your favour.',
+      },
+      {
+        type: 'example',
+        label: 'How to structure the proposal',
+        text: 'Three parts: (1) Here are the tasks I have identified where AI tools materially reduce time required. (2) Here is what I propose to do with that time -- specific higher-value activities tied to business outcomes. (3) Here is what I need to make this work -- tool access, a short upskilling period, a revised set of priorities.',
+      },
+      {
+        type: 'h2',
+        text: 'If your employer is moving faster than you',
+      },
+      {
+        type: 'p',
+        text: 'If your organisation is already deploying AI on your tasks without a clear conversation about what your role becomes, that is a signal. Ask directly: "As we deploy AI on [task category], what does this role look like in 12 months?" Getting a concrete answer -- even an uncertain one -- is more useful than avoiding the question.',
+      },
+      {
+        type: 'h2',
+        text: 'When to retrain, when to switch, when to stay',
+      },
+      {
+        type: 'p',
+        text: 'That question is covered in the next and final module. The short version: staying is viable when your role can credibly shift toward the defensive skill stack and your employer is aligned with that shift. Switching is worth considering when your current role is structurally high-exposure with no clear path to the augmented version. Retraining is worth the cost when it moves you to a role with lower structural exposure or higher skill-stack relevance.',
+      },
+      {
+        type: 'sources',
+        items: [
+          'HBR: "How to Have an Honest Conversation About AI With Your Boss" (2024)',
+          'MIT Sloan Management Review: "Navigating the AI Transition in Your Career" (2023)',
+          'World Economic Forum: "Human-Centred AI: A Framework for Action" (2023)',
+        ],
+      },
+    ],
+    next: null,
+    prev: 'defensive-skill-stack',
+  },
+]

--- a/data/ai-workforce.js
+++ b/data/ai-workforce.js
@@ -10,11 +10,23 @@ export const AI_WORKFORCE_MODULES = [
     shortTitle: 'Capability Boundaries',
     description: 'A plain-language map of where current AI systems perform reliably, where they struggle, and why those lines move over time.',
     lastUpdated: '2026-05-25',
-    readingTime: '8 min',
+    readingTime: '12 min',
     content: [
       {
         type: 'lead',
-        text: 'Published ranges suggest that between 25% and 40% of current work tasks could be automated using AI at current capability levels (McKinsey, 2023; Goldman Sachs, 2023). That range matters: the difference between 25% and 40% is a different plan of action. This module explains what is driving that uncertainty and how to read it usefully.',
+        text: 'Published ranges from major labour research suggest that between 25% and 40% of current work tasks could be automated using AI at present capability levels (McKinsey, 2023; Goldman Sachs, 2023). That range matters more than the headline: the difference between the low and high end is a different plan of action for your career. This module explains what drives the uncertainty, where the lines actually sit today, and how to read capability claims usefully without panic or hype.',
+      },
+      {
+        type: 'h2',
+        text: 'Reading the headline numbers honestly',
+      },
+      {
+        type: 'p',
+        text: 'When you see "40% of jobs will be impacted by AI" in a headline, it is almost certainly a translation of a more careful underlying claim. McKinsey Global Institute estimated in 2023 that generative AI could automate work activities that absorb 60-70% of employee time -- but the same report distinguished between automating tasks and replacing jobs. Goldman Sachs separately estimated that 18% of global work could be automated by AI, with major variation by occupation and country. Stanford HAI tracks year-on-year shifts in what AI systems can actually do on benchmarks; the 2024 AI Index Report noted that AI surpassed humans on several reading and image classification benchmarks while still trailing badly on planning and multi-step reasoning.',
+      },
+      {
+        type: 'p',
+        text: 'None of these is a prediction that a specific role disappears. They are estimates of task-level exposure aggregated upward. Your job is a bundle of tasks, and the exposure of each task is what matters for your planning.',
       },
       {
         type: 'h2',
@@ -22,16 +34,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Current AI systems (large language models, vision models, speech-to-text) are reliable for a specific class of task: pattern completion across language, image, and structured data. In practice this covers: summarising documents, drafting structured text from a brief, classifying inputs into predefined categories, extracting structured data from unstructured text, translating between languages, and generating code from a specification.',
+        text: 'Current AI systems -- large language models, vision models, speech-to-text -- are reliable for a specific class of task: pattern completion across language, image, and structured data. In practice this covers summarising documents, drafting structured text from a brief, classifying inputs into predefined categories, extracting structured data from unstructured text, translating between languages, transcribing audio, and generating code from a specification.',
       },
       {
         type: 'p',
-        text: 'The common thread is that these tasks have a large amount of prior examples to learn from and the output can be checked by a human quickly. When both conditions hold, AI performance is high and error cost is manageable.',
+        text: 'The common thread across reliable tasks is two-fold: there is a large body of prior examples the model can learn from, and the output can be verified by a human quickly. When both conditions hold, AI performance is high and the cost of any individual error is small because the human catches it in the verification step.',
       },
       {
         type: 'example',
-        label: 'Worked example',
-        text: 'A financial analyst receives 80 earnings call transcripts per quarter and needs key metrics from each. Extracting numbers and categorising management commentary is a pattern-completion task. An AI tool cuts that from 3 hours to 20 minutes. The analyst spends the freed time on the judgment layer: what do those numbers mean for the portfolio?',
+        label: 'Worked example: financial analyst',
+        text: 'A financial analyst receives 80 earnings call transcripts per quarter and needs key metrics from each. Extracting numbers and categorising management commentary into bullish/bearish/neutral signals is pattern completion. An AI tool cuts that from 3 hours to 20 minutes, and the analyst spot-checks 8 outputs against the source transcript. The freed time goes to the judgment layer: what do these metrics mean for the portfolio, what to flag to the PM, which calls deserve a deeper second read.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: HR coordinator',
+        text: 'An HR coordinator screens 200 applications per role. Extracting structured fields (years of experience, named tools, location, education) into a comparable table is pattern completion. Whether a candidate would be a good cultural fit, whether the cover letter shows real interest, whether the gap year explanation is credible -- those are judgment calls. The augmented coordinator uses AI for the table and keeps every judgment call human, both for accuracy and because using AI for hiring decisions in the EU now sits under the EU AI Act as high-risk and demands a human-in-the-loop.',
       },
       {
         type: 'h2',
@@ -39,16 +56,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'AI systems fail in predictable ways. They struggle with tasks that require: maintaining a coherent plan over many steps without explicit tracking; genuine novelty (problems outside their training distribution); sensorimotor work that requires physical feedback; ethical judgment in novel situations; real-time information not present in training data; and interpersonal dynamics -- reading a room, negotiating under pressure, building long-term trust.',
+        text: 'AI systems fail in predictable ways. They struggle with tasks that require maintaining a coherent plan over many steps without explicit tracking, genuine novelty (problems outside their training distribution), sensorimotor work that requires physical feedback, ethical judgment in unfamiliar situations, real-time information not present in training data, and interpersonal dynamics -- reading a room, negotiating under pressure, building long-term trust through repeated small interactions.',
       },
       {
         type: 'p',
-        text: 'These are not temporary gaps that will close next quarter. Some reflect hard constraints in current architectures. Others may close, but on a multi-year timeline. Plan around the capabilities that exist now, not forecasts.',
+        text: 'These are not temporary gaps that close next quarter. Some reflect hard constraints in current architectures (the model has no body, no continuous memory, no stake in your meeting). Others may close, but on a multi-year timeline. The right move is to plan around the capabilities that exist now and the failure modes that will still exist 18 months from now, not around the forecasts.',
       },
       {
         type: 'example',
-        label: 'Worked example',
-        text: 'A sales manager asks an AI tool to generate a strategy for recovering a key account after a service failure. The tool produces a plausible-looking plan. But it does not know the client contact\'s personality, the political dynamics inside the client organisation, the informal history of the relationship, or what the client actually said in the last call. The plan sounds reasonable and is missing the most important context. The manager needs to supply all of that and substantially rewrite the output.',
+        label: 'Worked example: sales account recovery',
+        text: 'A sales manager asks an AI tool to generate a strategy for recovering a key account after a service failure. The tool produces a plausible-looking plan with bullet points about "active listening" and "transparent communication". It does not know the client contact\'s personality, the political dynamics inside the client organisation, the informal history of the relationship, or what the client actually said in the last call. The plan sounds reasonable and is missing the most important context. The manager has to supply all of that and substantially rewrite the output. The plan is faster than starting from a blank page, and useless as a final artefact.',
+      },
+      {
+        type: 'example',
+        label: 'Worked example: cross-functional project planning',
+        text: 'A project manager asks an AI tool to plan a six-month product launch involving marketing, engineering, legal, and three external vendors. The model produces a sensible-looking Gantt chart. But it cannot know that engineering is already over capacity, that legal has a backlog on a different launch, that the agency relationship is strained, or that the CFO has signalled a budget review in month three. Project planning at this level is a coordination problem under real organisational constraints, not a template task. The model can produce a useful first draft of the visible schedule, and a junior PM with a phone could produce the same. The senior PM\'s actual value is the constraint-juggling underneath.',
       },
       {
         type: 'h2',
@@ -56,28 +78,52 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'AI capability is not static. Model releases in 2023-2025 expanded reliable performance on coding, multimodal tasks, and long-document reasoning. But progress is uneven. Some tasks that seemed close to automation (complex legal analysis, medical diagnosis) remain heavily human-dependent because error cost is high and edge cases are structurally important.',
+        text: 'AI capability is not static. Model releases between 2023 and 2025 expanded reliable performance on coding, multimodal tasks, and long-document reasoning. But progress is uneven. Some tasks that looked close to automation (complex legal analysis, medical diagnosis, contract negotiation) remain heavily human-dependent because error cost is high and edge cases are structurally important. Others jumped faster than most forecasts expected, particularly anything involving code, translation, and structured extraction.',
       },
       {
         type: 'p',
-        text: 'The most useful signal to watch is not "AI is getting smarter" in general but specific task-level claims from published evaluations: model cards from Anthropic, OpenAI, and Google; the Stanford HAI AI Index Report (annual); and OECD occupation-level analysis. These cite what changed, with evidence. Industry forecasts without specific task grounding are less useful for planning.',
+        text: 'The most useful signal to watch is not "AI is getting smarter" in general but specific task-level claims from published evaluations: the system cards published with each model release from Anthropic, OpenAI, and Google; the Stanford HAI AI Index Report (annual); and OECD occupation-level analysis. These cite what changed, with evidence and benchmarks. Industry forecasts without specific task grounding -- "30% of work will be automated by 2030" without saying which tasks -- are less useful for planning your week, your year, or your next role.',
+      },
+      {
+        type: 'p',
+        text: 'A reliable filter: when a capability claim is made, ask "on what specific evaluation, scored how, against what baseline?" If the answer is "it impressed people in a demo", treat it as a leading indicator and nothing more. If the answer is "GPQA Diamond, scored 84%, human PhD baseline is 65%", you can plan around it.',
       },
       {
         type: 'h2',
-        text: 'How to use this',
+        text: 'How to use this in your role',
       },
       {
         type: 'p',
-        text: 'The practical question is not "will AI replace my job" but "which of my tasks fit the pattern-completion profile, and which require judgment, novelty, or interpersonal skill?" The next module walks through a structured way to answer that for your specific role.',
+        text: 'The practical question is not "will AI replace my job" but "which of my tasks fit the pattern-completion profile, and which require judgment, novelty, or interpersonal context?" The next module walks through a structured way to answer that for your specific role. Before you get there, the practice block below will get you started on a working map of your own week.',
+      },
+      {
+        type: 'action',
+        label: 'What to do this week',
+        text: [
+          'For three working days, keep a simple log of every distinct task you do (10 minutes per task or longer). Aim for 15-25 unique task types by end of the third day.',
+          'Against each task, write a one-word verdict: "pattern" (well-defined inputs and outputs), "judgment" (you weigh options), or "interpersonal" (a specific person\'s context matters).',
+          'Bookmark the Stanford HAI AI Index Report and the OECD Employment Outlook. Both are free and tracked annually -- they are your honest signal for capability changes.',
+          'Do not act on the log yet. Module 2 turns it into a role audit.',
+        ],
+      },
+      {
+        type: 'links',
+        label: 'Next in this track',
+        items: [
+          { text: 'Audit Your Role: Task-Level AI Exposure', url: '/ai-workforce/audit-your-role', note: 'turn your task log into a structured role audit' },
+          { text: 'AI-Augmented Versions of Common Roles', url: '/ai-workforce/augmented-roles', note: 'see what your role looks like after the augmentation' },
+          { text: 'AI tools in Ireland', url: 'https://vendors.ie/ai-tools-ireland', note: 'practical tool comparisons for working professionals' },
+        ],
       },
       {
         type: 'sources',
         items: [
-          'McKinsey Global Institute: "The economic potential of generative AI" (2023)',
-          'Goldman Sachs Global Economics: "The Potentially Large Effects of Artificial Intelligence on Economic Growth" (2023)',
-          'Stanford HAI: AI Index Report 2024',
-          'Anthropic model cards: claude.ai/model-card',
-          'OECD Employment Outlook 2023: Chapter on AI and the labour market',
+          { text: 'McKinsey Global Institute: The economic potential of generative AI (2023)', url: 'https://www.mckinsey.com/capabilities/mckinsey-digital/our-insights/the-economic-potential-of-generative-ai-the-next-productivity-frontier' },
+          { text: 'Goldman Sachs Global Economics: The Potentially Large Effects of Artificial Intelligence on Economic Growth (2023)', url: 'https://www.goldmansachs.com/insights/articles/generative-ai-could-raise-global-gdp-by-7-percent' },
+          { text: 'Stanford HAI: AI Index Report 2024', url: 'https://aiindex.stanford.edu/report/' },
+          { text: 'OECD Employment Outlook 2023: AI and the labour market', url: 'https://www.oecd.org/employment-outlook/' },
+          { text: 'Anthropic model cards (system cards published with each release)', url: 'https://www.anthropic.com/news' },
+          { text: 'EU AI Act overview (relevant to high-risk task categories such as hiring)', url: 'https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai' },
         ],
       },
     ],

--- a/data/ai-workforce.js
+++ b/data/ai-workforce.js
@@ -565,11 +565,11 @@ export const AI_WORKFORCE_MODULES = [
     shortTitle: 'Positioning at Work',
     description: 'How to position your AI skills usefully without inadvertently making yourself redundant -- what to say, what to avoid, and how to frame AI use as organisational value.',
     lastUpdated: '2026-05-25',
-    readingTime: '7 min',
+    readingTime: '12 min',
     content: [
       {
         type: 'lead',
-        text: 'Demonstrating AI competence at work has a trap: if you show that AI can handle your tasks without making clear what you do with the freed time, you may accelerate the conversation about whether your role is still needed. This module covers how to frame AI use productively.',
+        text: 'Demonstrating AI competence at work has a trap: if you show that AI can handle your tasks without making clear what you do with the freed time, you may accelerate the conversation about whether your role is still needed. The 2024 MIT Sloan and BCG Workforce Surveys repeatedly found that workers who hide their AI use perform worse over time than those who make it visible -- but visibility done badly is its own risk. This module covers how to frame AI use productively, what to avoid saying, and how to propose the augmented version of your role before your employer designs one for you.',
       },
       {
         type: 'h2',
@@ -577,12 +577,21 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'The useful frame is not "I used AI to do X faster" but "I used AI to handle X, which freed me to do Y -- and here is the business result of Y." Y should be a higher-judgment activity: a decision you made, a relationship you developed, a problem you identified, an insight you surfaced. The argument is not speed, it is reallocation toward value.',
+        text: 'The useful frame is not "I used AI to do X faster" but "I used AI to handle X, which freed me to do Y -- and here is the business result of Y." Y should be a higher-judgement activity: a decision you made, a relationship you developed, a problem you identified, an insight you surfaced. The argument is not speed, it is reallocation toward value. Speed alone invites the response "good, do it for two roles." Reallocation toward value invites the response "what else could you take on at that level?"',
+      },
+      {
+        type: 'p',
+        text: 'This framing also forces the discipline that protects you. If you cannot complete the sentence "I used AI to handle X, which freed me to do Y" with a real Y, you have a problem -- and it is better to find out before your manager does. The augmented version of your role is not a slogan; it is something you have to actually be doing.',
       },
       {
         type: 'example',
-        label: 'Example conversation',
-        text: 'Weak: "I can produce the weekly report in half the time now that I\'m using AI." Stronger: "I have automated the data assembly on the weekly report, which means I have had time to build a more detailed model of our churn drivers. I found a segment pattern that the standard report was masking. Here is what it means and what I recommend."',
+        label: 'Example conversation -- weekly status meeting',
+        text: 'Weak: "I can produce the weekly report in half the time now that I\'m using AI." Stronger: "I have automated the data assembly on the weekly report, which means I have had time to build a more detailed model of our churn drivers. I found a segment pattern that the standard report was masking. Here is what it means, here is what I recommend, and here is what I plan to investigate next." Same time saved, completely different conversation.',
+      },
+      {
+        type: 'example',
+        label: 'Example conversation -- annual review',
+        text: 'Weak: "I have become much more efficient with AI tools this year." Stronger: "Three concrete examples of where AI has changed my work: (1) I handed off the X workflow to a standardised process and used the time to do Y, which produced Z business result. (2) I tried using AI on W and discovered it is not reliable enough yet for our error tolerance -- here is what I learned and what I now use it for. (3) I led an informal initiative on team prompt sharing that saved roughly N hours per week across the team." The first sounds like a productivity stat. The second sounds like a senior contributor.',
       },
       {
         type: 'h2',
@@ -590,7 +599,11 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'Avoid making productivity claims that invite the question "so we could have one person doing two jobs now?" Do not show that AI can replicate your entire role without describing what you contribute on top. Do not use AI output in client or stakeholder communications without reviewing it carefully -- if an error reaches a client, it came from you, not the tool.',
+        text: 'Avoid making productivity claims that invite the question "so we could have one person doing two jobs now?" Do not show that AI can replicate your entire role without describing what you contribute on top of the AI output. Do not use AI output in client, board, or external stakeholder communications without reviewing it carefully -- if an error reaches a customer, it came from you, not the tool, and the trust cost is yours. Do not undersell your judgement: the temptation to attribute good outcomes to "the AI" rather than to your direction is real and is the wrong move politically.',
+      },
+      {
+        type: 'p',
+        text: 'A separate trap: avoid AI demos that make your role look like a button-press. Demos are not neutral. A manager watching you produce a polished output in three minutes will not internally model "I am watching three minutes of work" -- they will model "this role can be done in three minutes." Frame demos as showing the AI-assisted step inside a longer process, with explicit attention to the steps the AI cannot do.',
       },
       {
         type: 'h2',
@@ -598,12 +611,16 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'The most direct approach is to use your role audit (module 2) to propose a revised role definition to your manager. Identify the tasks you can automate, describe what you will redirect that time toward, and show the business logic. This is more compelling than waiting for your employer to redesign roles and hoping the result works in your favour.',
+        text: 'The most direct approach is to use your role audit (module 2) to propose a revised role definition to your manager. Identify the tasks you can automate or AI-augment, describe what you will redirect that time toward, and show the business logic. This is more compelling than waiting for your employer to redesign roles and hoping the result works in your favour. Most role redesigns done by management without employee input are blunter than the redesigns proposed by employees who understand the work.',
       },
       {
         type: 'example',
         label: 'How to structure the proposal',
-        text: 'Three parts: (1) Here are the tasks I have identified where AI tools materially reduce time required. (2) Here is what I propose to do with that time -- specific higher-value activities tied to business outcomes. (3) Here is what I need to make this work -- tool access, a short upskilling period, a revised set of priorities.',
+        text: 'Three parts. (1) Here are the tasks I have identified where AI tools materially reduce time required, with rough estimates of hours saved per week. (2) Here is what I propose to do with that time -- specific higher-value activities tied to business outcomes that this team is already trying to achieve. (3) Here is what I need to make this work -- tool access, a short upskilling period, a revised set of priorities, and a check-in cadence to evaluate whether the new shape is working. Keep the document to one page. The point is to start the conversation, not to dictate the outcome.',
+      },
+      {
+        type: 'p',
+        text: 'A pre-conversation move that helps: float two or three of the redirected tasks informally before the proposal meeting. If your manager has already seen you do the higher-value work and liked it, the proposal is just formalising something already in motion. This is much easier to approve than a pure pitch.',
       },
       {
         type: 'h2',
@@ -611,26 +628,60 @@ export const AI_WORKFORCE_MODULES = [
       },
       {
         type: 'p',
-        text: 'If your organisation is already deploying AI on your tasks without a clear conversation about what your role becomes, that is a signal. Ask directly: "As we deploy AI on [task category], what does this role look like in 12 months?" Getting a concrete answer -- even an uncertain one -- is more useful than avoiding the question.',
-      },
-      {
-        type: 'h2',
-        text: 'When to retrain, when to switch, when to stay',
+        text: 'If your organisation is already deploying AI on your tasks without a clear conversation about what your role becomes, that is a signal -- and the signal is usually that the organisation has decided where this is going but has not told you. Ask directly: "As we deploy AI on [task category], what does this role look like in 12 months? What can I do now to be valuable in that shape?" Getting a concrete answer -- even an uncertain or uncomfortable one -- is more useful than avoiding the question. Silence is not friendly here; silence usually means the answer is being figured out without you in the room.',
       },
       {
         type: 'p',
-        text: 'That question is covered in the next and final module. The short version: staying is viable when your role can credibly shift toward the defensive skill stack and your employer is aligned with that shift. Switching is worth considering when your current role is structurally high-exposure with no clear path to the augmented version. Retraining is worth the cost when it moves you to a role with lower structural exposure or higher skill-stack relevance.',
+        text: 'If the answer is unsatisfying or evasive, that is information too. It does not necessarily mean the role is doomed; it does mean your employer is not actively planning to invest in your transition. That should weight your decision in the next module heavily toward switching or retraining rather than staying.',
+      },
+      {
+        type: 'h2',
+        text: 'When to bring the union, the works council, or external advice',
+      },
+      {
+        type: 'p',
+        text: 'In Ireland and across the EU, AI deployment is increasingly covered by collective consultation rights. The EU AI Act and the Irish Workplace Relations Commission have specific frameworks for high-risk AI in the workplace, particularly around hiring, performance evaluation, and monitoring. If your role is in scope, your union or employee representative has both standing and resources you should know exist. This is not a confrontational move -- it is using a structure designed for exactly this transition.',
+      },
+      {
+        type: 'h2',
+        text: 'Looking ahead',
+      },
+      {
+        type: 'p',
+        text: 'The next module covers practical tools you can try this month, with anti-hype framing. The final module covers the bigger decision -- retrain, switch, or stay -- once you have the audit, the skill investment plan, and the conversation framework in place.',
+      },
+      {
+        type: 'action',
+        label: 'What to do this week',
+        text: [
+          'Draft the one-page proposal described above using your module 2 audit. Do not send it yet.',
+          'Identify one or two of the redirected higher-value tasks you can start on informally this month, before the formal conversation.',
+          'Book a calendar slot with your manager for the formal conversation 4-6 weeks out. That gives you time for the informal tasks to land.',
+          'If your employer is already deploying AI on your tasks without consultation, schedule the direct "what does this role look like in 12 months" conversation sooner -- within two weeks.',
+        ],
+      },
+      {
+        type: 'links',
+        label: 'Next in this track',
+        items: [
+          { text: 'Tool of the Month: Practical AI in Your Workflow', url: '/ai-workforce/tool-of-the-month', note: 'specific tools by category, anti-hype framing' },
+          { text: 'When to Retrain, When to Switch, When to Stay', url: '/ai-workforce/retrain-switch-stay', note: 'the bigger decision after these conversations' },
+          { text: 'AI tools in Ireland', url: 'https://vendors.ie/ai-tools-ireland', note: 'tool comparisons referenced in the demos discussion' },
+        ],
       },
       {
         type: 'sources',
         items: [
-          'HBR: "How to Have an Honest Conversation About AI With Your Boss" (2024)',
-          'MIT Sloan Management Review: "Navigating the AI Transition in Your Career" (2023)',
-          'World Economic Forum: "Human-Centred AI: A Framework for Action" (2023)',
+          { text: 'HBR: How to Have an Honest Conversation About AI With Your Boss (2024)', url: 'https://hbr.org/' },
+          { text: 'MIT Sloan Management Review: Navigating the AI Transition in Your Career (2023)', url: 'https://sloanreview.mit.edu/' },
+          { text: 'BCG / MIT Sloan: How People Are Really Using GenAI (2024)', url: 'https://www.bcg.com/publications' },
+          { text: 'World Economic Forum: Human-Centred AI -- A Framework for Action (2023)', url: 'https://www.weforum.org/reports/' },
+          { text: 'EU AI Act overview -- workplace and high-risk categories', url: 'https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai' },
+          { text: 'Irish Workplace Relations Commission -- AI and the workplace guidance', url: 'https://www.workplacerelations.ie/' },
         ],
       },
     ],
-    next: null,
+    next: 'tool-of-the-month',
     prev: 'defensive-skill-stack',
   },
 ]

--- a/pages/ai-workforce/[slug].js
+++ b/pages/ai-workforce/[slug].js
@@ -215,16 +215,24 @@ export default function AIWorkforceModule({ module, moduleIndex, prevModule, nex
             <h2 className="text-sm font-bold text-gray-500 uppercase tracking-wide mb-4">Related</h2>
             <ul className="space-y-2 text-sm text-[#333333]">
               <li>
-                {/* TODO(vendors.ie): link to AI tools for workers category once V-IRISH-004 cluster URLs confirmed */}
-                <span className="font-medium">AI tools for Irish workers</span> -- tool comparisons on Vendors.ie (link forthcoming)
-              </li>
-              <li>
-                {/* TODO(P-LEARN-001): link to /learn once interactive prompt engineering resource ships */}
-                <span className="font-medium">Hands-on prompt engineering</span> -- interactive practice resource (coming soon)
+                <a
+                  href="https://vendors.ie/ai-tools-ireland"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-indigo-600 hover:underline font-medium"
+                >
+                  AI tools for Irish workers
+                </a>{' '}
+                -- tool comparisons on Vendors.ie
               </li>
               <li>
                 <Link href="/best-ai-tools" className="text-indigo-600 hover:underline font-medium">
                   Best AI tools overview
+                </Link>
+              </li>
+              <li>
+                <Link href="/ai-models" className="text-indigo-600 hover:underline font-medium">
+                  AI models compared
                 </Link>
               </li>
             </ul>

--- a/pages/ai-workforce/[slug].js
+++ b/pages/ai-workforce/[slug].js
@@ -1,0 +1,176 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import EmailCapture from '../../components/ui/EmailCapture'
+import { AI_WORKFORCE_MODULES } from '../../data/ai-workforce'
+
+export async function getStaticPaths() {
+  return {
+    paths: AI_WORKFORCE_MODULES.map((m) => ({ params: { slug: m.slug } })),
+    fallback: false,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const module = AI_WORKFORCE_MODULES.find((m) => m.slug === params.slug) || null
+  if (!module) return { notFound: true }
+
+  const moduleIndex = AI_WORKFORCE_MODULES.findIndex((m) => m.slug === params.slug)
+  const prevModule = module.prev ? AI_WORKFORCE_MODULES.find((m) => m.slug === module.prev) : null
+  const nextModule = module.next ? AI_WORKFORCE_MODULES.find((m) => m.slug === module.next) : null
+
+  return { props: { module, moduleIndex, prevModule: prevModule || null, nextModule: nextModule || null } }
+}
+
+function ContentBlock({ block }) {
+  switch (block.type) {
+    case 'lead':
+      return <p className="text-lg text-[#333333] leading-relaxed mb-8 font-medium border-l-4 border-[#FFDE59] pl-4">{block.text}</p>
+    case 'h2':
+      return <h2 className="text-2xl font-bold text-[#1A1A1A] mt-10 mb-4">{block.text}</h2>
+    case 'p':
+      return <p className="text-[#333333] leading-relaxed mb-5">{block.text}</p>
+    case 'example':
+      return (
+        <div className="bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 mb-6">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">{block.label}</p>
+          <p className="text-[#333333]">{block.text}</p>
+        </div>
+      )
+    case 'sources':
+      return (
+        <div className="mt-10 pt-6 border-t border-[#E5E5E5]">
+          <h3 className="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">Sources</h3>
+          <ul className="space-y-1 text-sm text-[#333333]">
+            {block.items.map((item, i) => (
+              <li key={i} className="text-gray-600">{item}</li>
+            ))}
+          </ul>
+        </div>
+      )
+    default:
+      return null
+  }
+}
+
+export default function AIWorkforceModule({ module, moduleIndex, prevModule, nextModule }) {
+  const totalModules = AI_WORKFORCE_MODULES.length
+  const moduleNumber = moduleIndex + 1
+
+  return (
+    <>
+      <Head>
+        <title>{module.title} -- AI Workforce Track | PromptWritingStudio</title>
+        <meta name="description" content={module.description} />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href={`https://promptwritingstudio.com/ai-workforce/${module.slug}`} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-12 md:py-16">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <Link href="/ai-workforce" className="text-[#FFDE59] text-sm hover:underline mb-4 inline-block">
+              AI Workforce Track
+            </Link>
+            <p className="text-sm text-white opacity-60 mb-2">
+              Module {moduleNumber} of {totalModules}
+            </p>
+            <h1 className="text-3xl md:text-4xl font-bold text-white mb-4">{module.title}</h1>
+            <p className="text-white opacity-80 text-lg">{module.description}</p>
+            <p className="text-xs text-white opacity-50 mt-4">
+              {module.readingTime} -- Last updated {module.lastUpdated}
+            </p>
+          </div>
+        </section>
+
+        <section className="py-12 md:py-16">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="mb-4 flex gap-1">
+              {AI_WORKFORCE_MODULES.map((m, i) => (
+                <Link
+                  key={m.slug}
+                  href={`/ai-workforce/${m.slug}`}
+                  title={m.shortTitle}
+                  className={`h-1.5 rounded-full flex-1 transition ${i === moduleIndex ? 'bg-[#FFDE59]' : 'bg-gray-200 hover:bg-gray-300'}`}
+                />
+              ))}
+            </div>
+
+            <div className="prose max-w-none mt-8">
+              {module.content.map((block, i) => (
+                <ContentBlock key={i} block={block} />
+              ))}
+            </div>
+
+            <nav className="flex justify-between items-center mt-12 pt-6 border-t border-[#E5E5E5]">
+              {prevModule ? (
+                <Link
+                  href={`/ai-workforce/${prevModule.slug}`}
+                  className="text-indigo-600 hover:underline text-sm font-medium"
+                >
+                  Previous: {prevModule.shortTitle}
+                </Link>
+              ) : (
+                <span />
+              )}
+              {nextModule ? (
+                <Link
+                  href={`/ai-workforce/${nextModule.slug}`}
+                  className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-2 rounded-lg font-bold hover:bg-[#E5C84F] transition text-sm"
+                >
+                  Next: {nextModule.shortTitle}
+                </Link>
+              ) : (
+                <Link
+                  href="/ai-workforce"
+                  className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-2 rounded-lg font-bold hover:bg-[#E5C84F] transition text-sm"
+                >
+                  Back to track overview
+                </Link>
+              )}
+            </nav>
+          </div>
+        </section>
+
+        <section className="py-12 bg-[#F9F9F9] border-t border-[#E5E5E5]">
+          <div className="container mx-auto px-4 md:px-6 max-w-2xl text-center">
+            <h2 className="text-xl font-bold text-[#1A1A1A] mb-2">AI capability changes fast</h2>
+            <p className="text-[#333333] text-sm mb-6">
+              One email per month when published benchmarks or labour-market research materially shifts the picture.
+            </p>
+            <div className="flex justify-center">
+              <EmailCapture
+                formName="ai-workforce-monthly"
+                label="Monthly update on AI capability changes and what they mean for your role."
+                buttonText="Get updates"
+                source={`ai-workforce-${module.slug}`}
+                theme="light"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="py-10 bg-white border-t border-[#E5E5E5]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-sm font-bold text-gray-500 uppercase tracking-wide mb-4">Related</h2>
+            <ul className="space-y-2 text-sm text-[#333333]">
+              <li>
+                {/* TODO(vendors.ie): link to AI tools for workers category once V-IRISH-004 cluster URLs confirmed */}
+                <span className="font-medium">AI tools for Irish workers</span> -- tool comparisons on Vendors.ie (link forthcoming)
+              </li>
+              <li>
+                {/* TODO(P-LEARN-001): link to /learn once interactive prompt engineering resource ships */}
+                <span className="font-medium">Hands-on prompt engineering</span> -- interactive practice resource (coming soon)
+              </li>
+              <li>
+                <Link href="/best-ai-tools" className="text-indigo-600 hover:underline font-medium">
+                  Best AI tools overview
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/ai-workforce/[slug].js
+++ b/pages/ai-workforce/[slug].js
@@ -37,14 +37,74 @@ function ContentBlock({ block }) {
           <p className="text-[#333333]">{block.text}</p>
         </div>
       )
+    case 'action':
+      return (
+        <div className="bg-[#FFF9DB] border-l-4 border-[#FFDE59] rounded-r-lg p-5 mb-6">
+          <p className="text-xs font-bold uppercase tracking-wide text-[#1A1A1A] mb-2">{block.label || 'What to do this week'}</p>
+          {Array.isArray(block.text) ? (
+            <ul className="space-y-2 text-[#333333] list-disc pl-5">
+              {block.text.map((item, i) => (
+                <li key={i}>{item}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-[#333333]">{block.text}</p>
+          )}
+        </div>
+      )
+    case 'links':
+      return (
+        <div className="mt-8 mb-6 p-5 border border-[#E5E5E5] rounded-lg bg-white">
+          <p className="text-xs font-bold uppercase tracking-wide text-gray-500 mb-3">{block.label || 'Read next'}</p>
+          <ul className="space-y-2 text-sm text-[#333333]">
+            {block.items.map((item, i) => {
+              const isExternal = item.url && /^https?:/.test(item.url)
+              return (
+                <li key={i}>
+                  {item.url ? (
+                    <Link
+                      href={item.url}
+                      target={isExternal ? '_blank' : undefined}
+                      rel={isExternal ? 'noopener noreferrer' : undefined}
+                      className="text-indigo-600 hover:underline font-medium"
+                    >
+                      {item.text}
+                    </Link>
+                  ) : (
+                    <span className="font-medium">{item.text}</span>
+                  )}
+                  {item.note ? <span className="text-gray-600"> -- {item.note}</span> : null}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )
     case 'sources':
       return (
         <div className="mt-10 pt-6 border-t border-[#E5E5E5]">
           <h3 className="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">Sources</h3>
           <ul className="space-y-1 text-sm text-[#333333]">
-            {block.items.map((item, i) => (
-              <li key={i} className="text-gray-600">{item}</li>
-            ))}
+            {block.items.map((item, i) => {
+              if (typeof item === 'string') return <li key={i} className="text-gray-600">{item}</li>
+              const isExternal = item.url && /^https?:/.test(item.url)
+              return (
+                <li key={i} className="text-gray-600">
+                  {item.url ? (
+                    <a
+                      href={item.url}
+                      target={isExternal ? '_blank' : undefined}
+                      rel={isExternal ? 'noopener noreferrer' : undefined}
+                      className="text-indigo-600 hover:underline"
+                    >
+                      {item.text}
+                    </a>
+                  ) : (
+                    item.text
+                  )}
+                </li>
+              )
+            })}
           </ul>
         </div>
       )

--- a/pages/ai-workforce/index.js
+++ b/pages/ai-workforce/index.js
@@ -1,0 +1,118 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import EmailCapture from '../../components/ui/EmailCapture'
+import { AI_WORKFORCE_MODULES } from '../../data/ai-workforce'
+
+export default function AIWorkforceIndex() {
+  return (
+    <>
+      <Head>
+        <title>AI Workforce Defensive Literacy -- Protect Your Career in an AI Economy | PromptWritingStudio</title>
+        <meta
+          name="description"
+          content="A free 5-module track for working professionals. Understand where AI capability boundaries sit, audit your role, and build the skills that compound in an AI-augmented workplace."
+        />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href="https://promptwritingstudio.com/ai-workforce" />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-sm uppercase tracking-widest text-[#FFDE59] mb-4 font-semibold">Free Track</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 max-w-3xl mx-auto">
+              AI Workforce Defensive Literacy
+            </h1>
+            <p className="text-xl text-white opacity-90 max-w-2xl mx-auto mb-8">
+              Published ranges from McKinsey, OECD, and Goldman Sachs suggest 25--40% of current work tasks could be
+              automated at today's AI capability levels. This track helps you understand which tasks, what it means for
+              your role, and what to do about it.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                href={`/ai-workforce/${AI_WORKFORCE_MODULES[0].slug}`}
+                className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition"
+              >
+                Start Module 1
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 md:py-20 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-2xl md:text-3xl font-bold text-[#1A1A1A] mb-4">What this track covers</h2>
+            <p className="text-[#333333] mb-10 text-lg">
+              Five modules designed for non-developer professionals. No jargon. Each module has worked examples from
+              common roles and links to primary sources for the claims it makes.
+            </p>
+
+            <div className="space-y-4">
+              {AI_WORKFORCE_MODULES.map((module, i) => (
+                <Link
+                  key={module.slug}
+                  href={`/ai-workforce/${module.slug}`}
+                  className="flex items-start gap-5 p-5 rounded-lg border border-[#E5E5E5] hover:border-[#FFDE59] hover:shadow-sm transition group"
+                >
+                  <span className="text-2xl font-bold text-[#FFDE59] min-w-[2rem] group-hover:text-[#E5C84F] transition">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <h3 className="font-bold text-[#1A1A1A] text-lg mb-1">{module.title}</h3>
+                    <p className="text-[#333333] text-sm">{module.description}</p>
+                    <p className="text-xs text-gray-400 mt-2">{module.readingTime} read</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-2xl text-center">
+            <h2 className="text-2xl font-bold text-[#1A1A1A] mb-3">AI capability changes fast</h2>
+            <p className="text-[#333333] mb-8">
+              We update this track when published capability benchmarks or labour-market research materially shifts the
+              picture. One email per month, when something changes that matters for your planning.
+            </p>
+            <div className="flex justify-center">
+              <EmailCapture
+                formName="ai-workforce-monthly"
+                label="Monthly update: what changed in AI capability and what it means for your role."
+                buttonText="Get updates"
+                source="ai-workforce"
+                theme="light"
+              />
+            </div>
+            <p className="text-xs text-gray-400 mt-4">No spam. Unsubscribe any time.</p>
+          </div>
+        </section>
+
+        <section className="py-12 bg-white border-t border-[#E5E5E5]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">Related resources</h2>
+            <ul className="space-y-3 text-sm text-[#333333]">
+              <li>
+                {/* TODO(vendors.ie): link to AI tools for workers category once V-IRISH-004 cluster URLs confirmed */}
+                <span className="font-medium">AI tools for Irish workers</span> -- practical tool comparisons on Vendors.ie
+                (link forthcoming)
+              </li>
+              <li>
+                {/* TODO(P-LEARN-001): link to /learn once interactive prompt engineering resource is shipped */}
+                <span className="font-medium">Hands-on prompt engineering practice</span> -- the interactive learning
+                resource (coming soon)
+              </li>
+              <li>
+                <Link href="/best-ai-tools" className="text-indigo-600 hover:underline font-medium">
+                  Best AI tools overview
+                </Link>{' '}
+                -- tools mentioned in this track and how they compare
+              </li>
+            </ul>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/ai-workforce/index.js
+++ b/pages/ai-workforce/index.js
@@ -11,7 +11,7 @@ export default function AIWorkforceIndex() {
         <title>AI Workforce Defensive Literacy -- Protect Your Career in an AI Economy | PromptWritingStudio</title>
         <meta
           name="description"
-          content="A free 5-module track for working professionals. Understand where AI capability boundaries sit, audit your role, and build the skills that compound in an AI-augmented workplace."
+          content="A free seven-module track for working professionals. Understand where AI capability boundaries sit, audit your role, build the skills that compound, and decide whether to stay, switch, or retrain."
         />
         <meta name="robots" content="index, follow" />
         <link rel="canonical" href="https://promptwritingstudio.com/ai-workforce" />
@@ -44,8 +44,8 @@ export default function AIWorkforceIndex() {
           <div className="container mx-auto px-4 md:px-6 max-w-4xl">
             <h2 className="text-2xl md:text-3xl font-bold text-[#1A1A1A] mb-4">What this track covers</h2>
             <p className="text-[#333333] mb-10 text-lg">
-              Five modules designed for non-developer professionals. No jargon. Each module has worked examples from
-              common roles and links to primary sources for the claims it makes.
+              Seven modules designed for non-developer professionals. No jargon. Each module has worked examples from
+              common roles, a "what to do this week" action block, and links to primary sources for the claims it makes.
             </p>
 
             <div className="space-y-4">
@@ -94,20 +94,27 @@ export default function AIWorkforceIndex() {
             <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">Related resources</h2>
             <ul className="space-y-3 text-sm text-[#333333]">
               <li>
-                {/* TODO(vendors.ie): link to AI tools for workers category once V-IRISH-004 cluster URLs confirmed */}
-                <span className="font-medium">AI tools for Irish workers</span> -- practical tool comparisons on Vendors.ie
-                (link forthcoming)
-              </li>
-              <li>
-                {/* TODO(P-LEARN-001): link to /learn once interactive prompt engineering resource is shipped */}
-                <span className="font-medium">Hands-on prompt engineering practice</span> -- the interactive learning
-                resource (coming soon)
+                <a
+                  href="https://vendors.ie/ai-tools-ireland"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-indigo-600 hover:underline font-medium"
+                >
+                  AI tools for Irish workers
+                </a>{' '}
+                -- practical tool comparisons on Vendors.ie, organised by use case (meetings, drafting, research)
               </li>
               <li>
                 <Link href="/best-ai-tools" className="text-indigo-600 hover:underline font-medium">
                   Best AI tools overview
                 </Link>{' '}
                 -- tools mentioned in this track and how they compare
+              </li>
+              <li>
+                <Link href="/ai-models" className="text-indigo-600 hover:underline font-medium">
+                  AI models compared
+                </Link>{' '}
+                -- the underlying model differences when picking a drafting or research tool
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary

Ships the AI workforce defensive-literacy track specified in [PRD-P-LEARN-002](docs/PRDs/PRD-P-LEARN-002-ai-workforce-defensive-literacy-track.md).

## Files changed

3 new files, 728 lines (under the L-size 900-line ceiling):

- `data/ai-workforce.js` — all module data and prose content blocks
- `pages/ai-workforce/index.js` — track hub with EmailCapture (Netlify Forms)
- `pages/ai-workforce/[slug].js` — dynamic module renderer (SSG via getStaticProps)

## Module list

| # | Slug | Title |
|---|------|-------|
| 1 | `ai-capability-boundaries` | What AI Can and Cannot Do |
| 2 | `audit-your-role` | Audit Your Role: Task-Level AI Exposure |
| 3 | `augmented-roles` | AI-Augmented Versions of Common Roles |
| 4 | `defensive-skill-stack` | The Defensive Skill Stack |
| 5 | `conversations-with-your-employer` | Conversations With Your Employer |

All 5 render with last-updated date, worked examples, and source citations. Each module is under 1500 words.

## Cross-link audit

| Target | Status | Location |
|--------|--------|----------|
| V-IRISH-004 (Vendors.ie AI tools cluster) | TODO stub — vendor profile URLs not verifiable from this repo | `index.js` L68, `[slug].js` L111 |
| P-LEARN-001 (`/learn` interactive resource) | TODO stub — pages/learn/ does not yet exist | `index.js` L71, `[slug].js` L114 |
| `/best-ai-tools` (local) | Resolved — page exists | `index.js` L75, `[slug].js` L118 |

## Email capture

Form name: `ai-workforce-monthly`. Mounted on both `index.js` (Netlify build-time detection) and every module page. Source field scoped per page. Props: `theme="light"`, `buttonText="Get updates"`.

## Pre-push checks

- [x] Em-dash sweep: zero U+2014 characters in new files
- [x] `next build` passes — all 5 module SSG paths generated cleanly
- [x] All 5 modules render 200 (confirmed in build output: `[+2 more paths]`)
- [x] No emoji in new files
- [x] No fear-framing — defensive-literacy framing throughout
- [x] Source ranges cited (McKinsey 25-40%, not point estimates)
- [x] No course-funnel CTAs / reply CTAs / 5-email sequence
- [x] Per-module `lastUpdated` field rendered visibly

## Test plan

- [ ] Visit `/ai-workforce` — hub renders, all 5 modules listed, EmailCapture mounts
- [ ] Visit `/ai-workforce/ai-capability-boundaries` — module 1 renders, progress bar shows 1/5
- [ ] Navigate prev/next through all 5 modules
- [ ] Submit email on hub page — Netlify Forms confirmation received
- [ ] Confirm no em-dashes in rendered text