### PR TITLE
Gateway: Phase 0–1 BYOK + multi-model compare

### DIFF
--- a/__tests__/gateway/compare.test.js
+++ b/__tests__/gateway/compare.test.js
@@ -1,0 +1,165 @@
+import { compareModels } from '../../lib/gateway/compare'
+
+// Fake OpenRouter whose behaviour is keyed by model slug so we can make some
+// models succeed and others fail within one batch. Records Authorization
+// headers so we can assert which key funded each call.
+function makeFakeFetch(behaviour = {}) {
+  const calls = []
+  let inFlight = 0
+  let maxInFlight = 0
+  const fetchImpl = async (url, opts) => {
+    inFlight++
+    maxInFlight = Math.max(maxInFlight, inFlight)
+    calls.push({ slug: JSON.parse(opts.body).model, auth: opts.headers.Authorization })
+    await new Promise(r => setTimeout(r, 5)) // let parallelism overlap
+    inFlight--
+    const slug = JSON.parse(opts.body).model
+    const status = behaviour[slug]?.status ?? 200
+    if (status !== 200) {
+      return { ok: false, status, json: async () => ({}) }
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: `gen-${slug}`,
+        choices: [{ message: { content: `out:${slug}` } }],
+        usage: { prompt_tokens: 100, completion_tokens: 50 },
+      }),
+    }
+  }
+  return { fetchImpl, calls, getMaxInFlight: () => maxInFlight }
+}
+
+const noSleep = async () => {}
+
+describe('compareModels — Phase 1', () => {
+  it('runs ≥3 models and returns a result + tokens + cost + latency per model', async () => {
+    const { fetchImpl } = makeFakeFetch()
+    const { results, totals } = await compareModels({
+      prompt: 'hi',
+      models: ['claude-sonnet-4-6', 'gpt-4o', 'gemini-2-5-pro'],
+      userKey: 'sk-or-user',
+      fetchImpl,
+    })
+
+    expect(results).toHaveLength(3)
+    results.forEach(r => {
+      expect(r.ok).toBe(true)
+      expect(r.output).toMatch(/^out:/)
+      expect(r.tokensIn).toBe(100)
+      expect(r.tokensOut).toBe(50)
+      expect(typeof r.latencyMs).toBe('number')
+    })
+    expect(totals.succeeded).toBe(3)
+    expect(totals.failed).toBe(0)
+    // 3 × (100/1e6*input + 50/1e6*output); all > 0, summed.
+    expect(totals.costUsd).toBeGreaterThan(0)
+  })
+
+  it('preserves input order', async () => {
+    const { fetchImpl } = makeFakeFetch()
+    const { results } = await compareModels({
+      prompt: 'hi',
+      models: ['gpt-4o', 'claude-sonnet-4-6', 'gemini-2-5-pro'],
+      userKey: 'sk-or-user',
+      fetchImpl,
+    })
+    expect(results.map(r => r.model)).toEqual(['gpt-4o', 'claude-sonnet-4-6', 'gemini-2-5-pro'])
+  })
+
+  it('actually runs models in parallel (bounded by concurrency)', async () => {
+    const { fetchImpl, getMaxInFlight } = makeFakeFetch()
+    await compareModels({
+      prompt: 'hi',
+      models: ['claude-sonnet-4-6', 'gpt-4o', 'gemini-2-5-pro', 'claude-opus-4-7'],
+      userKey: 'sk-or-user',
+      concurrency: 4,
+      fetchImpl,
+    })
+    expect(getMaxInFlight()).toBeGreaterThan(1)
+  })
+
+  it('one model failing does not sink the batch', async () => {
+    const { fetchImpl } = makeFakeFetch({ 'openai/gpt-4o': { status: 500 } })
+    const { results, totals } = await compareModels({
+      prompt: 'hi',
+      models: ['claude-sonnet-4-6', 'gpt-4o', 'gemini-2-5-pro'],
+      userKey: 'sk-or-user',
+      fetchImpl,
+      retries: 0,
+    })
+    const failed = results.find(r => !r.ok)
+    expect(failed.model).toBe('gpt-4o')
+    expect(failed.code).toBe('upstream_error')
+    expect(totals.succeeded).toBe(2)
+    expect(totals.failed).toBe(1)
+  })
+
+  it('retries transient failures with backoff', async () => {
+    let attempts = 0
+    const fetchImpl = async (url, opts) => {
+      attempts++
+      if (attempts < 2) return { ok: false, status: 429, json: async () => ({}) }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 'g',
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        }),
+      }
+    }
+    const { results } = await compareModels({
+      prompt: 'hi',
+      models: ['gpt-4o'],
+      userKey: 'sk-or-user',
+      fetchImpl,
+      retries: 2,
+      sleepImpl: noSleep,
+    })
+    expect(results[0].ok).toBe(true)
+    expect(attempts).toBe(2)
+  })
+
+  it('de-dupes repeated models', async () => {
+    const { fetchImpl, calls } = makeFakeFetch()
+    const { results } = await compareModels({
+      prompt: 'hi',
+      models: ['gpt-4o', 'gpt-4o', 'claude-sonnet-4-6'],
+      userKey: 'sk-or-user',
+      fetchImpl,
+    })
+    expect(results).toHaveLength(2)
+    expect(calls).toHaveLength(2)
+  })
+
+  it('BYOK fan-out funds every call with the user key (zero studio spend)', async () => {
+    const { fetchImpl, calls } = makeFakeFetch()
+    const { results } = await compareModels({
+      prompt: 'hi',
+      models: ['claude-sonnet-4-6', 'gpt-4o'],
+      userKey: 'sk-or-USER',
+      studioFreeKey: 'sk-or-STUDIO',
+      fetchImpl,
+    })
+    calls.forEach(c => expect(c.auth).toBe('Bearer sk-or-USER'))
+    results.forEach(r => expect(r.fundedBy).toBe('user'))
+  })
+
+  it('never leaks the key in the results', async () => {
+    const { fetchImpl } = makeFakeFetch()
+    const out = await compareModels({
+      prompt: 'hi',
+      models: ['gpt-4o'],
+      userKey: 'sk-or-SECRET-xyz',
+      fetchImpl,
+    })
+    expect(JSON.stringify(out)).not.toContain('sk-or-SECRET-xyz')
+  })
+
+  it('throws on an empty models array', async () => {
+    await expect(compareModels({ prompt: 'hi', models: [], userKey: 'k' })).rejects.toThrow()
+  })
+})

--- a/__tests__/gateway/gateway.test.js
+++ b/__tests__/gateway/gateway.test.js
@@ -1,0 +1,129 @@
+import { gateway } from '../../lib/gateway'
+import { listModels, getModel } from '../../lib/gateway/models'
+import { MissingKeyError, AuthProviderError, BadRequestError } from '../../lib/gateway/errors'
+
+// A fake OpenRouter that records what it was called with, so we can assert on
+// the Authorization header (which key was actually used) without a network call.
+function makeFakeFetch({ usage = { prompt_tokens: 100, completion_tokens: 50 }, status = 200 } = {}) {
+  const calls = []
+  const fetchImpl = async (url, opts) => {
+    calls.push({ url, opts })
+    if (status !== 200) {
+      return { ok: false, status, json: async () => ({}) }
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: 'gen-123',
+        choices: [{ message: { content: 'hello from the model' } }],
+        usage,
+      }),
+    }
+  }
+  return { fetchImpl, calls }
+}
+
+describe('gateway.complete — Phase 0', () => {
+  it('runs a BYOK prompt end-to-end and returns output + tokens + cost + latency', async () => {
+    const { fetchImpl, calls } = makeFakeFetch()
+    const result = await gateway.complete({
+      prompt: 'Explain recursion',
+      model: 'claude-sonnet-4-6',
+      userKey: 'sk-or-user-XYZ',
+      fetchImpl,
+    })
+
+    expect(result.output).toBe('hello from the model')
+    expect(result.tokensIn).toBe(100)
+    expect(result.tokensOut).toBe(50)
+    expect(typeof result.latencyMs).toBe('number')
+    // Sonnet: input $3/1M, output $15/1M → 100/1e6*3 + 50/1e6*15 = 0.00105
+    expect(result.costUsd).toBeCloseTo(0.00105, 8)
+    expect(result.fundedBy).toBe('user')
+    expect(calls).toHaveLength(1)
+  })
+
+  it('BYOK uses the user key and incurs ZERO studio-funded spend', async () => {
+    const { fetchImpl, calls } = makeFakeFetch()
+    const result = await gateway.complete({
+      prompt: 'hi',
+      model: 'gpt-4o',
+      userKey: 'sk-or-user-XYZ',
+      studioFreeKey: 'sk-or-STUDIO-should-not-be-used',
+      fetchImpl,
+    })
+
+    // The provider was authorized with the USER key, not the studio key.
+    expect(calls[0].opts.headers.Authorization).toBe('Bearer sk-or-user-XYZ')
+    expect(result.fundedBy).toBe('user')
+  })
+
+  it('never leaks the key in the returned result object', async () => {
+    const { fetchImpl } = makeFakeFetch()
+    const result = await gateway.complete({
+      prompt: 'hi',
+      model: 'gpt-4o',
+      userKey: 'sk-or-SECRET-123',
+      fetchImpl,
+    })
+    expect(JSON.stringify(result)).not.toContain('sk-or-SECRET-123')
+    expect(result).not.toHaveProperty('userKey')
+    expect(result).not.toHaveProperty('apiKey')
+  })
+
+  it('falls back to the studio key ONLY for free-tier models', async () => {
+    const { fetchImpl, calls } = makeFakeFetch({ usage: { prompt_tokens: 10, completion_tokens: 10 } })
+    const result = await gateway.complete({
+      prompt: 'hi',
+      model: 'llama-3.3-70b-free',
+      userKey: null,
+      studioFreeKey: 'sk-or-STUDIO',
+      fetchImpl,
+    })
+    expect(calls[0].opts.headers.Authorization).toBe('Bearer sk-or-STUDIO')
+    expect(result.fundedBy).toBe('studio')
+    expect(result.costUsd).toBeNull() // free model has no pricing entry
+  })
+
+  it('refuses a paid model when no user key is supplied', async () => {
+    const { fetchImpl, calls } = makeFakeFetch()
+    await expect(
+      gateway.complete({ prompt: 'hi', model: 'gpt-4o', userKey: null, studioFreeKey: 'sk-or-STUDIO', fetchImpl })
+    ).rejects.toThrow(MissingKeyError)
+    expect(calls).toHaveLength(0) // never reached the provider
+  })
+
+  it('maps a 401 from the provider to AuthProviderError', async () => {
+    const { fetchImpl } = makeFakeFetch({ status: 401 })
+    await expect(
+      gateway.complete({ prompt: 'hi', model: 'gpt-4o', userKey: 'bad', fetchImpl })
+    ).rejects.toThrow(AuthProviderError)
+  })
+
+  it('rejects an empty prompt', async () => {
+    const { fetchImpl } = makeFakeFetch()
+    await expect(
+      gateway.complete({ prompt: '', model: 'gpt-4o', userKey: 'k', fetchImpl })
+    ).rejects.toThrow(BadRequestError)
+  })
+
+  it('swapping a model is a config change, not a code change', async () => {
+    // Every registered model resolves through the same complete() path with no
+    // model-specific branches in the gateway.
+    const ids = listModels().map(m => m.id)
+    expect(ids.length).toBeGreaterThanOrEqual(3)
+    for (const id of ids) {
+      const { fetchImpl } = makeFakeFetch()
+      const cfg = getModel(id)
+      const result = await gateway.complete({
+        prompt: 'x',
+        model: id,
+        userKey: 'sk-or-user',
+        fetchImpl,
+      })
+      expect(result.model).toBe(id)
+      expect(result.route).toBe(cfg.route)
+    }
+  })
+})

--- a/docs/prompt-studio-gateway.md
+++ b/docs/prompt-studio-gateway.md
@@ -1,7 +1,7 @@
 # Prompt Studio — Gateway & Key-Handling Design (Phase 0)
 
-Status: **Phase 0 landed** (one model, BYOK, end-to-end). This is the
-report-back checkpoint before building Phase 1 (multi-model fan-out).
+Status: **Phase 0 + Phase 1 landed** (single-model BYOK end-to-end, plus
+parallel multi-model compare). Phase 2 (templates) is next.
 
 ## What this layer is
 
@@ -42,7 +42,9 @@ streaming + cancellation); production callers pass none of them.
 | `lib/gateway/cost.js` | Estimated cost from tokens × `data/api-pricing.json`. |
 | `lib/gateway/errors.js` | Typed errors carrying safe HTTP `status` + `code`. |
 | `lib/gateway/index.js` | `complete()` — validation, funding policy, routing, result assembly. |
+| `lib/gateway/compare.js` | `compareModels()` — parallel fan-out (bounded concurrency + backoff). |
 | `pages/api/studio/run.js` | Phase-0 HTTP endpoint (single model). |
+| `pages/api/studio/compare.js` | Phase-1 HTTP endpoint (N models side by side). |
 
 ## Key-handling design (decided: client-only BYOK)
 
@@ -86,18 +88,31 @@ that isn't installed). Rather than stand that up just to store secrets, keys are
 
 | Criterion | Status |
 |---|---|
-| Prompt runs vs ≥3 models via one OpenRouter integration | Gateway + registry ready (4 paid + 1 free registered); fan-out endpoint is Phase 1 |
+| Prompt runs vs ≥3 models via one OpenRouter integration | ✅ done (`compareModels`; test-verified) |
 | BYOK accepted, not stored, absent from logs/traces | ✅ done (client-only header; test-verified) |
-| Compare view returns output + tokens + est. cost + latency per model | Per-model result shape ✅ done; compare endpoint is Phase 1 |
+| Compare view returns output + tokens + est. cost + latency per model | ✅ done (per-model + batch totals) |
 | Swapping a model is config, not code | ✅ done (registry-only; test-verified) |
-| No studio-funded spend on a BYOK run | ✅ done (test-verified) |
+| No studio-funded spend on a BYOK run | ✅ done (single + fan-out test-verified) |
 
-## Next (Phase 1, after review)
+## Phase 1 — multi-model compare
 
-Add `pages/api/studio/compare.js` that fans the same `gateway.complete()` out
-across N models in parallel (bounded concurrency + backoff, mirroring the
-observatory's per-provider semaphore), returning an array of the same result
-objects for side-by-side display. **No gateway change required.**
+`compareModels({ prompt, models, params, userKey })` → `{ prompt, results[], totals }`:
+
+- Runs the same `gateway.complete()` across N models, **bounded concurrency**
+  (default 4) and **exponential backoff** retries on transient codes
+  (`rate_limited`, `upstream_error`). No gateway change — pure orchestration.
+- **Partial failure is isolated:** a model that errors comes back as
+  `{ ok: false, model, error, code }` next to the successes; the batch still
+  returns. Input order preserved; duplicate model ids de-duped.
+- `totals`: `{ models, succeeded, failed, costUsd (summed estimate),
+  maxLatencyMs (parallel wall-clock, not the sum) }`.
+- Endpoint `pages/api/studio/compare.js` meters the free tier per model in the
+  batch and caps at 8 models/request.
+
+## Next (Phase 2, after review)
+
+Wire the course-derived template library (`data/prompt-library.js`) as
+versioned, slot-filled prompts feeding `gateway.complete()` / `compareModels()`.
 
 ## Open items for Bryan
 

--- a/docs/prompt-studio-gateway.md
+++ b/docs/prompt-studio-gateway.md
@@ -1,0 +1,111 @@
+# Prompt Studio — Gateway & Key-Handling Design (Phase 0)
+
+Status: **Phase 0 landed** (one model, BYOK, end-to-end). This is the
+report-back checkpoint before building Phase 1 (multi-model fan-out).
+
+## What this layer is
+
+The studio's defensibility is the opinionated structure (templates, guided
+builders, the critique rubric) — not model access. So the gateway does one
+job cleanly and gets out of the way: run a prompt against a model, return
+output + tokens + cost + latency, while keeping studio inference cost ≈ $0 via
+BYOK.
+
+## The single interface
+
+All app code calls one function. OpenRouter vs (future) provider-direct is a
+routing detail owned by the registry, never by callers.
+
+```js
+import { gateway } from 'lib/gateway'
+
+const result = await gateway.complete({
+  prompt,            // string, required
+  model,             // internal id, e.g. 'claude-sonnet-4-6'
+  params,            // { temperature, maxTokens } — optional
+  userKey,           // BYOK key (in-memory only) — null ⇒ try free tier
+})
+// → { model, label, vendor, route, output,
+//     tokensIn, tokensOut, costUsd, costEstimated, latencyMs,
+//     fundedBy: 'user' | 'studio', providerResponseId }
+```
+
+`studioFreeKey`, `fetchImpl`, and `signal` are injectable (tests / future
+streaming + cancellation); production callers pass none of them.
+
+## Files
+
+| File | Role |
+|---|---|
+| `lib/gateway/models.js` | Registry: internal id → OpenRouter slug, vendor, `free` flag, `pricingId`. **Add/swap a model here only.** |
+| `lib/gateway/openrouter.js` | OpenRouter backend (OpenAI-compatible `fetch`). The only place a key touches the wire. |
+| `lib/gateway/cost.js` | Estimated cost from tokens × `data/api-pricing.json`. |
+| `lib/gateway/errors.js` | Typed errors carrying safe HTTP `status` + `code`. |
+| `lib/gateway/index.js` | `complete()` — validation, funding policy, routing, result assembly. |
+| `pages/api/studio/run.js` | Phase-0 HTTP endpoint (single model). |
+
+## Key-handling design (decided: client-only BYOK)
+
+There is **no DB or auth in the repo today** (CLAUDE.md describes Prisma/NextAuth
+that isn't installed). Rather than stand that up just to store secrets, keys are
+**client-only**:
+
+- The key lives in the browser (sessionStorage) and is sent per request in the
+  `x-user-api-key` **header** — kept out of the JSON body so it can't land in
+  body logs.
+- The server uses it in-memory for exactly one call, then drops it. It is
+  **never persisted, never logged, never returned to the client, never attached
+  to a trace.** `lib/gateway/index.js` has no `console.log` of inputs; the result
+  object is assembled field-by-field with no key field; error paths surface
+  typed messages only and never echo the request.
+- This is verified by tests: the returned object cannot contain the key, and a
+  BYOK call authorizes the provider with the *user's* key even when a studio key
+  is also present (zero studio spend).
+
+## Funding policy (decided: BYOK + capped free tier)
+
+- **BYOK is default.** A user key ⇒ `fundedBy: 'user'`, studio spend = $0.
+- **Capped free tier:** with no user key, only models flagged `free` in the
+  registry run, drawing on `OPENROUTER_FREE_KEY` (OpenRouter's rate-limited free
+  models). A paid model with no key throws `MissingKeyError` *before* any provider
+  call. The free path is metered per-IP/hour via the existing
+  `lib/observatory/rateLimit`. A user's key is never used to fund anyone else; the
+  studio key never funds a paid model.
+
+## Reuse map (what already existed)
+
+- **Rubric + LLM-as-judge:** `scripts/observatory/_lib/judge.py` +
+  `judge_templates/default.txt` + the `rubric` block in
+  `data/observatory/prompts/*.json` (criteria[], 0–3 scoring, pass_threshold).
+  Phase 3 critique = **port this grounded judge to JS** (decided), not new infra.
+- **Template library:** `data/prompt-library.js` (slot-filled prompts) feeds Phase 2.
+- **Pricing:** `data/api-pricing.json` (per-1M token prices) drives cost estimates.
+- **Rate limiting:** `lib/observatory/rateLimit.js`.
+
+## Phase-1 acceptance criteria — status
+
+| Criterion | Status |
+|---|---|
+| Prompt runs vs ≥3 models via one OpenRouter integration | Gateway + registry ready (4 paid + 1 free registered); fan-out endpoint is Phase 1 |
+| BYOK accepted, not stored, absent from logs/traces | ✅ done (client-only header; test-verified) |
+| Compare view returns output + tokens + est. cost + latency per model | Per-model result shape ✅ done; compare endpoint is Phase 1 |
+| Swapping a model is config, not code | ✅ done (registry-only; test-verified) |
+| No studio-funded spend on a BYOK run | ✅ done (test-verified) |
+
+## Next (Phase 1, after review)
+
+Add `pages/api/studio/compare.js` that fans the same `gateway.complete()` out
+across N models in parallel (bounded concurrency + backoff, mirroring the
+observatory's per-provider semaphore), returning an array of the same result
+objects for side-by-side display. **No gateway change required.**
+
+## Open items for Bryan
+
+1. **CLAUDE.md drift:** it documents Prisma/NextAuth/Postgres that aren't
+   installed. Phase 4 (saved library + freemium gating) needs a real decision on
+   persistence/auth. Flagging now; not blocking Phase 0/1.
+2. **OpenRouter slugs** in `models.js` are placeholders for the repo's
+   (fictional, 2026) model ids — verify against https://openrouter.ai/models
+   before a live run.
+3. Set `OPENROUTER_FREE_KEY` in the environment to enable the free tier; without
+   it, the studio is pure BYOK (still fully functional).

--- a/lib/gateway/compare.js
+++ b/lib/gateway/compare.js
@@ -1,0 +1,100 @@
+// Phase 1 — multi-model compare.
+//
+// Fan the SAME gateway.complete() call out across N models in parallel so the
+// UI can show output + tokens + estimated cost + latency side by side. This
+// adds no model-specific logic and does not change the gateway: it's pure
+// orchestration on top of the single interface.
+//
+// Concurrency is bounded (mirrors the observatory's per-provider semaphore so a
+// wide fan-out can't hammer the provider) and transient failures get a couple
+// of backoff retries. One model failing never sinks the batch — its slot comes
+// back as { ok: false, ... } alongside the successes.
+
+import { complete } from './index'
+import { GatewayError } from './errors'
+
+const DEFAULT_CONCURRENCY = 4
+const DEFAULT_RETRIES = 2
+const RETRYABLE_CODES = new Set(['rate_limited', 'upstream_error'])
+
+const defaultSleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+// Run `fn` over `items` with at most `limit` in flight, preserving input order.
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length)
+  let next = 0
+  async function worker() {
+    while (next < items.length) {
+      const i = next++
+      results[i] = await fn(items[i], i)
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, worker)
+  await Promise.all(workers)
+  return results
+}
+
+async function completeWithRetry(args, { retries, baseDelayMs, sleepImpl }) {
+  let attempt = 0
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await complete(args)
+    } catch (err) {
+      const code = err instanceof GatewayError ? err.code : null
+      if (!RETRYABLE_CODES.has(code) || attempt >= retries) throw err
+      // Exponential backoff: 1x, 2x, 4x ... of base delay.
+      await sleepImpl(baseDelayMs * 2 ** attempt)
+      attempt++
+    }
+  }
+}
+
+export async function compareModels({
+  prompt,
+  models = [],
+  params = {},
+  userKey = null,
+  concurrency = DEFAULT_CONCURRENCY,
+  retries = DEFAULT_RETRIES,
+  baseDelayMs = 500,
+  // Injectable for tests; production callers pass none of these.
+  studioFreeKey = process.env.OPENROUTER_FREE_KEY || null,
+  fetchImpl,
+  sleepImpl = defaultSleep,
+  signal,
+} = {}) {
+  if (!Array.isArray(models) || models.length === 0) {
+    throw new GatewayError('At least one model is required.', { status: 400, code: 'bad_request' })
+  }
+  // De-dupe while preserving order — comparing a model against itself is noise.
+  const uniqueModels = [...new Set(models)]
+
+  const results = await mapWithConcurrency(uniqueModels, concurrency, async model => {
+    try {
+      const result = await completeWithRetry(
+        { prompt, model, params, userKey, studioFreeKey, fetchImpl, signal },
+        { retries, baseDelayMs, sleepImpl }
+      )
+      return { ok: true, ...result }
+    } catch (err) {
+      const code = err instanceof GatewayError ? err.code : 'internal_error'
+      // Surface a typed, key-safe message — never the raw error.
+      const message = err instanceof GatewayError ? err.message : 'Internal error running this model.'
+      return { ok: false, model, error: message, code }
+    }
+  })
+
+  const succeeded = results.filter(r => r.ok)
+  const totals = {
+    models: results.length,
+    succeeded: succeeded.length,
+    failed: results.length - succeeded.length,
+    // Sum of estimated costs (free-tier nulls count as 0).
+    costUsd: succeeded.reduce((sum, r) => sum + (r.costUsd || 0), 0),
+    // Wall-clock is bounded by the slowest model, not the sum (they run parallel).
+    maxLatencyMs: succeeded.reduce((max, r) => Math.max(max, r.latencyMs || 0), 0),
+  }
+
+  return { prompt, results, totals }
+}

--- a/lib/gateway/cost.js
+++ b/lib/gateway/cost.js
@@ -1,0 +1,16 @@
+// Estimated cost from token usage + the per-1M pricing table.
+//
+// This is an ESTIMATE for side-by-side comparison, not a bill. OpenRouter
+// charges its own (often slightly different) per-token price plus a
+// credit-purchase fee, so we never present this as the amount the user paid.
+// Returns null when we have no pricing entry (e.g. free-tier models).
+
+const PER_MILLION = 1_000_000
+
+export function estimateCostUsd(pricing, tokensIn, tokensOut) {
+  if (!pricing) return null
+  const inCost = (tokensIn / PER_MILLION) * pricing.input_per_1m
+  const outCost = (tokensOut / PER_MILLION) * pricing.output_per_1m
+  // Round to 6 dp — these numbers are tiny and we don't want float noise.
+  return Math.round((inCost + outCost) * 1e6) / 1e6
+}

--- a/lib/gateway/errors.js
+++ b/lib/gateway/errors.js
@@ -1,0 +1,47 @@
+// Typed gateway errors. Each carries an HTTP `status` so API routes can map a
+// failure to a response without leaking provider internals or — critically —
+// any part of a user's key. Messages here are safe to surface to the client.
+
+export class GatewayError extends Error {
+  constructor(message, { status = 500, code = 'gateway_error' } = {}) {
+    super(message)
+    this.name = 'GatewayError'
+    this.status = status
+    this.code = code
+  }
+}
+
+export class BadRequestError extends GatewayError {
+  constructor(message) {
+    super(message, { status: 400, code: 'bad_request' })
+    this.name = 'BadRequestError'
+  }
+}
+
+export class MissingKeyError extends GatewayError {
+  constructor(message = 'No API key provided and this model is not on the free tier.') {
+    super(message, { status: 401, code: 'missing_key' })
+    this.name = 'MissingKeyError'
+  }
+}
+
+export class AuthProviderError extends GatewayError {
+  constructor(message = 'The provider rejected the API key.') {
+    super(message, { status: 401, code: 'auth_failed' })
+    this.name = 'AuthProviderError'
+  }
+}
+
+export class RateLimitError extends GatewayError {
+  constructor(message = 'Rate limit exceeded. Try again shortly or use your own API key.') {
+    super(message, { status: 429, code: 'rate_limited' })
+    this.name = 'RateLimitError'
+  }
+}
+
+export class UpstreamError extends GatewayError {
+  constructor(message = 'The model provider returned an error.') {
+    super(message, { status: 502, code: 'upstream_error' })
+    this.name = 'UpstreamError'
+  }
+}

--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -95,5 +95,9 @@ export async function complete({
   }
 }
 
-export const gateway = { complete }
+// Re-export the Phase-1 fan-out so callers import everything from one barrel.
+export { compareModels } from './compare'
+import { compareModels as _compareModels } from './compare'
+
+export const gateway = { complete, compareModels: _compareModels }
 export default gateway

--- a/lib/gateway/index.js
+++ b/lib/gateway/index.js
@@ -1,0 +1,99 @@
+// The model gateway — the ONE interface the rest of the app calls.
+//
+//   gateway.complete({ prompt, model, params, userKey })
+//
+// App code never talks to OpenRouter (or, later, a provider-direct route)
+// itself. Whether a model goes over OpenRouter or a direct provider is a
+// routing detail owned by the registry (lib/gateway/models.js), so swapping a
+// model is config, not code (Phase-1 acceptance criterion).
+//
+// ── SECURITY (non-negotiable) ────────────────────────────────────────────
+//  • BYOK by default: `userKey` is the user's own OpenRouter key. It is used
+//    in-memory for exactly one call and then dropped. It is NEVER logged,
+//    NEVER persisted, NEVER returned to the client, and NEVER attached to a
+//    trace. There is intentionally no `console.log` of inputs in this module.
+//  • The returned result object is built field-by-field and contains no key.
+//  • A funded free tier exists ONLY for models flagged `free` in the registry,
+//    drawing on a studio key from the environment — never a user's key, and
+//    never funding a paid model.
+//
+// A BYOK run therefore produces ZERO studio-funded token spend.
+
+import { getModel, isFreeModel, getPricing } from './models'
+import { callOpenRouter } from './openrouter'
+import { estimateCostUsd } from './cost'
+import { BadRequestError, MissingKeyError, GatewayError } from './errors'
+
+const ROUTE_HANDLERS = {
+  openrouter: callOpenRouter,
+}
+
+// Resolve who pays and which key to use, enforcing the BYOK + capped-free-tier
+// policy. Returns { apiKey, fundedBy }. Throws when neither path is available.
+function resolveFunding({ modelId, userKey, studioFreeKey }) {
+  if (userKey) {
+    return { apiKey: userKey, fundedBy: 'user' }
+  }
+  if (isFreeModel(modelId) && studioFreeKey) {
+    return { apiKey: studioFreeKey, fundedBy: 'studio' }
+  }
+  throw new MissingKeyError()
+}
+
+export async function complete({
+  prompt,
+  model: modelId,
+  params = {},
+  userKey = null,
+  // Injectable for tests; defaults to env so prod code passes nothing.
+  studioFreeKey = process.env.OPENROUTER_FREE_KEY || null,
+  fetchImpl = fetch,
+  signal,
+} = {}) {
+  if (!prompt || typeof prompt !== 'string') {
+    throw new BadRequestError('A non-empty `prompt` string is required.')
+  }
+  const modelConfig = getModel(modelId)
+  if (!modelConfig) {
+    throw new BadRequestError(`Unknown model: ${modelId}`)
+  }
+
+  const { apiKey, fundedBy } = resolveFunding({ modelId, userKey, studioFreeKey })
+
+  const handler = ROUTE_HANDLERS[modelConfig.route]
+  if (!handler) {
+    throw new GatewayError(`No handler for route: ${modelConfig.route}`)
+  }
+
+  const startedAt = Date.now()
+  const resp = await handler({
+    slug: modelConfig.openrouterSlug,
+    prompt,
+    params,
+    apiKey,
+    fetchImpl,
+    signal,
+  })
+  const latencyMs = Date.now() - startedAt
+
+  const costUsd = estimateCostUsd(getPricing(modelId), resp.tokensIn, resp.tokensOut)
+
+  // Built explicitly — note the absence of any key field.
+  return {
+    model: modelId,
+    label: modelConfig.label,
+    vendor: modelConfig.vendor,
+    route: modelConfig.route,
+    output: resp.text,
+    tokensIn: resp.tokensIn,
+    tokensOut: resp.tokensOut,
+    costUsd, // estimated; null for free-tier models
+    costEstimated: true,
+    latencyMs,
+    fundedBy, // 'user' (BYOK) | 'studio' (free tier)
+    providerResponseId: resp.providerResponseId,
+  }
+}
+
+export const gateway = { complete }
+export default gateway

--- a/lib/gateway/models.js
+++ b/lib/gateway/models.js
@@ -1,0 +1,85 @@
+// Gateway model registry — the single source of truth for which models the
+// studio exposes and how each one is routed.
+//
+// Swapping or adding a model is a CONFIG change here, never a code change in
+// the gateway or API routes (Phase-1 acceptance criterion). The rest of the
+// app refers to models by their stable internal `id`; the registry maps that
+// id to an OpenRouter slug (or, later, a provider-direct route).
+//
+// `pricingId` points at an entry in data/api-pricing.json so cost estimates
+// stay in one place. OpenRouter applies its own pricing (plus a credit-purchase
+// fee), so costs computed from this table are clearly labelled ESTIMATES.
+//
+// NOTE: the `:free` slugs below are OpenRouter's rate-limited free tier. Verify
+// every slug against https://openrouter.ai/models before a live run — model
+// availability on OpenRouter changes over time.
+
+import apiPricing from '../../data/api-pricing.json'
+
+export const ROUTE_OPENROUTER = 'openrouter'
+
+// Internal id -> routing + display config.
+const REGISTRY = {
+  'claude-opus-4-7': {
+    label: 'Claude Opus 4.7',
+    vendor: 'Anthropic',
+    route: ROUTE_OPENROUTER,
+    openrouterSlug: 'anthropic/claude-opus-4',
+    pricingId: 'claude-opus-4-7',
+    free: false,
+  },
+  'claude-sonnet-4-6': {
+    label: 'Claude Sonnet 4.6',
+    vendor: 'Anthropic',
+    route: ROUTE_OPENROUTER,
+    openrouterSlug: 'anthropic/claude-sonnet-4',
+    pricingId: 'claude-sonnet-4-6',
+    free: false,
+  },
+  'gpt-4o': {
+    label: 'GPT-4o',
+    vendor: 'OpenAI',
+    route: ROUTE_OPENROUTER,
+    openrouterSlug: 'openai/gpt-4o',
+    pricingId: 'gpt-4o',
+    free: false,
+  },
+  'gemini-2-5-pro': {
+    label: 'Gemini 2.5 Pro',
+    vendor: 'Google',
+    route: ROUTE_OPENROUTER,
+    openrouterSlug: 'google/gemini-2.5-pro',
+    pricingId: 'gemini-2-5-pro',
+    free: false,
+  },
+  // --- Free tier (OpenRouter rate-limited, studio-funded demo) -------------
+  'llama-3.3-70b-free': {
+    label: 'Llama 3.3 70B (free)',
+    vendor: 'Meta',
+    route: ROUTE_OPENROUTER,
+    openrouterSlug: 'meta-llama/llama-3.3-70b-instruct:free',
+    pricingId: null,
+    free: true,
+  },
+}
+
+export function getModel(id) {
+  return REGISTRY[id] || null
+}
+
+export function listModels() {
+  return Object.entries(REGISTRY).map(([id, m]) => ({ id, ...m }))
+}
+
+export function isFreeModel(id) {
+  const m = REGISTRY[id]
+  return Boolean(m && m.free)
+}
+
+// Per-1M-token prices for an internal model id, or null when we have no entry
+// (e.g. free models). Used only for ESTIMATED cost — never billed.
+export function getPricing(id) {
+  const m = REGISTRY[id]
+  if (!m || !m.pricingId) return null
+  return apiPricing.models.find(p => p.id === m.pricingId) || null
+}

--- a/lib/gateway/openrouter.js
+++ b/lib/gateway/openrouter.js
@@ -1,0 +1,74 @@
+// OpenRouter backend — one key, 300+ models, OpenAI-compatible API.
+//
+// We talk to OpenRouter's chat-completions endpoint directly with `fetch`
+// rather than pulling in the OpenAI SDK: it keeps the dependency surface small
+// and the request shape is identical. The `apiKey` is used in-memory for this
+// single call and is NEVER logged, returned, or persisted (see SECURITY notes
+// in lib/gateway/index.js).
+
+import { AuthProviderError, RateLimitError, UpstreamError } from './errors'
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions'
+const DEFAULT_MAX_TOKENS = 1024
+const DEFAULT_TEMPERATURE = 0.7
+
+// Sent so OpenRouter can attribute traffic; safe to be public.
+const REFERER = 'https://promptwritingstudio.com'
+const TITLE = 'PromptWritingStudio'
+
+export async function callOpenRouter({
+  slug,
+  prompt,
+  params = {},
+  apiKey,
+  fetchImpl = fetch,
+  signal,
+}) {
+  const body = {
+    model: slug,
+    messages: [{ role: 'user', content: prompt }],
+    max_tokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
+    temperature: params.temperature ?? DEFAULT_TEMPERATURE,
+  }
+
+  let res
+  try {
+    res = await fetchImpl(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        'HTTP-Referer': REFERER,
+        'X-Title': TITLE,
+      },
+      body: JSON.stringify(body),
+      signal,
+    })
+  } catch (e) {
+    // Network/transport failure — deliberately do NOT echo `e` to avoid any
+    // chance of including request details. The key is never in the message.
+    throw new UpstreamError('Could not reach the model provider.')
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    throw new AuthProviderError()
+  }
+  if (res.status === 429) {
+    throw new RateLimitError('The provider rate-limited this request.')
+  }
+  if (!res.ok) {
+    throw new UpstreamError(`Provider returned HTTP ${res.status}.`)
+  }
+
+  const data = await res.json()
+  const choice = data.choices?.[0]
+  const text = choice?.message?.content ?? ''
+  const usage = data.usage || {}
+
+  return {
+    text,
+    tokensIn: usage.prompt_tokens ?? 0,
+    tokensOut: usage.completion_tokens ?? 0,
+    providerResponseId: data.id ?? null,
+  }
+}

--- a/pages/api/studio/compare.js
+++ b/pages/api/studio/compare.js
@@ -1,0 +1,64 @@
+// pages/api/studio/compare.js
+// Phase-1: run ONE prompt against N models in parallel for side-by-side compare.
+//
+// Same key handling as the single-run endpoint: the BYOK key arrives in the
+// x-user-api-key header, is used in-memory only, and is never stored, logged,
+// returned, or traced. A BYOK fan-out incurs zero studio-funded spend.
+//
+// Free-tier metering counts each model in the batch against the per-IP/hour cap,
+// since each model is its own studio-funded call.
+
+import { compareModels } from '../../../lib/gateway'
+import { GatewayError } from '../../../lib/gateway/errors'
+import { checkRateLimit } from '../../../lib/observatory/rateLimit'
+
+const FREE_TIER_MAX_PER_HOUR = 20
+const MAX_MODELS_PER_REQUEST = 8
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const userKey = req.headers['x-user-api-key'] || null
+  const { prompt, models, params } = req.body || {}
+
+  if (!Array.isArray(models) || models.length === 0) {
+    return res.status(400).json({ error: 'Provide a non-empty `models` array.', code: 'bad_request' })
+  }
+  if (models.length > MAX_MODELS_PER_REQUEST) {
+    return res.status(400).json({
+      error: `Compare at most ${MAX_MODELS_PER_REQUEST} models per request.`,
+      code: 'too_many_models',
+    })
+  }
+
+  // Meter only the studio-funded free path: one token per model in the fan-out.
+  if (!userKey) {
+    let allowed = true
+    for (let i = 0; i < models.length; i++) {
+      if (!checkRateLimit(req, { max: FREE_TIER_MAX_PER_HOUR }).allowed) {
+        allowed = false
+        break
+      }
+    }
+    if (!allowed) {
+      return res.status(429).json({
+        error: 'Free-tier limit reached for this hour. Add your own API key to keep going.',
+        code: 'rate_limited',
+      })
+    }
+  }
+
+  try {
+    const result = await compareModels({ prompt, models, params, userKey })
+    return res.status(200).json(result)
+  } catch (err) {
+    if (err instanceof GatewayError) {
+      return res.status(err.status).json({ error: err.message, code: err.code })
+    }
+    console.error('Studio compare failed:', err?.name || 'UnknownError')
+    return res.status(500).json({ error: 'Internal error running the comparison.' })
+  }
+}

--- a/pages/api/studio/run.js
+++ b/pages/api/studio/run.js
@@ -1,0 +1,52 @@
+// pages/api/studio/run.js
+// Phase-0 vertical slice: run ONE prompt against ONE model through the gateway.
+//
+// BYOK key handling is client-only: the user's key arrives in the
+// `x-user-api-key` header (kept out of the JSON body so it never lands in body
+// logs), is handed straight to the gateway for a single in-memory call, and is
+// never stored, never returned, and never logged. We deliberately do not echo
+// the request body on error.
+//
+// Phase-1 (multi-model compare) will add a sibling endpoint that fans this same
+// gateway.complete() call out across N models — no change to the gateway.
+
+import { gateway } from '../../../lib/gateway'
+import { GatewayError } from '../../../lib/gateway/errors'
+import { checkRateLimit } from '../../../lib/observatory/rateLimit'
+
+// Free-tier abuse cap (per IP/hour) for unauthenticated, studio-funded runs.
+const FREE_TIER_MAX_PER_HOUR = 20
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const userKey = req.headers['x-user-api-key'] || null
+  const { prompt, model, params } = req.body || {}
+
+  // Only meter the studio-funded free path. BYOK runs cost the studio nothing,
+  // so the user's own key (and the provider's own limits) governs them.
+  if (!userKey) {
+    const { allowed } = checkRateLimit(req, { max: FREE_TIER_MAX_PER_HOUR })
+    if (!allowed) {
+      return res.status(429).json({
+        error: 'Free-tier limit reached for this hour. Add your own API key to keep going.',
+        code: 'rate_limited',
+      })
+    }
+  }
+
+  try {
+    const result = await gateway.complete({ prompt, model, params, userKey })
+    return res.status(200).json(result)
+  } catch (err) {
+    if (err instanceof GatewayError) {
+      return res.status(err.status).json({ error: err.message, code: err.code })
+    }
+    // Never surface internal details (or anything derived from the key).
+    console.error('Studio run failed:', err?.name || 'UnknownError')
+    return res.status(500).json({ error: 'Internal error running the prompt.' })
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Prompt Studio gateway — a unified interface for running prompts against LLMs with client-only BYOK (Bring Your Own Key) and a capped free tier. Includes Phase 0 (single-model completion) and Phase 1 (parallel multi-model compare).

## Key Changes

- **`lib/gateway/index.js`** — Core `gateway.complete()` function. Validates input, resolves funding (BYOK vs. free tier), routes to the appropriate provider handler, and assembles the result. Keys are never logged, persisted, or returned.

- **`lib/gateway/compare.js`** — Phase 1 fan-out orchestration. Runs the same `complete()` call across N models in parallel with bounded concurrency (default 4), exponential backoff retries on transient failures, and graceful partial failure handling. Input order preserved; duplicates de-duped.

- **`lib/gateway/models.js`** — Registry mapping internal model IDs to OpenRouter slugs, vendors, pricing IDs, and free-tier flags. Swapping or adding a model is config-only, not code.

- **`lib/gateway/openrouter.js`** — OpenRouter backend using OpenAI-compatible chat-completions API. Keys are used in-memory for a single call and never logged or returned.

- **`lib/gateway/cost.js`** — Estimated cost calculation from token usage and per-1M pricing table (for side-by-side comparison, not billing).

- **`lib/gateway/errors.js`** — Typed errors (`GatewayError`, `MissingKeyError`, `AuthProviderError`, `RateLimitError`, `UpstreamError`) with safe HTTP status and code fields. Never echo request details or keys.

- **`pages/api/studio/run.js`** — Phase 0 HTTP endpoint. Accepts `prompt`, `model`, `params` in the body and the user's key in the `x-user-api-key` header. Meters the free tier per IP/hour; BYOK runs are unmetered.

- **`pages/api/studio/compare.js`** — Phase 1 HTTP endpoint. Fans a single prompt across N models (max 8 per request). Meters each model in the batch against the free-tier cap.

- **`__tests__/gateway/gateway.test.js`** — 8 tests covering single-model completion: BYOK funding, key non-leakage, free-tier fallback, auth errors, input validation, and model-agnostic routing.

- **`__tests__/gateway/compare.test.js`** — 8 tests covering multi-model compare: parallel execution, concurrency bounds, partial failure isolation, retry logic with backoff, deduplication, and BYOK funding across the batch.

- **`docs/prompt-studio-gateway.md`** — Design document covering the gateway's role, key-handling security model, funding policy (BYOK + capped free tier), file structure, and Phase 1 acceptance criteria.

## Notable Implementation Details

- **Security (non-negotiable):** Keys are client-only, used in-memory for exactly one call, never logged, never persisted, never returned, and never attached to traces. The result object is built field-by-field with no key field. Tests verify key non-leakage.

- **Funding policy:** BYOK is default (`fundedBy: 'user'`, studio spend = $0). Free tier is capped to models flagged `free` in the registry, drawing on `OPENROUTER_FREE_KEY` from the environment. A paid model with no key throws `MissingKeyError` *before* any provider call.

- **Concurrency & retries:** `compareModels()` bounds parallelism (default 4 workers) and retries transient codes (`rate_limited`, `upstream_error`) with exponential backoff. One model failing never sinks the batch.

- **Model-agnostic routing:** All app code calls `gateway.complete()` or `gateway.compareModels()`. Whether a model goes over OpenRouter or a future provider-direct route is a registry detail, so swapping a

https://claude.ai/code/session_01LVJzsrCU91tXbRJLYSvVw4