### PR TITLE
SEO: exact-match title/H1 on image-prompt page + 'Free' H1 on templates page

### DIFF
--- a/data/modifiers/image.json
+++ b/data/modifiers/image.json
@@ -3,10 +3,11 @@
   "searchVolume": 150,
   "keywordDifficulty": 19,
   "seoData": {
-    "title": "Claude + ChatGPT Prompts for Image — Expert Templates | Prompt Writing Studio",
-    "description": "Discover 15+ effective Claude and ChatGPT prompts for creating stunning AI images. Our expert-crafted templates help you generate detailed image descriptions for DALL-E, Midjourney, and other AI image generators."
+    "title": "ChatGPT Image Prompt Templates — 5+ Tested Examples (DALL-E, Midjourney) | Prompt Writing Studio",
+    "description": "Discover 15+ effective Claude and ChatGPT prompts for creating stunning AI images. Our expert-crafted templates help you generate detailed image descriptions for DALL-E, Midjourney, and other AI image generators.",
+    "h1": "5+ ChatGPT Image Prompt Templates (Claude-Ready)"
   },
-  "answerBlock": "ChatGPT image prompts are detailed text descriptions that direct AI image generators — including DALL-E, Midjourney, and Stable Diffusion — to create specific visuals. Effective prompts combine a clear subject, art style, lighting, and composition. The templates below are structured to work across all major AI image platforms with minimal editing required.",
+  "answerBlock": "A ChatGPT image prompt template is a detailed, reusable text description that directs AI image generators -- including DALL-E, Midjourney, and Stable Diffusion -- to create specific visuals. Effective templates combine a clear subject, art style, lighting, and composition. The templates below are structured to work across all major AI image platforms with minimal editing required.",
   "promptTemplates": [
     {
       "title": "Detailed Scene Generator",

--- a/pages/chatgpt-prompt-templates.js
+++ b/pages/chatgpt-prompt-templates.js
@@ -35,7 +35,7 @@ export default function ChatGPTPromptTemplates({ modifiers }) {
         <div className="container mx-auto px-4 md:px-6">
           <div className="max-w-3xl mx-auto text-center">
             <h1 className="text-4xl md:text-5xl font-bold mb-6">
-              ChatGPT Prompt Templates
+              Free ChatGPT Prompt Templates
             </h1>
             <p className="text-xl mb-8">
               100+ free, copy-paste ChatGPT prompt templates organised by profession and use case. Based on OpenAI best practices — tested for business, writing, coding, marketing, and more.

--- a/pages/chatgpt-prompts-for/[modifier].js
+++ b/pages/chatgpt-prompts-for/[modifier].js
@@ -109,7 +109,7 @@ export default function ModifierPage({ modifierData }) {
           <div className="max-w-3xl mx-auto text-center">
             <span className="bg-white/20 text-white px-4 py-1 rounded-full text-sm font-medium mb-4 inline-block">Claude + ChatGPT Prompts</span>
             <h1 className="text-4xl md:text-5xl font-bold mb-4">
-              {promptTemplates.length}+ Claude &amp; ChatGPT Prompts for {modifierName}
+              {seoData.h1 || `${promptTemplates.length}+ Claude & ChatGPT Prompts for ${modifierName}`}
             </h1>
             <h2 className="text-xl font-semibold mb-3 text-white/90">
               What are the best ChatGPT prompts for {modifierName}?


### PR DESCRIPTION
## PRDs implemented

### PRD-1: Image-prompt page — exact-match title/H1 alignment

**Root problem:** `/chatgpt-prompts-for/image` ranks pos 19.1 for "chatgpt image prompt template" with 24% CTR but the exact phrase was absent from both title and H1.

**DoD checklist:**
- [x] `image.json` `seoData.title` updated — now leads with "ChatGPT Image Prompt Templates": `ChatGPT Image Prompt Templates — 5+ Tested Examples (DALL-E, Midjourney) | Prompt Writing Studio`
- [x] `image.json` `seoData.h1` added: `5+ ChatGPT Image Prompt Templates (Claude-Ready)`
- [x] `image.json` `answerBlock` opens with exact phrase: "A ChatGPT image prompt template is a detailed, reusable text description..."
- [x] `[modifier].js` H1 now uses `seoData.h1 || <count-based default>` — all other modifier pages unaffected (opt-in per data field)
- [x] `python3 -c "import json;json.load(open('data/modifiers/image.json'))"` exits 0
- [x] `npm run build` exits 0

### PRD-2: Templates page — H1 "Free" reinforcement

**Root problem:** `/chatgpt-prompt-templates` ranks pos 16.8 for "free chatgpt prompt templates" but H1 read "ChatGPT Prompt Templates" without "Free".

**DoD checklist:**
- [x] H1 on `pages/chatgpt-prompt-templates.js` now reads "Free ChatGPT Prompt Templates"
- [x] `npm run build` exits 0
- [x] No other copy changed

## Needs-Bryan tail

None. Both PRDs marked autonomous-safe with no needs-Bryan items. Re-park after merge.

## pr-critic verdict

**ADEQUATE**

Two gaps were noted but both are by-spec:
1. H1 value `"5+ ChatGPT Image Prompt Templates (Claude-Ready)"` has the count prefix before the keyword — this is the exact string the PRD specifies (`"keep the count token concept"`), not an implementation gap.
2. No sweep of other modifier pages — explicitly out of scope per PRD-1: "No change to other modifiers' titles/H1s (the override must be opt-in via data, default behaviour unchanged)."

## Deploy preview

Check the Netlify deploy-preview URL on this PR to verify:
- `/chatgpt-prompts-for/image` H1 = "5+ ChatGPT Image Prompt Templates (Claude-Ready)" and `<title>` = "ChatGPT Image Prompt Templates — 5+ Tested Examples..."
- `/chatgpt-prompt-templates` H1 = "Free ChatGPT Prompt Templates"

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)