### PR TITLE
docs(PRDs): orchestrator dispatch batch 2026-05-25 (5 PRDs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 next-env.d.ts
 
 /lib/generated/prisma
+
+# Per-session worktree dirs (orchestrator dispatch isolation)
+.claude/worktrees/

--- a/docs/PRDs/PRD-P-INSIGHTS-001-model-market-share-section.md
+++ b/docs/PRDs/PRD-P-INSIGHTS-001-model-market-share-section.md
@@ -1,0 +1,63 @@
+---
+status: DRAFT
+repo: promptwritingstudio
+cluster: P-INSIGHTS (AI Insights Hub)
+date: 2026-05-25
+size: M
+model_recommendation: sonnet
+qa_corrections_2026-05-25: Framework corrected — PWS is Next.js (not Astro). Pages live at `pages/` (no `src/`). Components at `components/`. Data at `data/`. CRITICAL DUPE found: `pages/ai-models.js` already ships model comparison (Claude, GPT, Gemini, Llama, Mistral, etc) with schema + FAQs + comparison UI. Existing data at `lib/ai-models.js`. PRD reframed as EXTEND existing page with market-share + monthly snapshots, NOT new section.
+---
+
+# PRD: PWS Model market share — extend existing ai-models surface
+
+## Mission
+Extend the existing `pages/ai-models.js` surface with a market-share data layer (monthly snapshots, trend chart, sortable table) so the page evolves from "comparison reference" into "comparison + cadence-tracking surface" with month-over-month change data.
+
+## Why this matters
+The model comparison page already exists and has schema markup, FAQs, model data via `lib/ai-models.js`. The strategic wish was for a returning-cadence surface that AIO can't easily collapse. Adding market-share with monthly snapshots gives readers a reason to return + a Dataset JSON-LD wrapper for AEO attribution.
+
+This is a separate concern from API pricing (P-INSIGHTS-002) — both extend the AI Insights theme but should ship as independent merges.
+
+## Success criteria
+- Extend `pages/ai-models.js` (do NOT build a new `/ai-insights/` route — extend the existing surface)
+- Add a "Market share" section/tab on the page:
+  - Sortable table: model, vendor, market share %, change vs prior month, last snapshot date
+  - Trend chart (line) over last 12 months
+  - Methodology footnote citing data sources (OpenRouter usage stats, Hugging Face download counts, public API call estimates)
+- Monthly snapshot data file: `data/ai-models-market-share/<yyyy-mm>.json`
+- Dataset JSON-LD added to the page (existing TechArticle JSON-LD stays; Dataset is additive)
+- Last-updated date is snapshot date, not page-deploy date
+- Methodology in business language (`feedback_summaries_plain_language.md`)
+- Mobile readable on 320px
+
+## Out of scope
+- Real-time data (monthly snapshots only)
+- Predictions / forecasts
+- Speculation about *why* share moved (one-sentence factual notes OK)
+- Bryan's voice / founder commentary
+- Display ads
+- Reply CTAs (`feedback_no_reply_ctas.md`)
+- Building a new `/ai-insights/` route hierarchy — extend the existing page
+- Modifying `lib/ai-models.js` model definitions (only ADDS market-share data, doesn't alter model schema)
+
+## Acceptance tests
+- Page still renders 200 (no regression in existing FAQ, comparison, schema)
+- New market-share section renders
+- Sortable table works
+- Chart renders on mobile without overflow
+- Dataset JSON-LD validates alongside existing TechArticle schema
+- Snapshot file committed (at least one snapshot to seed)
+- Methodology section reads in business language
+
+## Implementation hints
+- Read `pages/ai-models.js` first to understand existing component structure
+- Read `lib/ai-models.js` to see model definitions
+- Chart library: check existing deps; if none, use minimal solution (CSS-only sparklines acceptable for v1)
+- Data sources: OpenRouter (usage); Hugging Face (download counts); Stack Overflow Developer Survey (annual)
+- v1 = manually committed monthly snapshots; cron automation later
+
+## Ship instructions
+- Branch: `bryancollins/prd-p-insights-001-model-share`
+- PR title: `feat(ai-models): market share extension + first snapshot`
+- PR body: link to PRD + screenshot of extended page + data source citations
+- Confirm no regression in existing ai-models.js functionality

--- a/docs/PRDs/PRD-P-INSIGHTS-002-api-pricing-caching-section.md
+++ b/docs/PRDs/PRD-P-INSIGHTS-002-api-pricing-caching-section.md
@@ -1,0 +1,59 @@
+---
+status: DRAFT
+repo: promptwritingstudio
+cluster: P-INSIGHTS (AI Insights Hub)
+date: 2026-05-25
+size: M
+model_recommendation: sonnet
+qa_corrections_2026-05-25: Framework corrected — Next.js. Pages at `pages/`, components at `components/`, data at `data/`. May overlap with `pages/ai-models.js` pricing data — PRD now scopes the unique "calculator + caching cost model" component as the differentiator, not generic pricing listing.
+---
+
+# PRD: PWS API pricing + caching benefits — calculator + tracking
+
+## Mission
+Ship an API pricing + caching cost calculator on PWS at `pages/api-pricing.js` (or `pages/ai-pricing-calculator.js` — confirm namespace) — a working calculator where a user inputs task shape (input/output tokens, cache hit ratio) and sees cost per task across all major LLM API providers, with explainer content on what caching actually saves.
+
+## Why this matters
+Generic pricing tables are commodity (and `pages/ai-models.js` likely already lists pricing). The differentiator is the CALCULATOR — input your real task shape, see real cost across providers. AIO can't easily collapse a calculator into a snippet. That's the moat.
+
+Also: caching cost models are genuinely underexplained (Anthropic prompt cache vs OpenAI automatic vs Gemini context caching) and most "API pricing" articles just show sticker prices without the caching layer.
+
+## Success criteria
+- New page: `pages/api-pricing.js` (or whichever namespace doesn't collide with existing — confirm by `ls pages/ | grep -i pric` first; if exists, extend instead)
+- Current pricing table: input $/1M tokens, output $/1M tokens, prompt-cache pricing where available, last_updated, source link to vendor pricing page
+- **Cost calculator (the differentiator)**: user inputs task shape (input tokens, output tokens, cache hit ratio) → outputs cost per task across all listed models — calculator > PDF (`feedback_calculator_over_pdf.md`)
+- Caching-benefit section: per provider, what caching actually achieves with worked example
+- Last-updated dates per row sourced from vendor pricing page
+- Dataset JSON-LD on the page
+- RSS feed for monthly pricing updates (or appended to existing PWS RSS if there is one)
+- Page reuses existing PWS Layout / Header / Footer components
+
+## Out of scope
+- Actually calling APIs (no live latency benchmarks v1)
+- Reseller / OpenRouter pricing (first-party vendor pricing only)
+- Quality / output-quality comparisons (separate page)
+- Recommending specific providers ("use Anthropic because cheap") — facts only; calculator IS the recommendation engine
+- Display ads
+- Reply CTAs
+- Duplicating `pages/ai-models.js` pricing data — if duplication arises, link rather than duplicate
+
+## Acceptance tests
+- Page renders 200
+- Cost calculator: inputs match hand calculation
+- Caching section: worked example for at least 2 providers (Anthropic + OpenAI)
+- Click each source link → vendor pricing page resolves
+- Dataset JSON-LD validates
+- Mobile (320px): calculator usable
+- No collision with existing `pages/ai-models.js` data — link to it for the broader comparison
+
+## Implementation hints
+- Pricing data: single canonical file at `data/api-pricing.json`
+- Cache cost model: Anthropic = write 1.25x, read 0.1x; OpenAI input cache = 50% of input; Gemini context cache varies — be honest about each
+- Calculator: client-side JS, no server calls
+- Component pattern: match existing PWS components in `components/` (likely React functional components)
+- Schema generator: PWS has `lib/schemaGenerator.js` — reuse
+
+## Ship instructions
+- Branch: `bryancollins/prd-p-insights-002-api-pricing`
+- PR title: `feat(insights): API pricing calculator + caching cost model`
+- PR body: link to PRD + screenshot of calculator + sample cost-comparison output + path confirmation (extended ai-models OR new page)

--- a/docs/PRDs/PRD-P-INSIGHTS-003-weekly-best-mover-email.md
+++ b/docs/PRDs/PRD-P-INSIGHTS-003-weekly-best-mover-email.md
@@ -1,0 +1,64 @@
+---
+status: DRAFT
+repo: promptwritingstudio
+cluster: P-INSIGHTS (AI Insights Hub)
+date: 2026-05-25
+size: M
+model_recommendation: sonnet
+depends_on: PWS Observatory data layer (in flight — `data/observatory/`, `lib/observatory/`, `components/observatory/`, `pages/observatory/` all exist)
+qa_corrections_2026-05-25: Framework corrected — Next.js. PWS uses Netlify Forms (not Kit) for email capture via `components/ui/EmailCapture.js`. Kit integration would be NEW work. PRD now flags this — Bryan needs to confirm: use Netlify Forms (existing), add Kit integration, or use Resend/sendgrid for transactional cron sends.
+---
+
+# PRD: PWS Observatory — Weekly best-mover email
+
+## Mission
+Ship a weekly cron + email send for "best-mover" Observatory model (the model that improved most on PWS benchmarks vs prior week), with a one-paragraph context note and a link to the Observatory page.
+
+## Why this matters
+Observatory infrastructure exists (`pages/observatory/`, `data/observatory/`, `lib/observatory/`, `components/observatory/`, `scripts/observatory/`, `__tests__/api/observatory/`). The weekly email turns it from a static benchmark surface into a returning-cadence touchpoint. Value-only email — NOT a 5-email sequence, NOT a course funnel, NOT a paid-tier upsell.
+
+## Success criteria
+- Cron job (Netlify scheduled function OR GitHub Action — match whichever pattern PWS already uses):
+  - Reads latest Observatory snapshot vs prior week
+  - Identifies model with largest absolute improvement on the headline benchmark
+  - Generates one-paragraph context note (template-driven, deterministic — no LLM in the weekly loop per `feedback_automated_content_accuracy_over_polish.md`)
+  - Builds email (plain text + simple HTML)
+  - Sends to subscriber segment
+- **Subscriber list mechanism**: PWS currently uses Netlify Forms for email capture (no Kit integration found in PWS repo). For the weekly send, options:
+  - Option A: Add Kit integration (new dep, new subscriber sync flow)
+  - Option B: Use Resend transactional with subscriber list maintained in PWS (simpler, no third party)
+  - Option C: Reuse Bryan's existing Kit account via Kit MCP (build-time read, batch send via Kit API)
+  - **PRD requires Bryan to pick the path before implementation can fire**. Default if unspecified: Option B (Resend + local subscriber list) for minimum new dependency.
+- Skip logic: no significant mover (all changes < threshold) → no email sent
+- Subject line: "<Model> moved the most this week on the AI Observatory"
+- CTA: single link to Observatory page; no "reply with feedback" (`feedback_no_reply_ctas.md`)
+- Unsubscribe link works
+- Send tracking via whichever channel chosen
+
+## Out of scope
+- A 5-email sequence
+- Paid-tier upsell (PWS paid tier deferred)
+- Cross-channel syndication (no auto-LinkedIn/Substack)
+- Personalised "your favourite model moved" emails
+- Reply CTAs
+
+## Acceptance tests
+- Cron runs end-to-end in test mode with last week's data → email rendered (not sent)
+- Skip logic: feed cron a no-mover scenario → no email built
+- Email renders in Gmail web + Apple Mail mobile (test sends to bryan@becomeawritertoday.com)
+- Unsubscribe link works
+- Subject line under 60 chars
+- Subscriber list mechanism decision documented in PR body
+
+## Implementation hints
+- Read `lib/observatory/loadRuns.js` and `data/observatory/` to understand snapshot shape
+- Read existing scripts in `scripts/observatory/` for cron pattern
+- For Resend (Option B): add `resend` dep, env var `RESEND_API_KEY` (confirm if Bryan has separate from Tenderwatch's)
+- For Kit MCP (Option C): batch reads + sends via existing Kit account; no new deps in PWS repo
+- Significance threshold: pick reasonable default (>2 pp on headline benchmark), config-driven
+
+## Ship instructions
+- Branch: `bryancollins/prd-p-insights-003-best-mover-email`
+- PR title: `feat(observatory): weekly best-mover email cron`
+- PR body: link to PRD + sample rendered email + subscriber list mechanism chosen + Bryan-decision flag if Option A vs B vs C
+- DO NOT ship until Observatory data layer is confirmed stable

--- a/docs/PRDs/PRD-P-LEARN-001-interactive-prompt-engineering-resource.md
+++ b/docs/PRDs/PRD-P-LEARN-001-interactive-prompt-engineering-resource.md
@@ -1,0 +1,72 @@
+---
+status: DRAFT
+repo: promptwritingstudio
+cluster: P-LEARN (AI literacy track)
+date: 2026-05-25
+size: XL
+model_recommendation: opus
+qa_corrections_2026-05-25: Framework corrected — Next.js (pages at `pages/`, API routes at `pages/api/`). `@anthropic-ai/sdk` NOT in PWS package.json — PRD now scopes adding it as part of work. API routes pattern exists at `pages/api/ai/` and `pages/api/observatory/`.
+---
+
+# PRD: Interactive prompt-engineering learning resource
+
+## Mission
+Ship a non-technical, interactive prompt-engineering learning resource on PWS — the "Codecademy for prompt engineering" equivalent — where a working professional can step through structured prompt patterns, run them live against a Claude model via PWS server-side, see output, iterate. Without writing code.
+
+## Why this matters
+Bryan surfaced this as a recurring wish across multiple framings. The highest-value PWS PRD because:
+- AIO-resistant (interactive > read-once)
+- Recurring traffic (people return to practice)
+- Genuinely differentiated (most prompt-engineering content is read-only)
+- Compatible with no-funnel constraint (value content, not sales sequence)
+
+## Success criteria
+- Resource at `pages/learn/` (or `pages/prompt-craft/` — confirm namespace; create new directory under pages)
+- Module structure: at least 6 modules at `pages/learn/[module].js` covering:
+  - Clear instructions, role/persona, structured output, few-shot patterns, chain-of-thought, system + user composition
+- Each module:
+  - Concept explainer (200-400 words, business-language)
+  - Worked example showing before/after prompt
+  - Interactive try-it: textarea + run button → POST to `/api/learn/run` → calls Claude (Haiku for cost — `feedback_personal_cli_cost_order.md`) → shows output
+  - Rate-limit guard: per-IP or per-session quota (e.g. 20 runs/day)
+  - "Save your variant" button: saves to anonymous-token store (Netlify Blobs or simple JSON)
+- **Add `@anthropic-ai/sdk` to PWS dependencies** (not currently present — verified)
+- Anthropic API key from env: `process.env.ANTHROPIC_API_KEY` (server-side only via Next.js API route)
+- Cost guardrails: max output tokens conservative (500), Haiku model, daily spend cap (alert if exceeded)
+- Progress tracking: anonymous token tracks completed modules (no auth v1)
+- Mobile: textareas usable
+
+## Out of scope
+- User accounts / passwords (anonymous token only v1)
+- Paid tier (PWS paid tier deferred)
+- 5-email upsell triggered by completion (banned)
+- "Submit your prompt for review" with Bryan-as-reviewer CTA (coaching-funnel territory — `feedback_no_reply_ctas.md`)
+- Gemini / OpenAI integration (Claude only v1 for cost control)
+- Leaderboard / public sharing of variants (privacy)
+- Bryan's voice / founder anecdote in module content
+
+## Acceptance tests
+- `/learn/` → module list renders
+- Click module 1 → concept renders, try-it textarea works, run button calls Claude, output appears
+- Run 20 times in succession → 21st returns rate-limit response
+- Save variant → reload page → variant persisted
+- Mobile (320px): textarea usable, output readable
+- Cost-guardrail: normal session for 1 hour → spend stays under expected budget
+- Anthropic API key NOT exposed client-side (view source check)
+- `npm install` adds `@anthropic-ai/sdk` cleanly
+- `next build` passes
+
+## Implementation hints
+- Read existing API route pattern: `pages/api/ai/*` and `pages/api/observatory/*` — match
+- API route: `pages/api/learn/run.js` (handles POST → Claude call → response)
+- Anonymous token: cookie + localStorage; persistence via Netlify Blobs (Tenders uses `@netlify/blobs` — would need to add to PWS as new dep, OR use simple JSON file)
+- Rate limit: existing `lib/observatory/rateLimit.js` may be reusable — check
+- Module content: MDX or React component per module
+- "Run" button: POSTs prompt + module ID to API route; server returns model output
+
+## Ship instructions
+- Branch: `bryancollins/prd-p-learn-001-interactive-resource`
+- PR title: `feat(learn): interactive prompt-engineering resource v1 (6 modules + Claude)`
+- PR body: link to PRD + module list + sample run + cost-guardrail evidence + new dep confirmation
+- XL — if scope ceiling hits, ship 3 modules + infrastructure in this PR; remaining in P-LEARN-001b
+- Watch budget: any unusual cost burst → DRAFT PR + flag immediately

--- a/docs/PRDs/PRD-P-LEARN-002-ai-workforce-defensive-literacy-track.md
+++ b/docs/PRDs/PRD-P-LEARN-002-ai-workforce-defensive-literacy-track.md
@@ -1,0 +1,70 @@
+---
+status: DRAFT
+repo: promptwritingstudio
+cluster: P-LEARN (AI literacy track)
+date: 2026-05-25
+size: L
+model_recommendation: sonnet
+related: V-IRISH-004 (Vendors AI tools cluster — distinct but complementary)
+qa_corrections_2026-05-25: Framework corrected — Next.js. Pages at `pages/`, components at `components/`. Layout component at `components/layout/Layout` (verified from `ai-models.js`). Email capture is Netlify Forms via `components/ui/EmailCapture.js` (not Kit).
+---
+
+# PRD: AI workforce defensive-literacy track
+
+## Mission
+Ship a structured AI literacy track on PWS targeted at working professionals whose jobs face AI disruption (40%-of-Irish-jobs-impacted framing): where the human/AI boundary is, how to audit your role, defensive skills to build, tools worth learning, how to position for the AI-augmented version of your role.
+
+## Why this matters
+PWS sits across both ambitious AI-using professionals AND professionals scared of being displaced. The interactive resource (P-LEARN-001) serves the first cohort. This track serves the second. Defensive AI literacy is a real, growing audience.
+
+PWS-side of the AI-jobs theme. Vendors.ie side is V-IRISH-004 (AI tools for Irish workers). Personal-essay side is X-AI-JOBS-NOTES. Three independent surfaces, one coherent theme.
+
+## Success criteria
+- Track at `pages/ai-workforce/` or `pages/protect-your-job/` — confirm naming with `ls pages/` first (avoid collision)
+- 5-7 modules (NOT lessons with 5-email upsell — `feedback_no_reply_ctas.md`):
+  - What AI can and can't do (capability boundaries, date-stamped)
+  - Audit your role — task-level AI capability
+  - AI-augmented versions of common roles (accountant, marketer, writer, customer support, designer)
+  - Defensive skill stack — judgement, communication, taste — why they compound
+  - Tool-of-the-month — practical workflow (Otter for meetings, Claude for drafting) — anti-hype framing
+  - Conversations with your employer — positioning AI use without automating yourself out
+  - When to retrain, when to switch, when to stay
+- Each module: business-language explainer + 1-2 worked examples + linked further-reading (no in-line course-upsell CTAs)
+- Cross-link: tool mentions → Vendors.ie vendor profile (V-IRISH-004 cluster) where applicable; stub if V-IRISH-004 not yet shipped
+- Cross-link: relevant modules → P-LEARN-001 for hands-on practice
+- No "buy our course to unlock" — track is fully free
+- Last-updated date per module (capability boundaries change fast)
+- Optional opt-in: monthly "what changed in AI capability" email via existing `EmailCapture.js` Netlify Forms component — single new form, granular opt-in/out
+
+## Out of scope
+- Paid tier locked behind the track
+- 5-email "AI threat assessment" sequence — banned
+- Bryan's voice / founder anecdote in module text (`feedback_byline_vs_personal_brand.md`)
+- Fear-framing or doom prose (defensive-literacy = empower, not panic)
+- AI-replacement-for-developers content (non-developer professionals)
+- Predictions about exact job-loss percentages (cite ranges from authoritative sources only)
+- Cross-tagging with PWS course funnel (course funnel is sunset)
+- Building a new email-list infrastructure — use existing `components/ui/EmailCapture.js` Netlify Forms pattern
+
+## Acceptance tests
+- All 5-7 modules render 200
+- Each under 1500 words, scannable headings, mobile readable
+- Cross-links to Vendors cluster resolve (stub with TODO + open issue if V-IRISH-004 not yet shipped)
+- Cross-links to P-LEARN-001 resolve
+- Netlify Forms email capture works (test submission)
+- No emoji unless requested
+- Em-dash sweep on public-facing content (`feedback_em_dash_scope.md`)
+- `next build` passes
+
+## Implementation hints
+- Content format: MDX or page-per-module (React component)
+- Tone reference: business-language, plain English (`feedback_summaries_plain_language.md`)
+- Layout: reuse `components/layout/Layout`
+- Email capture: `<EmailCapture formName="ai-workforce-monthly" source="ai-workforce" />` (per existing component API)
+- Sources for capability boundaries: Anthropic/OpenAI/Google published model cards; Stanford HAI; AI Index Report
+- Sources for job-impact ranges: McKinsey, OECD, Goldman Sachs — cite ranges, not point estimates
+
+## Ship instructions
+- Branch: `bryancollins/prd-p-learn-002-workforce-track`
+- PR title: `feat(learn): AI workforce defensive-literacy track (5-7 modules)`
+- PR body: link to PRD + module list + cross-link audit + form name used


### PR DESCRIPTION
Filing the 5 PRDs drafted during the 2026-05-25 multi-batch orchestrator dispatch session.

Each PRD has been:
- QA'd against actual repo state (paths verified, schema fields confirmed, framework correctness checked)
- Bryan-decisions locked in frontmatter (e.g. Shape A for Fintech, weekly-only for Tenderwatch digest, CC-BY-4.0 for /dataset.json)
- Already implemented as a separate PR (implementation work shipped under different branches today)

This PR files the PRDs themselves so the repo has an audit trail of what was spec'd vs what shipped.

See ~/.claude/dispatches/2026-05-25-1434/ for the full dispatch log.