### PR TITLE
feat(learn): interactive prompt-engineering resource v1 (6 modules + Claude)

### DIFF
--- a/components/learn/TryItPanel.js
+++ b/components/learn/TryItPanel.js
@@ -1,0 +1,217 @@
+import { useEffect, useState } from 'react'
+
+// Per v1 PRD: anonymous persistence only — variants live in localStorage,
+// keyed by module slug. No server-side store. No account, no auth.
+
+function storageKey(moduleSlug) {
+  return `pws.learn.variants.${moduleSlug}`
+}
+
+function loadVariants(moduleSlug) {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(storageKey(moduleSlug))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function saveVariants(moduleSlug, variants) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(storageKey(moduleSlug), JSON.stringify(variants))
+  } catch {
+    // Quota exceeded or storage blocked — fail silent, the run still worked.
+  }
+}
+
+export default function TryItPanel({ moduleSlug, starterPrompt, hint }) {
+  const [promptText, setPromptText] = useState(starterPrompt || '')
+  const [output, setOutput] = useState('')
+  const [error, setError] = useState('')
+  const [remaining, setRemaining] = useState(null)
+  const [isRunning, setIsRunning] = useState(false)
+  const [variants, setVariants] = useState([])
+  const [saveLabel, setSaveLabel] = useState('')
+
+  useEffect(() => {
+    setVariants(loadVariants(moduleSlug))
+  }, [moduleSlug])
+
+  async function runPrompt() {
+    if (isRunning) return
+    setIsRunning(true)
+    setError('')
+    setOutput('')
+
+    try {
+      const res = await fetch('/api/learn/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: promptText, moduleSlug }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'Run failed.')
+        if (typeof data.remaining === 'number') setRemaining(data.remaining)
+      } else {
+        setOutput(data.output || '')
+        if (typeof data.remaining === 'number') setRemaining(data.remaining)
+      }
+    } catch {
+      setError('Network error. Try again.')
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  function saveCurrentVariant() {
+    if (!promptText.trim()) return
+    const label = saveLabel.trim() || `Variant ${variants.length + 1}`
+    const next = [
+      ...variants,
+      {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        label,
+        prompt: promptText,
+        savedAt: new Date().toISOString(),
+      },
+    ]
+    setVariants(next)
+    saveVariants(moduleSlug, next)
+    setSaveLabel('')
+  }
+
+  function loadVariant(id) {
+    const v = variants.find(x => x.id === id)
+    if (v) setPromptText(v.prompt)
+  }
+
+  function deleteVariant(id) {
+    const next = variants.filter(x => x.id !== id)
+    setVariants(next)
+    saveVariants(moduleSlug, next)
+  }
+
+  function resetToStarter() {
+    setPromptText(starterPrompt || '')
+  }
+
+  return (
+    <div className="border border-[#E5E5E5] rounded-lg bg-white p-5 md:p-6">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold text-[#1A1A1A]">Try it</h3>
+        {remaining !== null && (
+          <span className="text-xs text-gray-500">
+            {remaining} runs left today
+          </span>
+        )}
+      </div>
+
+      <label htmlFor={`prompt-${moduleSlug}`} className="sr-only">
+        Prompt
+      </label>
+      <textarea
+        id={`prompt-${moduleSlug}`}
+        value={promptText}
+        onChange={e => setPromptText(e.target.value)}
+        rows={8}
+        className="w-full text-sm font-mono border border-[#E5E5E5] rounded-md p-3 focus:outline-none focus:ring-2 focus:ring-[#FFDE59] focus:border-transparent"
+        spellCheck={false}
+      />
+
+      {hint && (
+        <p className="text-xs text-gray-500 mt-2">{hint}</p>
+      )}
+
+      <div className="flex flex-wrap gap-3 mt-4">
+        <button
+          type="button"
+          onClick={runPrompt}
+          disabled={isRunning || !promptText.trim()}
+          className="bg-[#FFDE59] text-black font-semibold px-5 py-2 rounded-md hover:bg-[#FFD633] disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isRunning ? 'Running...' : 'Run prompt'}
+        </button>
+        <button
+          type="button"
+          onClick={resetToStarter}
+          className="border border-[#E5E5E5] text-[#333333] px-4 py-2 rounded-md hover:bg-gray-50"
+        >
+          Reset
+        </button>
+      </div>
+
+      {error && (
+        <div className="mt-4 p-3 rounded-md bg-red-50 border border-red-200 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      {output && (
+        <div className="mt-5">
+          <h4 className="text-sm font-semibold text-[#1A1A1A] mb-2">Model output</h4>
+          <pre className="whitespace-pre-wrap text-sm bg-[#F9F9F9] border border-[#E5E5E5] rounded-md p-4 text-[#333333]">
+            {output}
+          </pre>
+        </div>
+      )}
+
+      <div className="mt-6 pt-5 border-t border-[#E5E5E5]">
+        <h4 className="text-sm font-semibold text-[#1A1A1A] mb-2">Save your variant</h4>
+        <p className="text-xs text-gray-500 mb-3">
+          Saved variants stay in your browser only. Clearing site data removes them.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <input
+            type="text"
+            value={saveLabel}
+            onChange={e => setSaveLabel(e.target.value)}
+            placeholder="Label (optional)"
+            className="text-sm border border-[#E5E5E5] rounded-md px-3 py-2 flex-1 min-w-0"
+          />
+          <button
+            type="button"
+            onClick={saveCurrentVariant}
+            disabled={!promptText.trim()}
+            className="border border-[#1A1A1A] text-[#1A1A1A] font-semibold px-4 py-2 rounded-md hover:bg-[#1A1A1A] hover:text-white disabled:opacity-50"
+          >
+            Save variant
+          </button>
+        </div>
+
+        {variants.length > 0 && (
+          <ul className="mt-4 space-y-2">
+            {variants.map(v => (
+              <li
+                key={v.id}
+                className="flex items-center justify-between text-sm border border-[#E5E5E5] rounded-md px-3 py-2"
+              >
+                <span className="text-[#1A1A1A] truncate flex-1 mr-3">{v.label}</span>
+                <div className="flex gap-2 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => loadVariant(v.id)}
+                    className="text-xs text-[#1A1A1A] underline hover:no-underline"
+                  >
+                    Load
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => deleteVariant(v.id)}
+                    className="text-xs text-gray-500 hover:text-red-700"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/data/learn/modules.js
+++ b/data/learn/modules.js
@@ -25,7 +25,7 @@ A useful test: read your prompt back as if you were a new contractor seeing the 
 
 Three traps to avoid. First, stacking too many instructions in one prompt without ordering them, which causes the model to weight them equally when you meant some to dominate. Second, using soft words like "good" or "engaging" without defining what good means in your context. Third, asking for output and then immediately constraining it ("write a long article but keep it short"), which forces the model to pick a side and rarely picks the one you wanted.
 
-The rest of this resource builds on this foundation. Role prompting, structured output, few-shot examples — all of them are specialised forms of being clearer about what you want.`,
+The rest of this resource builds on this foundation. Role prompting, structured output, few-shot examples. All of them are specialised forms of being clearer about what you want.`,
     workedExample: {
       before:
         'Write a follow-up email to a client who has gone quiet.',
@@ -70,20 +70,20 @@ When role prompting fails, the fix is almost always to add what the role should 
     starterPrompt:
       'You are a senior B2B copy director reviewing landing page headlines for a SaaS startup. Your job is to flag vague claims and ask one sharp question that would force the founder to make the headline more specific. Critique this headline: "We help businesses grow with AI." Output: one sentence on what is vague, then one direct question. No reassurance, no praise.',
     tryItHint:
-      'Swap the role to "supportive marketing coach" and run it again. Same task, very different output — that is the role doing work.',
+      'Swap the role to "supportive marketing coach" and run it again. Same task, very different output. That is the role doing work.',
   },
   {
     slug: 'structured-output',
     order: 3,
     title: 'Structured output',
     summary:
-      'When you need to use AI output downstream — in a spreadsheet, a form, another prompt — ask for it in a structure, not prose.',
+      'When you need to use AI output downstream, ask for it in a structure, not prose.',
     learningGoals: [
       'Pick a structure (JSON, markdown table, bulleted fields) that matches the downstream use',
       'Lock the shape so the model cannot improvise extra fields',
       'Recover from malformed output without re-running the whole prompt',
     ],
-    concept: `If you are pasting AI output back into a tool — a CRM, a spreadsheet, another prompt — prose is the wrong format. You are forcing yourself to do parsing work that the model could have done for you. Structured output solves this.
+    concept: `If you are pasting AI output back into a tool (a CRM, a spreadsheet, another prompt), prose is the wrong format. You are forcing yourself to do parsing work that the model could have done for you. Structured output solves this.
 
 The first decision is the shape. JSON works when the consumer is another script or AI step. A markdown table works when the consumer is you, scanning a page. Numbered bullets with labelled fields work when the structure is shallow and you want the model to keep its reasoning visible. Pick the lightest structure that survives the use case.
 
@@ -98,7 +98,7 @@ When structured output goes wrong, it is almost always because the schema was im
       after:
         'Summarise the customer support ticket below. Return only a JSON object with these keys: summary (string, max 25 words), category (one of: billing, bug, feature_request, account_access, other), urgency (one of: low, medium, high), suggested_owner (one of: support, engineering, sales). No preamble, no markdown fences.\n\nTicket: [paste ticket text here]',
       whyItWorks:
-        'Every consumer of this output — a triage script, a dashboard — can rely on the same shape. The enum values prevent the model from inventing a new category. The "no preamble" rule prevents the response from breaking a JSON parser.',
+        'Every consumer of this output, whether a triage script or a dashboard, can rely on the same shape. The enum values prevent the model from inventing a new category. The "no preamble" rule prevents the response from breaking a JSON parser.',
     },
     starterPrompt:
       'Summarise the customer support ticket below. Return only a JSON object with these keys: summary (string, max 25 words), category (one of: billing, bug, feature_request, account_access, other), urgency (one of: low, medium, high), suggested_owner (one of: support, engineering, sales). No preamble, no markdown fences.\n\nTicket: Customer reports that the export button on the reporting dashboard has been failing for two days. They have a board meeting tomorrow and need the data tonight. They have already tried two browsers.',

--- a/data/learn/modules.js
+++ b/data/learn/modules.js
@@ -1,0 +1,122 @@
+// Module content for /learn — interactive prompt-engineering resource.
+// Each module: concept explainer (business-language, 200-400 words),
+// worked example (before/after), and a starter prompt for the try-it panel.
+// Keep tone non-technical. No founder voice. No course CTAs inside the modules.
+
+export const LEARN_MODULES = [
+  {
+    slug: 'clear-instructions',
+    order: 1,
+    title: 'Clear instructions',
+    summary:
+      'The single biggest lever in prompt quality. Tell the model what you want, in what format, for whom, and what to leave out.',
+    learningGoals: [
+      'Spot ambiguous prompts that produce hedged or generic output',
+      'Rewrite a vague prompt as a specific instruction',
+      'Add format, audience, and exclusion constraints',
+    ],
+    concept: `Most poor AI output is not a model failure. It is an instruction failure. The model is doing its best with a prompt that did not actually specify the answer you wanted.
+
+A clear instruction does four things at once. It states the task in one sentence. It names the audience or context. It specifies the output format (length, structure, tone). And it lists what to avoid.
+
+Consider the difference between "write something about email marketing" and "write three subject lines for a sales onboarding email aimed at small-business owners; keep each under fifty characters and avoid the word free." The second prompt removes most of the room for misinterpretation. The model still has creative latitude inside those constraints, but the constraints are doing the heavy lifting.
+
+A useful test: read your prompt back as if you were a new contractor seeing the task for the first time. Could you complete it without asking questions? If not, you are leaving the model to guess, and it will guess toward the safest, blandest answer in its training data.
+
+Three traps to avoid. First, stacking too many instructions in one prompt without ordering them, which causes the model to weight them equally when you meant some to dominate. Second, using soft words like "good" or "engaging" without defining what good means in your context. Third, asking for output and then immediately constraining it ("write a long article but keep it short"), which forces the model to pick a side and rarely picks the one you wanted.
+
+The rest of this resource builds on this foundation. Role prompting, structured output, few-shot examples — all of them are specialised forms of being clearer about what you want.`,
+    workedExample: {
+      before:
+        'Write a follow-up email to a client who has gone quiet.',
+      after:
+        'Write a follow-up email to a B2B client who has not replied in 10 days after we sent a proposal. Tone: warm but direct, no apologetic language. Length: 90 words or less. Include one specific question that makes it easy to reply with a single sentence. Do not include subject line, signature, or any "just checking in" phrases.',
+      whyItWorks:
+        'The second prompt names the relationship, the time elapsed, the tone, the length, the desired response shape, and an explicit list of clichés to avoid. The model now has almost no room to default to bland output.',
+    },
+    starterPrompt:
+      'Write a follow-up email to a B2B client who has not replied in 10 days after we sent a proposal. Tone: warm but direct, no apologetic language. Length: 90 words or less. Include one specific question that makes it easy to reply with a single sentence. Do not include subject line, signature, or any "just checking in" phrases.',
+    tryItHint:
+      'Try removing one constraint (length, tone, or the cliché ban) and run it again. Notice how the output drifts.',
+  },
+  {
+    slug: 'role-and-persona',
+    order: 2,
+    title: 'Role and persona',
+    summary:
+      'Telling the model who it is, and who it is talking to, narrows the universe of possible responses to the one you actually want.',
+    learningGoals: [
+      'Distinguish a useful role prompt from decorative role-play',
+      'Layer audience with role for sharper output',
+      'Avoid role prompts that contradict the task',
+    ],
+    concept: `Role prompting is the second lever after clear instructions. Done well, it shifts the model into a specific voice, vocabulary, and set of priors. Done badly, it adds words without changing anything.
+
+A role prompt works when it carries information the model would otherwise have to guess. "You are a senior procurement officer reviewing a tender response" tells the model what to scrutinise, what jargon is acceptable, and what counts as a red flag. "You are a helpful assistant" tells it nothing it did not already assume.
+
+The most useful role prompts pair a role with an audience. "You are a tax accountant explaining VAT registration to a first-time freelancer" works because it sets both the expertise and the level of pitch. The model now knows to avoid technical shorthand without dumbing the content down.
+
+Three things to watch for. First, do not stack roles. A prompt that says "you are a CEO, a copywriter, and a developer" forces the model to average across three voices and produces something none of them would write. Pick one. Second, make sure the role matches the task. Asking "you are a poet" to write tax advice will produce flowery tax advice, which is not what anyone wanted. Third, role prompts decay. After a few turns of conversation the role drifts; if it matters, restate it.
+
+When role prompting fails, the fix is almost always to add what the role should be doing, not to add another role. "You are a marketing strategist" plus "your job in this conversation is to challenge weak positioning claims with one direct question per claim" is far more useful than a longer character sketch.`,
+    workedExample: {
+      before:
+        'Critique this landing page headline: "We help businesses grow with AI."',
+      after:
+        'You are a senior B2B copy director reviewing landing page headlines for a SaaS startup. Your job is to flag vague claims and ask one sharp question that would force the founder to make the headline more specific. Critique this headline: "We help businesses grow with AI." Output: one sentence on what is vague, then one direct question. No reassurance, no praise.',
+      whyItWorks:
+        'The role narrows vocabulary and standards. The audience (the founder) sets the pitch. The output format prevents the model from softening the critique with hedging language.',
+    },
+    starterPrompt:
+      'You are a senior B2B copy director reviewing landing page headlines for a SaaS startup. Your job is to flag vague claims and ask one sharp question that would force the founder to make the headline more specific. Critique this headline: "We help businesses grow with AI." Output: one sentence on what is vague, then one direct question. No reassurance, no praise.',
+    tryItHint:
+      'Swap the role to "supportive marketing coach" and run it again. Same task, very different output — that is the role doing work.',
+  },
+  {
+    slug: 'structured-output',
+    order: 3,
+    title: 'Structured output',
+    summary:
+      'When you need to use AI output downstream — in a spreadsheet, a form, another prompt — ask for it in a structure, not prose.',
+    learningGoals: [
+      'Pick a structure (JSON, markdown table, bulleted fields) that matches the downstream use',
+      'Lock the shape so the model cannot improvise extra fields',
+      'Recover from malformed output without re-running the whole prompt',
+    ],
+    concept: `If you are pasting AI output back into a tool — a CRM, a spreadsheet, another prompt — prose is the wrong format. You are forcing yourself to do parsing work that the model could have done for you. Structured output solves this.
+
+The first decision is the shape. JSON works when the consumer is another script or AI step. A markdown table works when the consumer is you, scanning a page. Numbered bullets with labelled fields work when the structure is shallow and you want the model to keep its reasoning visible. Pick the lightest structure that survives the use case.
+
+The second decision is the schema. State every field name, every type, and what to do when a field is unknown. "Return a JSON object with keys title (string), audience (string), priority (one of: high, medium, low), and rationale (string, max 30 words). If priority cannot be determined, return medium." That last sentence prevents the model from inventing a fourth priority value or leaving the field blank.
+
+The third decision is what happens at the boundaries. Models love to wrap structured output in conversational scaffolding ("Sure, here is the JSON you asked for!"). Tell them not to. "Return only the JSON object. No preamble, no markdown code fences, no closing remarks." When you are going to parse the output, every extra character is a parsing bug waiting to happen.
+
+When structured output goes wrong, it is almost always because the schema was implicit. The fix is to make it explicit: list the fields, list the allowed values, list the formatting rule for the response wrapper. If you find yourself writing a regex to clean the output, the prompt is doing too little work.`,
+    workedExample: {
+      before:
+        'Summarise this customer support ticket and tell me how urgent it is.',
+      after:
+        'Summarise the customer support ticket below. Return only a JSON object with these keys: summary (string, max 25 words), category (one of: billing, bug, feature_request, account_access, other), urgency (one of: low, medium, high), suggested_owner (one of: support, engineering, sales). No preamble, no markdown fences.\n\nTicket: [paste ticket text here]',
+      whyItWorks:
+        'Every consumer of this output — a triage script, a dashboard — can rely on the same shape. The enum values prevent the model from inventing a new category. The "no preamble" rule prevents the response from breaking a JSON parser.',
+    },
+    starterPrompt:
+      'Summarise the customer support ticket below. Return only a JSON object with these keys: summary (string, max 25 words), category (one of: billing, bug, feature_request, account_access, other), urgency (one of: low, medium, high), suggested_owner (one of: support, engineering, sales). No preamble, no markdown fences.\n\nTicket: Customer reports that the export button on the reporting dashboard has been failing for two days. They have a board meeting tomorrow and need the data tonight. They have already tried two browsers.',
+    tryItHint:
+      'Remove the "no preamble" rule and run it again. See how the model adds conversational wrapper text that would break a parser.',
+  },
+]
+
+export const DEFERRED_MODULES = [
+  { slug: 'few-shot-examples', title: 'Few-shot examples' },
+  { slug: 'chain-of-thought', title: 'Chain of thought' },
+  { slug: 'system-and-user-composition', title: 'System and user composition' },
+]
+
+export function getModuleBySlug(slug) {
+  return LEARN_MODULES.find(m => m.slug === slug) || null
+}
+
+export function getAllModuleSlugs() {
+  return LEARN_MODULES.map(m => m.slug)
+}

--- a/lib/learn/budget.js
+++ b/lib/learn/budget.js
@@ -1,0 +1,41 @@
+// Soft daily-spend telemetry for /learn Claude calls.
+// In-memory only — resets on cold start. Treat as a best-effort alarm,
+// not a hard cap. Server logs warn when exceeded so Bryan can spot bursts.
+
+const DAILY_SPEND_ALERT_USD = 1.5
+
+// Haiku 4.5 pricing (per 1M tokens): $1 input, $5 output (rough — verify in prod)
+const INPUT_USD_PER_TOKEN = 1 / 1_000_000
+const OUTPUT_USD_PER_TOKEN = 5 / 1_000_000
+
+let dayKey = ''
+let spentUsd = 0
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export function recordSpend({ inputTokens = 0, outputTokens = 0 }) {
+  const today = todayKey()
+  if (today !== dayKey) {
+    dayKey = today
+    spentUsd = 0
+  }
+
+  const callUsd = inputTokens * INPUT_USD_PER_TOKEN + outputTokens * OUTPUT_USD_PER_TOKEN
+  spentUsd += callUsd
+
+  if (spentUsd > DAILY_SPEND_ALERT_USD) {
+    // Visible in Netlify function logs. Best-effort signal — not a hard stop.
+    console.warn(
+      `[learn-budget] daily spend ${spentUsd.toFixed(4)} USD exceeds alert threshold ${DAILY_SPEND_ALERT_USD} USD (day=${today})`
+    )
+  }
+
+  return { spentUsdToday: spentUsd, callUsd }
+}
+
+export function _resetBudgetForTesting() {
+  dayKey = ''
+  spentUsd = 0
+}

--- a/lib/learn/rateLimit.js
+++ b/lib/learn/rateLimit.js
@@ -1,0 +1,44 @@
+import { createHash } from 'crypto'
+
+const store = new Map()
+
+export const LEARN_DAILY_MAX = 20
+export const LEARN_WINDOW_MS = 24 * 60 * 60 * 1000
+
+function getIp(req) {
+  const fwd = req.headers['x-forwarded-for']
+  if (fwd) return fwd.split(',')[0].trim()
+  return req.headers['x-nf-client-connection-ip'] || req.socket?.remoteAddress || 'unknown'
+}
+
+function hashIp(ip) {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 16)
+}
+
+export function checkLearnRateLimit(req, { max = LEARN_DAILY_MAX, windowMs = LEARN_WINDOW_MS } = {}) {
+  const key = hashIp(getIp(req))
+  const now = Date.now()
+  const windowStart = now - windowMs
+
+  const prev = store.get(key) || []
+  const recent = prev.filter(t => t > windowStart)
+
+  if (recent.length >= max) {
+    return { allowed: false, remaining: 0, retryAfterSec: Math.ceil(windowMs / 1000) }
+  }
+
+  recent.push(now)
+  store.set(key, recent)
+
+  if (store.size > 10000) {
+    for (const [k, times] of store.entries()) {
+      if (!times.some(t => t > windowStart)) store.delete(k)
+    }
+  }
+
+  return { allowed: true, remaining: max - recent.length, retryAfterSec: 0 }
+}
+
+export function _resetLearnStoreForTesting() {
+  store.clear()
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "promptwritingstudio-next",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.30.1",
         "@netlify/plugin-nextjs": "^5.11.1",
         "handlebars": "^4.7.8",
         "next": "^13.4.7",
@@ -34,6 +35,36 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.30.1.tgz",
+      "integrity": "sha512-nuKvp7wOIz6BFei8WrTdhmSsx5mwnArYyJgh4+vYu3V4J0Ltb8Xm3odPm51n1aSI0XxNCrDl7O88cxCtUdAkaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1443,11 +1474,19 @@
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1473,6 +1512,30 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -1553,6 +1616,12 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -1811,6 +1880,19 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2105,6 +2187,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2314,6 +2408,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2347,6 +2450,20 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2392,6 +2509,51 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2424,6 +2586,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -2584,6 +2755,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2624,7 +2830,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2650,6 +2855,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2658,6 +2887,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2713,6 +2955,18 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2750,11 +3004,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2778,6 +3058,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/import-local": {
@@ -3900,6 +4189,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3929,6 +4227,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -3980,7 +4299,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4098,6 +4416,46 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -5293,6 +5651,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -5346,7 +5710,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5423,6 +5786,31 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.30.1",
     "@netlify/plugin-nextjs": "^5.11.1",
     "handlebars": "^4.7.8",
     "next": "^13.4.7",

--- a/pages/api/learn/run.js
+++ b/pages/api/learn/run.js
@@ -1,0 +1,90 @@
+// pages/api/learn/run.js
+// Server-side Claude call for the /learn try-it panels.
+// Haiku model, capped output tokens, per-IP daily rate limit, spend telemetry.
+
+import Anthropic from '@anthropic-ai/sdk'
+import { checkLearnRateLimit, LEARN_DAILY_MAX } from '../../../lib/learn/rateLimit'
+import { recordSpend } from '../../../lib/learn/budget'
+import { getModuleBySlug } from '../../../data/learn/modules'
+
+const MAX_OUTPUT_TOKENS = 500
+const MAX_PROMPT_CHARS = 8000
+const MODEL = 'claude-haiku-4-5'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { prompt, moduleSlug } = req.body || {}
+
+  if (typeof prompt !== 'string' || prompt.trim().length === 0) {
+    return res.status(400).json({ error: 'prompt is required' })
+  }
+  if (prompt.length > MAX_PROMPT_CHARS) {
+    return res.status(400).json({ error: `prompt exceeds ${MAX_PROMPT_CHARS} characters` })
+  }
+  if (moduleSlug && !getModuleBySlug(moduleSlug)) {
+    return res.status(400).json({ error: 'unknown moduleSlug' })
+  }
+
+  const { allowed, remaining, retryAfterSec } = checkLearnRateLimit(req)
+  if (!allowed) {
+    res.setHeader('Retry-After', String(retryAfterSec))
+    return res.status(429).json({
+      error: `Daily limit of ${LEARN_DAILY_MAX} runs reached. Try again tomorrow.`,
+      limit: LEARN_DAILY_MAX,
+      remaining: 0,
+    })
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Server is not configured for AI runs.' })
+  }
+
+  try {
+    const client = new Anthropic({ apiKey })
+
+    const message = await client.messages.create({
+      model: MODEL,
+      max_tokens: MAX_OUTPUT_TOKENS,
+      messages: [{ role: 'user', content: prompt }],
+    })
+
+    const output = (message.content || [])
+      .filter(block => block.type === 'text')
+      .map(block => block.text)
+      .join('\n')
+      .trim()
+
+    const inputTokens = message.usage?.input_tokens || 0
+    const outputTokens = message.usage?.output_tokens || 0
+    const { spentUsdToday, callUsd } = recordSpend({ inputTokens, outputTokens })
+
+    return res.status(200).json({
+      output,
+      stopReason: message.stop_reason || null,
+      model: MODEL,
+      moduleSlug: moduleSlug || null,
+      remaining,
+      limit: LEARN_DAILY_MAX,
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        call_usd: Number(callUsd.toFixed(6)),
+        spent_usd_today: Number(spentUsdToday.toFixed(6)),
+      },
+    })
+  } catch (err) {
+    const status = typeof err?.status === 'number' ? err.status : 500
+    const message =
+      status === 429
+        ? 'Upstream model is rate-limited. Try again in a few seconds.'
+        : 'Run failed. Try a shorter prompt or try again in a moment.'
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('[learn/run] error', err)
+    }
+    return res.status(status === 429 ? 429 : 500).json({ error: message })
+  }
+}

--- a/pages/learn/[module].js
+++ b/pages/learn/[module].js
@@ -1,0 +1,169 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import TryItPanel from '../../components/learn/TryItPanel'
+import {
+  LEARN_MODULES,
+  getAllModuleSlugs,
+  getModuleBySlug,
+} from '../../data/learn/modules'
+
+const SITE_URL = 'https://promptwritingstudio.com'
+
+export async function getStaticPaths() {
+  return {
+    paths: getAllModuleSlugs().map(slug => ({ params: { module: slug } })),
+    fallback: false,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const mod = getModuleBySlug(params.module)
+  if (!mod) {
+    return { notFound: true }
+  }
+  const order = LEARN_MODULES.findIndex(m => m.slug === mod.slug)
+  return {
+    props: {
+      mod,
+      prev: order > 0 ? LEARN_MODULES[order - 1] : null,
+      next: order < LEARN_MODULES.length - 1 ? LEARN_MODULES[order + 1] : null,
+    },
+  }
+}
+
+export default function LearnModulePage({ mod, prev, next }) {
+  const pageUrl = `${SITE_URL}/learn/${mod.slug}`
+
+  const learningResourceSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'LearningResource',
+    name: mod.title,
+    description: mod.summary,
+    url: pageUrl,
+    learningResourceType: 'Lesson',
+    teaches: mod.learningGoals,
+    isPartOf: {
+      '@type': 'Course',
+      name: 'Interactive prompt-engineering modules',
+      url: `${SITE_URL}/learn`,
+    },
+  }
+
+  return (
+    <Layout
+      title={`${mod.title} — Prompt-engineering modules | PromptWritingStudio`}
+      description={mod.summary}
+      canonicalUrl={pageUrl}
+    >
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(learningResourceSchema) }}
+        />
+      </Head>
+
+      <article className="max-w-3xl mx-auto px-4 py-16 md:py-24">
+        <nav className="text-sm text-gray-500 mb-6">
+          <Link href="/learn" className="hover:text-[#1A1A1A] underline">
+            All modules
+          </Link>
+          <span className="mx-2">/</span>
+          <span>Module {mod.order}</span>
+        </nav>
+
+        <header className="mb-10">
+          <h1 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-3">
+            {mod.title}
+          </h1>
+          <p className="text-lg text-[#333333]">{mod.summary}</p>
+        </header>
+
+        <section className="mb-10">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">
+            What you will learn
+          </h2>
+          <ul className="list-disc pl-5 space-y-1 text-[#333333]">
+            {mod.learningGoals.map(g => (
+              <li key={g}>{g}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="mb-12 prose prose-neutral max-w-none">
+          <h2 className="text-2xl font-semibold text-[#1A1A1A] mb-4">Concept</h2>
+          {mod.concept.split(/\n\n+/).map((para, i) => (
+            <p key={i} className="text-[#333333] leading-relaxed mb-4">
+              {para}
+            </p>
+          ))}
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-2xl font-semibold text-[#1A1A1A] mb-4">Worked example</h2>
+
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">
+                Before
+              </h3>
+              <pre className="whitespace-pre-wrap text-sm bg-[#F9F9F9] border border-[#E5E5E5] rounded-md p-4 text-[#333333]">
+                {mod.workedExample.before}
+              </pre>
+            </div>
+
+            <div>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">
+                After
+              </h3>
+              <pre className="whitespace-pre-wrap text-sm bg-[#F9F9F9] border border-[#E5E5E5] rounded-md p-4 text-[#333333]">
+                {mod.workedExample.after}
+              </pre>
+            </div>
+
+            <div className="text-sm text-[#333333] bg-yellow-50 border border-yellow-200 rounded-md p-4">
+              <strong className="block text-[#1A1A1A] mb-1">Why it works</strong>
+              {mod.workedExample.whyItWorks}
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-12">
+          <TryItPanel
+            moduleSlug={mod.slug}
+            starterPrompt={mod.starterPrompt}
+            hint={mod.tryItHint}
+          />
+        </section>
+
+        <nav className="flex flex-col sm:flex-row gap-3 sm:justify-between border-t border-[#E5E5E5] pt-6">
+          {prev ? (
+            <Link
+              href={`/learn/${prev.slug}`}
+              className="text-sm text-[#1A1A1A] underline hover:no-underline"
+            >
+              &larr; {prev.title}
+            </Link>
+          ) : (
+            <span />
+          )}
+          {next ? (
+            <Link
+              href={`/learn/${next.slug}`}
+              className="text-sm text-[#1A1A1A] underline hover:no-underline sm:text-right"
+            >
+              {next.title} &rarr;
+            </Link>
+          ) : (
+            <Link
+              href="/learn"
+              className="text-sm text-[#1A1A1A] underline hover:no-underline sm:text-right"
+            >
+              Back to all modules
+            </Link>
+          )}
+        </nav>
+      </article>
+    </Layout>
+  )
+}

--- a/pages/learn/[module].js
+++ b/pages/learn/[module].js
@@ -52,7 +52,7 @@ export default function LearnModulePage({ mod, prev, next }) {
 
   return (
     <Layout
-      title={`${mod.title} — Prompt-engineering modules | PromptWritingStudio`}
+      title={`${mod.title} | Prompt-engineering modules | PromptWritingStudio`}
       description={mod.summary}
       canonicalUrl={pageUrl}
     >

--- a/pages/learn/index.js
+++ b/pages/learn/index.js
@@ -1,0 +1,101 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import { LEARN_MODULES, DEFERRED_MODULES } from '../../data/learn/modules'
+
+const SITE_URL = 'https://promptwritingstudio.com'
+const PAGE_URL = `${SITE_URL}/learn`
+
+export default function LearnIndexPage() {
+  const courseSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Course',
+    name: 'Interactive prompt-engineering modules',
+    description:
+      'Step through structured prompt patterns, run them live against Claude, and iterate. No code required.',
+    provider: {
+      '@type': 'Organization',
+      name: 'PromptWritingStudio',
+      url: SITE_URL,
+    },
+    hasCourseInstance: LEARN_MODULES.map(m => ({
+      '@type': 'CourseInstance',
+      name: m.title,
+      url: `${PAGE_URL}/${m.slug}`,
+      courseMode: 'online',
+    })),
+  }
+
+  return (
+    <Layout
+      title="Interactive prompt-engineering modules | PromptWritingStudio"
+      description="Step through structured prompt patterns, run them live against Claude, and iterate. Non-technical, free, no signup."
+      canonicalUrl={PAGE_URL}
+    >
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(courseSchema) }}
+        />
+      </Head>
+
+      <div className="max-w-4xl mx-auto px-4 py-16 md:py-24">
+        <header className="mb-12">
+          <h1 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-3">
+            Learn prompt engineering by doing
+          </h1>
+          <p className="text-lg text-[#333333] max-w-2xl">
+            Short modules on the patterns that move AI output from generic to useful. Each module has
+            a concept, a worked example, and a try-it panel that runs your prompt against Claude
+            live. No code. No signup. Twenty runs a day per browser.
+          </p>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-xl font-semibold text-[#1A1A1A] mb-4">Available now</h2>
+          <ul className="space-y-4">
+            {LEARN_MODULES.map(m => (
+              <li
+                key={m.slug}
+                className="border border-[#E5E5E5] rounded-lg p-5 hover:border-[#1A1A1A] transition-colors bg-white"
+              >
+                <Link href={`/learn/${m.slug}`} className="block">
+                  <div className="flex items-baseline gap-3 mb-1">
+                    <span className="text-xs font-mono text-gray-500">
+                      Module {m.order}
+                    </span>
+                    <h3 className="text-lg font-semibold text-[#1A1A1A]">{m.title}</h3>
+                  </div>
+                  <p className="text-sm text-[#333333]">{m.summary}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {DEFERRED_MODULES.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-xl font-semibold text-[#1A1A1A] mb-3">Coming soon</h2>
+            <ul className="text-sm text-gray-600 space-y-1">
+              {DEFERRED_MODULES.map(m => (
+                <li key={m.slug}>{m.title}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section className="border-t border-[#E5E5E5] pt-8 mt-8 text-sm text-gray-600">
+          <p className="mb-2">
+            <strong className="text-[#1A1A1A]">How runs work.</strong> Each try-it panel sends your
+            prompt to a Claude model running on our server. We do not store your prompts or outputs.
+            Saved variants live in your browser only.
+          </p>
+          <p>
+            <strong className="text-[#1A1A1A]">Limits.</strong> 20 runs per browser per day. Output
+            capped at 500 tokens to keep costs predictable.
+          </p>
+        </section>
+      </div>
+    </Layout>
+  )
+}

--- a/scripts/test-learn-rate-limit.js
+++ b/scripts/test-learn-rate-limit.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Verifies the per-IP daily rate limit blocks the 21st call.
+// Run directly: node scripts/test-learn-rate-limit.js
+
+const { checkLearnRateLimit, LEARN_DAILY_MAX, _resetLearnStoreForTesting } =
+  require('../lib/learn/rateLimit')
+
+_resetLearnStoreForTesting()
+
+const fakeReq = {
+  headers: { 'x-forwarded-for': '203.0.113.7' },
+  socket: { remoteAddress: '203.0.113.7' },
+}
+
+let lastResult
+for (let i = 1; i <= LEARN_DAILY_MAX; i++) {
+  lastResult = checkLearnRateLimit(fakeReq)
+  if (!lastResult.allowed) {
+    console.error(`UNEXPECTED: call ${i} was blocked. Result:`, lastResult)
+    process.exit(1)
+  }
+}
+
+const blocked = checkLearnRateLimit(fakeReq)
+if (blocked.allowed) {
+  console.error(`UNEXPECTED: call ${LEARN_DAILY_MAX + 1} was allowed. Result:`, blocked)
+  process.exit(1)
+}
+
+console.log(
+  `OK: calls 1..${LEARN_DAILY_MAX} allowed, call ${LEARN_DAILY_MAX + 1} blocked (remaining=${blocked.remaining}, retryAfterSec=${blocked.retryAfterSec}).`
+)
+process.exit(0)


### PR DESCRIPTION
## Summary

Ships **PRD-P-LEARN-001** — an interactive prompt-engineering resource at `/learn`. Each module pairs a concept explainer with a worked example and a try-it panel that runs the user's prompt against Claude Haiku server-side. No signup, no code, anonymous use.

**Files**: 10 (well under 20-file ceiling). **Lines**: ~1,212 added (within 1,500 line ceiling).

## What's in this PR

- 3 modules live at `/learn/clear-instructions`, `/learn/role-and-persona`, `/learn/structured-output`
- Index page at `/learn` listing available + deferred modules with Course JSON-LD
- Server endpoint `POST /api/learn/run` calling Claude Haiku 4.5 (max 500 output tokens)
- Per-IP rate limit: 20 runs / 24h sliding window (in-memory, hashed IPs)
- Daily spend telemetry alert at \$1.50/day (logged only, not a hard cap — Haiku at 500 tokens is ~\$0.0025 per call, so 20 calls/IP/day stays cheap)
- LocalStorage-only variant persistence (keyed by module slug)
- LearningResource / Course JSON-LD for SEO
- Rate-limit test script (\`node scripts/test-learn-rate-limit.js\` — passes)

## Deviations from PRD — please review

1. **New env var required**: \`ANTHROPIC_API_KEY\` (plain, not base64). Existing PWS code uses \`CLAUDE_API_KEY\` (base64) — I followed the PRD literally and used a separate var so this can ship independent of the old chat endpoint. **You must set \`ANTHROPIC_API_KEY\` in Netlify before /learn works in prod.**
2. **Scope cut 6 → 3 modules**: shipped clear-instructions, role-and-persona, structured-output. The remaining three (few-shot, chain-of-thought, system+user composition) are surfaced as "Coming soon" on the index and deferred to **P-LEARN-001b**. Reason: the XL ceiling guidance in the brief.
3. **Persistence is localStorage-only**: PRD hinted at Netlify Blobs or a JSON file. Netlify Functions have a read-only FS (and \`/tmp\` is per-invocation), so any file approach is broken in prod. For v1 anonymous use, localStorage is the right call — flagged here so we don't get surprised when users say "my variants disappeared on another browser". If we want cross-device, we add Netlify Blobs in v2.
4. **Rate-limit store is in-memory**: same Netlify-FS reason. Cold starts reset the counter. Acceptable for v1 abuse prevention; if traffic justifies it, swap to Blobs or Upstash.
5. **No PR-body sample run**: needs the live env var, so I haven't included a real Claude response. Manual smoke-test after Netlify deploy: visit \`/learn/clear-instructions\`, hit Run, confirm output renders + "runs left today" decrements.

## Cost guardrails (where to find them)

- Model: \`claude-haiku-4-5\` — \`pages/api/learn/run.js:43\`
- Max output tokens: 500 — \`pages/api/learn/run.js:44\`
- Per-IP daily cap: 20 runs — \`lib/learn/rateLimit.js\` (\`LEARN_DAILY_MAX\`)
- Daily spend alert: \$1.50 — \`lib/learn/budget.js\` (\`DAILY_SPEND_ALERT_USD\`)

## Test plan

- [ ] Set \`ANTHROPIC_API_KEY\` in Netlify env before merge
- [ ] After deploy, visit \`/learn\` — confirm 3 modules listed, 3 "Coming soon"
- [ ] Visit \`/learn/clear-instructions\` — Run the starter prompt, confirm Claude output renders
- [ ] Confirm "runs left today" counter decrements
- [ ] Save a variant, reload the page, confirm it persists (same browser)
- [ ] View source on \`/learn/clear-instructions\` — confirm no \`ANTHROPIC_API_KEY\` in client bundle
- [ ] Loop the Run button 21 times from one IP — 21st returns 429 with retry message

## Local checks passed

- \`npm run build\` — clean, all 3 SSG pages built, \`/api/learn/run\` lambda registered
- \`node scripts/test-learn-rate-limit.js\` — calls 1..20 allowed, call 21 blocked
- Em-dash sweep on public-facing copy (modules.js + page titles)
- Grep confirmed \`ANTHROPIC_API_KEY\` only appears in \`pages/api/learn/run.js\` (server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)