### PR TITLE
Prompt Studio Phase 4: persistence + freemium gating (+ CLAUDE.md fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,11 @@ Next.js 13 site for PromptWritingStudio — a programmatic SEO content site targ
 
 - **Framework**: Next.js 13 (Pages Router, not App Router)
 - **Styling**: Tailwind CSS
-- **Auth**: NextAuth.js with Prisma adapter
-- **DB**: PostgreSQL via Prisma (for auth/dashboard only)
+- **Auth**: None currently. (No NextAuth, no Prisma, no `/prisma` dir — these
+  were planned but never installed. Do not assume they exist.)
+- **DB**: None. The site is static/SSG content + serverless API routes. Any
+  per-user state (e.g. the Prompt Studio saved library) is **client-side
+  localStorage**, not a database.
 - **Deployment**: Netlify with `@netlify/plugin-nextjs`
 - **Build**: `npm run build` → `.next/` publish dir
 
@@ -30,8 +33,10 @@ Next.js 13 site for PromptWritingStudio — a programmatic SEO content site targ
 /data           — SEO content data and prompt templates
   /modifiers    — JSON files for /chatgpt-prompts-for/[modifier] pages
   seo-use-cases.js — Data for /ai-prompt-generator/[slug] pages
-/lib            — Utility functions
-/prisma         — Schema and migrations
+  /gateway      — Prompt Studio model gateway (OpenRouter, BYOK)
+  /critique     — Prompt Studio LLM-as-judge critique
+  /templates    — Prompt Studio template library + slot-filling
+  /studio       — Prompt Studio entitlements (gating) + saved library
 ```
 
 ## Programmatic SEO Routes
@@ -62,11 +67,38 @@ npm run build    # production build
 npm run lint     # ESLint
 ```
 
-## Env Vars Required
+## Env Vars
 
-- `DATABASE_URL` — PostgreSQL connection string
-- `NEXTAUTH_SECRET` — NextAuth secret
-- `NEXTAUTH_URL` — Site URL
+The core marketing site needs **no** env vars (it's static content). The Prompt
+Studio layer uses these, all optional — the studio degrades gracefully without
+them (pure BYOK, free tier off, everyone on the free plan):
+
+- `OPENROUTER_FREE_KEY` — studio key for the capped free tier (OpenRouter's
+  free/rate-limited models). Absent ⇒ studio is pure BYOK.
+- `STUDIO_ENTITLEMENT_SECRET` — HMAC secret for verifying paid-plan entitlement
+  tokens. Absent ⇒ every caller is treated as `free`.
+
+There is intentionally **no** `DATABASE_URL` / `NEXTAUTH_*` — there's no DB or
+auth (see Stack).
+
+## Prompt Studio
+
+The API/integration layer under `lib/` + `pages/api/studio/`. Sells structure,
+not inference. See `docs/prompt-studio-gateway.md` for the full design.
+
+- **BYOK, client-only keys.** A user's API key arrives per-request in the
+  `x-user-api-key` header, is used in-memory for one call, and is never stored,
+  logged, returned, or traced. Never persist or log a user key.
+- **One gateway interface.** All model calls go through `lib/gateway`
+  (`complete()` / `compareModels()`). Adding/swapping a model is a config change
+  in `lib/gateway/models.js`, never endpoint code.
+- **Critique is grounded.** Every rubric criterion needs a justification +
+  in-prompt evidence span; a bare score is rejected as malformed, never surfaced.
+- **Feature gating** lives in `lib/studio/entitlements.js` (free = templates +
+  single-model; paid = compare + critique + saved library). Tier comes from a
+  signed `x-studio-entitlement` header; no token ⇒ free.
+- **Saved library** is client-side localStorage (`lib/studio/savedLibrary.js`) —
+  no server state.
 
 ## Conventions
 

--- a/__tests__/studio/entitlements.test.js
+++ b/__tests__/studio/entitlements.test.js
@@ -1,0 +1,91 @@
+import {
+  signEntitlement,
+  verifyEntitlement,
+  getTier,
+  isFeatureAllowed,
+  assertFeature,
+  featureMapForTier,
+  EntitlementError,
+} from '../../lib/studio/entitlements'
+
+const SECRET = 'test-secret-123'
+const reqWith = token => ({ headers: token ? { 'x-studio-entitlement': token } : {} })
+
+describe('entitlements — Phase 4', () => {
+  describe('token signing/verification', () => {
+    it('round-trips a valid token', () => {
+      const token = signEntitlement({ tier: 'paid' }, SECRET)
+      expect(verifyEntitlement(token, SECRET)).toMatchObject({ tier: 'paid' })
+    })
+
+    it('rejects a tampered token', () => {
+      const token = signEntitlement({ tier: 'paid' }, SECRET)
+      const tampered = token.slice(0, -2) + (token.endsWith('a') ? 'bb' : 'aa')
+      expect(verifyEntitlement(tampered, SECRET)).toBeNull()
+    })
+
+    it('rejects a token signed with a different secret', () => {
+      const token = signEntitlement({ tier: 'paid' }, 'other-secret')
+      expect(verifyEntitlement(token, SECRET)).toBeNull()
+    })
+
+    it('rejects an expired token', () => {
+      const token = signEntitlement({ tier: 'paid', exp: Math.floor(Date.now() / 1000) - 10 }, SECRET)
+      expect(verifyEntitlement(token, SECRET)).toBeNull()
+    })
+
+    it('returns null with no token or no secret', () => {
+      expect(verifyEntitlement(null, SECRET)).toBeNull()
+      expect(verifyEntitlement(signEntitlement({ tier: 'paid' }, SECRET), null)).toBeNull()
+    })
+  })
+
+  describe('getTier', () => {
+    it('defaults to free with no token', () => {
+      expect(getTier(reqWith(null), { secret: SECRET })).toBe('free')
+    })
+    it('returns paid for a valid paid token', () => {
+      const token = signEntitlement({ tier: 'paid' }, SECRET)
+      expect(getTier(reqWith(token), { secret: SECRET })).toBe('paid')
+    })
+    it('falls back to free for an invalid token', () => {
+      expect(getTier(reqWith('garbage.token'), { secret: SECRET })).toBe('free')
+    })
+  })
+
+  describe('feature gating per the brief', () => {
+    it('free unlocks templates + single-model run only', () => {
+      expect(isFeatureAllowed('templates', 'free')).toBe(true)
+      expect(isFeatureAllowed('run.single', 'free')).toBe(true)
+      expect(isFeatureAllowed('compare.multi', 'free')).toBe(false)
+      expect(isFeatureAllowed('critique', 'free')).toBe(false)
+      expect(isFeatureAllowed('library.saved', 'free')).toBe(false)
+    })
+
+    it('paid unlocks everything', () => {
+      for (const f of ['templates', 'run.single', 'compare.multi', 'critique', 'library.saved']) {
+        expect(isFeatureAllowed(f, 'paid')).toBe(true)
+      }
+    })
+
+    it('unknown features are denied by default', () => {
+      expect(isFeatureAllowed('nope', 'paid')).toBe(false)
+    })
+
+    it('assertFeature throws a 402 EntitlementError for a gated feature', () => {
+      try {
+        assertFeature('critique', 'free')
+        throw new Error('should have thrown')
+      } catch (err) {
+        expect(err).toBeInstanceOf(EntitlementError)
+        expect(err.status).toBe(402)
+        expect(err.code).toBe('upgrade_required')
+      }
+    })
+
+    it('featureMapForTier reflects the tier', () => {
+      expect(featureMapForTier('free')['compare.multi']).toBe(false)
+      expect(featureMapForTier('paid')['compare.multi']).toBe(true)
+    })
+  })
+})

--- a/__tests__/studio/savedLibrary.test.js
+++ b/__tests__/studio/savedLibrary.test.js
@@ -1,0 +1,71 @@
+import { createSavedLibrary } from '../../lib/studio/savedLibrary'
+
+// Minimal in-memory localStorage stand-in (the store only needs get/setItem).
+function memStorage(initial = {}) {
+  const map = new Map(Object.entries(initial))
+  return {
+    getItem: k => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, v),
+    _dump: () => Object.fromEntries(map),
+  }
+}
+
+describe('savedLibrary — Phase 4', () => {
+  it('saves an entry and reads it back', () => {
+    const lib = createSavedLibrary(memStorage())
+    const item = lib.save({ title: 'Cold email', body: 'Write an email to {{x}}', tags: ['email'] })
+    expect(item.id).toBeTruthy()
+    expect(item.rev).toBe(1)
+    expect(lib.get(item.id)).toMatchObject({ title: 'Cold email', body: 'Write an email to {{x}}' })
+    expect(lib.list()).toHaveLength(1)
+  })
+
+  it('requires a body', () => {
+    const lib = createSavedLibrary(memStorage())
+    expect(() => lib.save({ title: 'no body' })).toThrow(/body/)
+  })
+
+  it('lists newest first', () => {
+    let t = 1000
+    const lib = createSavedLibrary(memStorage(), { now: () => t++ })
+    const a = lib.save({ body: 'a' })
+    const b = lib.save({ body: 'b' })
+    expect(lib.list()[0].id).toBe(b.id) // b saved later
+    lib.update(a.id, { title: 'bumped' }) // now a is newest
+    expect(lib.list()[0].id).toBe(a.id)
+  })
+
+  it('updates immutably and bumps rev + updatedAt', () => {
+    const store = memStorage()
+    const lib = createSavedLibrary(store)
+    const item = lib.save({ body: 'v1' })
+    const updated = lib.update(item.id, { body: 'v2' })
+    expect(updated.rev).toBe(2)
+    expect(updated.body).toBe('v2')
+    expect(updated.updatedAt).toBeGreaterThanOrEqual(item.updatedAt)
+    // id and createdAt are not patchable.
+    expect(lib.update(item.id, { id: 'hacked', createdAt: 0 })).toMatchObject({ id: item.id, createdAt: item.createdAt })
+  })
+
+  it('returns null when updating a missing id', () => {
+    const lib = createSavedLibrary(memStorage())
+    expect(lib.update('nope', { body: 'x' })).toBeNull()
+  })
+
+  it('removes an entry', () => {
+    const lib = createSavedLibrary(memStorage())
+    const item = lib.save({ body: 'x' })
+    expect(lib.remove(item.id)).toBe(true)
+    expect(lib.remove(item.id)).toBe(false)
+    expect(lib.list()).toHaveLength(0)
+  })
+
+  it('tolerates corrupt storage by treating it as empty', () => {
+    const lib = createSavedLibrary(memStorage({ 'pws.studio.savedLibrary': 'not json' }))
+    expect(lib.list()).toEqual([])
+  })
+
+  it('throws when no storage is available (server-side)', () => {
+    expect(() => createSavedLibrary(null)).toThrow(/No storage/)
+  })
+})

--- a/docs/prompt-studio-gateway.md
+++ b/docs/prompt-studio-gateway.md
@@ -109,18 +109,30 @@ that isn't installed). Rather than stand that up just to store secrets, keys are
 - Endpoint `pages/api/studio/compare.js` meters the free tier per model in the
   batch and caps at 8 models/request.
 
-## Next (Phase 2, after review)
+## Phase 4 — persistence + freemium gating
 
-Wire the course-derived template library (`data/prompt-library.js`) as
-versioned, slot-filled prompts feeding `gateway.complete()` / `compareModels()`.
+Decided: **client-side saved library** (no DB/auth) + **gate per the brief**.
+
+- `lib/studio/savedLibrary.js` — localStorage-backed saved prompts (injectable
+  storage ⇒ SSR-safe + unit-testable). Immutable updates; `id`/`createdAt`/`rev`
+  not patchable. Pure storage — no secrets (BYOK keys never go here).
+- `lib/studio/entitlements.js` — feature gating. **Free** = `templates`,
+  `run.single`; **Paid** = `compare.multi`, `critique`, `library.saved`. Tier is
+  resolved from a signed (HMAC-SHA256) `x-studio-entitlement` header; no token or
+  no `STUDIO_ENTITLEMENT_SECRET` ⇒ `free`. Honest best-effort gating: real for
+  anyone holding a valid token; **issuing** tokens is an auth concern deferred.
+- `pages/api/studio/entitlement.js` — `GET` returns `{ tier, features }` for UX
+  gating. `compare.js` now returns **402 `upgrade_required`** for free callers.
+  `critique.js` (#46) gets the same one-line gate when it merges.
 
 ## Open items for Bryan
 
-1. **CLAUDE.md drift:** it documents Prisma/NextAuth/Postgres that aren't
-   installed. Phase 4 (saved library + freemium gating) needs a real decision on
-   persistence/auth. Flagging now; not blocking Phase 0/1.
-2. **OpenRouter slugs** in `models.js` are placeholders for the repo's
+1. **OpenRouter slugs** in `models.js` are placeholders for the repo's
    (fictional, 2026) model ids — verify against https://openrouter.ai/models
    before a live run.
-3. Set `OPENROUTER_FREE_KEY` in the environment to enable the free tier; without
-   it, the studio is pure BYOK (still fully functional).
+2. Set `OPENROUTER_FREE_KEY` to enable the free tier; without it the studio is
+   pure BYOK (still fully functional).
+3. Set `STUDIO_ENTITLEMENT_SECRET` and wire a billing webhook to mint paid
+   tokens (`signEntitlement`) once real auth/billing exists — until then every
+   caller is `free` and paid features are locked.
+4. CLAUDE.md drift is now fixed (no Prisma/NextAuth; client-only + localStorage).

--- a/lib/studio/entitlements.js
+++ b/lib/studio/entitlements.js
@@ -1,0 +1,85 @@
+// Feature gating for the studio (Phase 4).
+//
+// Free  = templates + single-model run.
+// Paid  = multi-model compare + critique + saved library.
+//
+// There is no auth in the repo yet, so a caller's tier comes from a SIGNED
+// entitlement token (HMAC-SHA256) in the `x-studio-entitlement` header. This is
+// honest "best-effort" gating: enforcement is real for anyone holding a valid
+// token, and issuing tokens is an auth concern deferred to a later phase. With
+// no token (or no STUDIO_ENTITLEMENT_SECRET configured) the caller is `free`.
+
+import { createHmac, timingSafeEqual } from 'crypto'
+
+export class EntitlementError extends Error {
+  constructor(feature) {
+    super(`"${feature}" requires the paid plan.`)
+    this.name = 'EntitlementError'
+    this.status = 402 // Payment Required
+    this.code = 'upgrade_required'
+    this.feature = feature
+  }
+}
+
+const TIER_ORDER = { free: 0, paid: 1 }
+
+// Minimum tier per feature. Add features here, not in endpoint code.
+export const FEATURES = {
+  templates: 'free',
+  'run.single': 'free',
+  'compare.multi': 'paid',
+  critique: 'paid',
+  'library.saved': 'paid',
+}
+
+function b64url(buf) {
+  return Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// Mint a token (for tests / a future billing webhook). payload e.g. { tier: 'paid', exp }.
+export function signEntitlement(payload, secret) {
+  const body = b64url(JSON.stringify(payload))
+  const sig = b64url(createHmac('sha256', secret).update(body).digest())
+  return `${body}.${sig}`
+}
+
+export function verifyEntitlement(token, secret) {
+  if (!token || !secret) return null
+  const [body, sig] = String(token).split('.')
+  if (!body || !sig) return null
+  const expected = b64url(createHmac('sha256', secret).update(body).digest())
+  const a = Buffer.from(sig)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null
+  let payload
+  try {
+    payload = JSON.parse(Buffer.from(body.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'))
+  } catch {
+    return null
+  }
+  if (payload.exp && Date.now() / 1000 > payload.exp) return null
+  return payload
+}
+
+// Resolve the caller's tier from the request. Defaults to 'free'.
+export function getTier(req, { secret = process.env.STUDIO_ENTITLEMENT_SECRET } = {}) {
+  const token = req?.headers?.['x-studio-entitlement']
+  const payload = verifyEntitlement(token, secret)
+  return payload && payload.tier === 'paid' ? 'paid' : 'free'
+}
+
+export function isFeatureAllowed(feature, tier) {
+  const required = FEATURES[feature]
+  if (required == null) return false // unknown feature → deny by default
+  return TIER_ORDER[tier] >= TIER_ORDER[required]
+}
+
+// Throw EntitlementError (402) when the tier can't use the feature.
+export function assertFeature(feature, tier) {
+  if (!isFeatureAllowed(feature, tier)) throw new EntitlementError(feature)
+}
+
+// A client-facing map of which features the tier can use (for UX gating).
+export function featureMapForTier(tier) {
+  return Object.fromEntries(Object.keys(FEATURES).map(f => [f, isFeatureAllowed(f, tier)]))
+}

--- a/lib/studio/savedLibrary.js
+++ b/lib/studio/savedLibrary.js
@@ -1,0 +1,104 @@
+// Saved prompt library — per-user persistence (Phase 4).
+//
+// Client-side by decision: entries live in localStorage, matching the existing
+// studio (PROMPT_STUDIO_SETUP.md). Nothing leaves the browser, so there's no DB
+// or auth to stand up. The store takes an injectable `storage` (anything with
+// getItem/setItem) so it's SSR-safe and unit-testable without a browser.
+//
+// All updates are immutable: methods return new objects/arrays and rewrite the
+// whole collection rather than mutating in place.
+//
+// NOTE: saving is a PAID feature ('library.saved' in entitlements). This module
+// is pure storage; the UI gates access via the entitlement endpoint. Don't put
+// secrets (e.g. BYOK keys) in here — it's plaintext localStorage.
+
+const STORAGE_KEY = 'pws.studio.savedLibrary'
+
+function genId() {
+  if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID()
+  return `sp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+// Returns the browser's localStorage, or null on the server / when unavailable.
+export function getBrowserStorage() {
+  try {
+    return typeof window !== 'undefined' && window.localStorage ? window.localStorage : null
+  } catch {
+    return null // Safari private mode etc.
+  }
+}
+
+export function createSavedLibrary(storage = getBrowserStorage(), { now = () => Date.now() } = {}) {
+  if (!storage) {
+    throw new Error('No storage available (server-side or disabled). Call from the browser.')
+  }
+
+  function readAll() {
+    const raw = storage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    try {
+      const parsed = JSON.parse(raw)
+      return Array.isArray(parsed) ? parsed : []
+    } catch {
+      return []
+    }
+  }
+
+  function writeAll(items) {
+    storage.setItem(STORAGE_KEY, JSON.stringify(items))
+    return items
+  }
+
+  return {
+    // Newest first.
+    list() {
+      return readAll().slice().sort((a, b) => b.updatedAt - a.updatedAt)
+    },
+
+    get(id) {
+      return readAll().find(it => it.id === id) || null
+    },
+
+    // Add a new entry. Returns the created item.
+    save({ title, body, tags = [], source = 'manual' }) {
+      if (!body || typeof body !== 'string') throw new Error('`body` is required.')
+      const ts = now()
+      const item = {
+        id: genId(),
+        title: title || 'Untitled prompt',
+        body,
+        tags,
+        source,
+        rev: 1,
+        createdAt: ts,
+        updatedAt: ts,
+      }
+      writeAll([...readAll(), item])
+      return item
+    },
+
+    // Immutable patch. Returns the updated item, or null if not found.
+    update(id, patch = {}) {
+      const items = readAll()
+      const idx = items.findIndex(it => it.id === id)
+      if (idx === -1) return null
+      const prev = items[idx]
+      // id/createdAt/rev are not patchable from the outside.
+      const { id: _i, createdAt: _c, rev: _r, ...safe } = patch
+      const next = { ...prev, ...safe, rev: prev.rev + 1, updatedAt: now() }
+      writeAll(items.map((it, i) => (i === idx ? next : it)))
+      return next
+    },
+
+    remove(id) {
+      const items = readAll()
+      const next = items.filter(it => it.id !== id)
+      writeAll(next)
+      return next.length !== items.length
+    },
+
+    clear() {
+      writeAll([])
+    },
+  }
+}

--- a/pages/api/studio/compare.js
+++ b/pages/api/studio/compare.js
@@ -10,6 +10,7 @@
 
 import { compareModels } from '../../../lib/gateway'
 import { GatewayError } from '../../../lib/gateway/errors'
+import { getTier, isFeatureAllowed } from '../../../lib/studio/entitlements'
 import { checkRateLimit } from '../../../lib/observatory/rateLimit'
 
 const FREE_TIER_MAX_PER_HOUR = 20
@@ -19,6 +20,14 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST')
     return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  // Multi-model compare is a paid feature (free = single-model run).
+  if (!isFeatureAllowed('compare.multi', getTier(req))) {
+    return res.status(402).json({
+      error: 'Multi-model compare is on the paid plan. Upgrade to compare models side by side.',
+      code: 'upgrade_required',
+    })
   }
 
   const userKey = req.headers['x-user-api-key'] || null

--- a/pages/api/studio/entitlement.js
+++ b/pages/api/studio/entitlement.js
@@ -1,0 +1,15 @@
+// pages/api/studio/entitlement.js
+// Phase 4: report the caller's tier and which features it unlocks, so the
+// client can gate the UI. Tier comes from the signed x-studio-entitlement
+// header (see lib/studio/entitlements.js); no token ⇒ free.
+
+import { getTier, featureMapForTier } from '../../../lib/studio/entitlements'
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+  const tier = getTier(req)
+  return res.status(200).json({ tier, features: featureMapForTier(tier) })
+}


### PR DESCRIPTION
## Summary

Phase 4 of the Prompt Studio API/integration layer — **per-user persistence + freemium gating** — plus a **CLAUDE.md correction** ("the Update").

Per the agreed decisions: saved library is **client-side (localStorage)** (no DB/auth to stand up), and gating follows the brief — **free** = templates + single-model run; **paid** = multi-model compare + critique + saved library.

Branches off `main`. Gates the paid feature that's currently on `main` (multi-model compare); critique (#46) gets the same one-line gate when it merges.

## Key changes

- **`lib/studio/savedLibrary.js`** — localStorage-backed saved prompts. Injectable `storage` + `now` clock make it SSR-safe and unit-testable. Immutable updates; `id`/`createdAt`/`rev` are not patchable; corrupt storage is treated as empty. Pure storage — **no BYOK keys ever go here**.
- **`lib/studio/entitlements.js`** — feature gating. `FEATURES` config maps each feature to a minimum tier. A caller's tier comes from a signed (HMAC-SHA256) `x-studio-entitlement` header; no token (or no `STUDIO_ENTITLEMENT_SECRET`) ⇒ `free`. Includes `signEntitlement`/`verifyEntitlement` (constant-time, expiry-checked), `getTier`, `isFeatureAllowed`, `assertFeature` (402), `featureMapForTier`.
- **`pages/api/studio/entitlement.js`** — `GET` returns `{ tier, features }` for UX gating.
- **`pages/api/studio/compare.js`** — now returns **402 `upgrade_required`** for free callers (multi-model is paid).
- **`CLAUDE.md`** — fixes the long-standing drift: the documented NextAuth/Prisma/Postgres stack was never installed. Now documents the real posture (no DB/auth, client-only BYOK, localStorage persistence, entitlement-token gating) and the studio's optional env vars. Adds a Prompt Studio conventions section.
- **`docs/prompt-studio-gateway.md`** — Phase 4 section + refreshed open items.

## Honest gating note

Without real auth, enforcement is **best-effort**: it's genuinely enforced for anyone holding a valid signed token, but **issuing** tokens needs a billing/auth flow (deferred). Until `STUDIO_ENTITLEMENT_SECRET` is set and a webhook mints paid tokens, every caller is `free` and paid features are locked. This is called out in the code and docs.

## Test plan

- `npm test` — full suite green (48 tests; 21 new).
- New tests: token sign/verify (tamper, wrong-secret, expiry, missing), tier resolution, per-feature gating per the brief, and saved-library CRUD + immutability + corruption/SSR guards.
- Manual: `GET /api/studio/entitlement` → `{ tier: "free", features: {...} }`; `POST /api/studio/compare` without a paid token → 402 `upgrade_required`.

## Notes

- No gateway change — gating + persistence sit on top of the single interface.
- This completes Phases 0–4 of the brief. Remaining hardening (real auth/billing to issue entitlement tokens, OpenRouter slug verification) is noted in the docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVJzsrCU91tXbRJLYSvVw4)_