### PR TITLE
PWS stops selling the closed course; observatory pricing and the Opus-4.7 tail now match the fact sources

### DIFF
--- a/BUSINESS_STRATEGY.md
+++ b/BUSINESS_STRATEGY.md
@@ -1,3 +1,5 @@
+> **ARCHIVED — 2026-06-11.** The course described in this document is closed (PWS sunset, strategy v0.6 §0.7); this strategy is superseded by the Claude-resource pivot. Kept for history only — do not use it to guide site content, CTAs, or monetisation.
+
 # PromptWritingStudio - Business Strategy for Course Sales
 
 ## Primary Goal: #1 Business-Focused Prompt Engineering Resource

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ To add a new modifier page: create a JSON in `/data/modifiers/` and link it from
 
 ## Design System
 
-- **Primary CTA**: Yellow `#FFDE59` bg, black text, text "Join Now"
-- **CTA URL**: `https://courses.becomeawritertoday.com/purchase?product_id=6640678`
+- **Primary CTA**: Yellow `#FFDE59` bg, black text
+- **CTA targets**: on-site free resources only (`/ai-prompt-generator`, `/ai-prompt-examples`, `/claude-code-guide`, `/calculators`). The Teachable course is closed — its checkout URL 404s. Never link to `courses.becomeawritertoday.com/purchase`.
 - **Text**: `#1A1A1A` headings, `#333333` body
 - **Backgrounds**: white or `#F9F9F9` alternating
 - **Borders**: `#E5E5E5`

--- a/README.md
+++ b/README.md
@@ -106,10 +106,8 @@ Each page in `seo-use-cases.js` includes:
 - Use system fonts for optimal readability and performance
 
 ### Content Guidelines
-- Maintain "Join Now" as the primary CTA text throughout the site
-- All "Join Now" CTAs link directly to the single course purchase URL (https://courses.becomeawritertoday.com/purchase?product_id=6640678)
-- Purchase URL:
-  - Complete Course: https://courses.becomeawritertoday.com/purchase?product_id=6640678 ($197 one-time payment)
+- The Teachable course is CLOSED (checkout URL returns 404). Do NOT add course purchase CTAs.
+- CTAs point to on-site free resources: /ai-prompt-generator, /ai-prompt-examples, /claude-code-guide, /calculators
 - Use benefit-driven headlines and copy
 - Include social proof and credibility indicators
 - Each section should have a clear purpose and call-to-action

--- a/components/calculators/BusinessAIReadinessCalculator.js
+++ b/components/calculators/BusinessAIReadinessCalculator.js
@@ -532,23 +532,21 @@ export default function BusinessAIReadinessCalculator() {
         <div className="bg-gradient-to-r from-blue-100 to-purple-100 rounded-lg p-6 text-center">
           <h3 className="text-xl font-bold mb-3 text-[#1A1A1A]">Ready to Start Your AI Journey?</h3>
           <p className="text-gray-600 mb-4">
-            Get personalized guidance on implementing AI in your business.
+            Take the next step: see what AI could save your business.
           </p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <a
-              href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
-              onClick={() => trackCTAClick('course_purchase')}
-              className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition-colors"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Get Prompt Writing Studio
-            </a>
-            <a
               href="/calculators/ai-cost-comparison"
-              className="border border-blue-600 text-blue-600 px-6 py-3 rounded-lg font-bold hover:bg-blue-600 hover:text-white transition-colors"
+              onClick={() => trackCTAClick('ai_cost_comparison')}
+              className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition-colors"
             >
               Calculate AI ROI
+            </a>
+            <a
+              href="/ai-prompt-examples"
+              className="border border-blue-600 text-blue-600 px-6 py-3 rounded-lg font-bold hover:bg-blue-600 hover:text-white transition-colors"
+            >
+              Browse Free AI Prompts
             </a>
           </div>
         </div>

--- a/components/calculators/CostComparisonCalculator.js
+++ b/components/calculators/CostComparisonCalculator.js
@@ -437,15 +437,13 @@ export default function CostComparisonCalculator() {
                 Ready to implement AI in your business?
               </h4>
               <p className="text-gray-600 mb-4">
-                Our PromptWritingStudio course teaches you the exact prompts and processes to achieve these savings.
+                Browse our free AI prompt examples to find the exact prompts and processes to achieve these savings.
               </p>
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                href="/ai-prompt-examples"
                 className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-bold hover:bg-blue-700 transition-colors duration-200"
-                target="_blank"
-                rel="noopener noreferrer"
               >
-                Start Learning Now
+                Browse Free Prompt Examples
               </a>
             </div>
 

--- a/components/tools/ROICalculator.js
+++ b/components/tools/ROICalculator.js
@@ -271,15 +271,13 @@ export default function ROICalculator() {
                 Ready to start saving time and money?
               </h4>
               <p className="text-gray-600 mb-4">
-                Our PromptWritingStudio course shows you exactly how to implement these AI automations in your business.
+                Our free AI prompt examples show you exactly how to implement these AI automations in your business.
               </p>
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                href="/ai-prompt-examples"
                 className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition-colors duration-200"
-                target="_blank"
-                rel="noopener noreferrer"
               >
-                Start Learning Now
+                Browse Free Prompt Examples
               </a>
             </div>
 

--- a/components/ui/ConversionOptimizer.js
+++ b/components/ui/ConversionOptimizer.js
@@ -60,21 +60,12 @@ export default function ConversionOptimizer({
 
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
-                onClick={() => handleCTAClick('course_purchase')}
-                className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200 inline-flex items-center justify-center"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                🚀 Start Saving Now - Get Course
-                {showUrgency && <span className="ml-2 text-sm">(Limited Time)</span>}
-              </a>
-              <button
+                href="/ai-prompt-examples"
                 onClick={() => handleCTAClick('free_prompts')}
-                className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-blue-600 transition-colors duration-200"
+                className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200 inline-flex items-center justify-center"
               >
                 📝 Get Free AI Prompts
-              </button>
+              </a>
             </div>
           </div>
         </div>
@@ -175,20 +166,18 @@ export function StickyMobileCTA({ calculatorName, hasResults = false }) {
             {hasResults ? '🎯 Ready to implement?' : '🚀 Start saving with AI'}
           </div>
           <div className="text-xs opacity-90">
-            {hasResults ? 'Get the course & prompts' : 'Calculate your savings first'}
+            {hasResults ? 'Get free prompts & guides' : 'Calculate your savings first'}
           </div>
         </div>
         <a
-          href={hasResults 
-            ? "https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+          href={hasResults
+            ? "/ai-prompt-examples"
             : "#calculator"
           }
-          onClick={() => handleCTAClick(hasResults ? 'mobile_sticky_course' : 'mobile_sticky_calculator')}
+          onClick={() => handleCTAClick(hasResults ? 'mobile_sticky_prompts' : 'mobile_sticky_calculator')}
           className="bg-[#FFDE59] text-[#1A1A1A] px-4 py-2 rounded-lg font-bold text-sm hover:bg-[#E5C84F] transition-colors"
-          target={hasResults ? "_blank" : undefined}
-          rel={hasResults ? "noopener noreferrer" : undefined}
         >
-          {hasResults ? 'Get Course' : 'Calculate'}
+          {hasResults ? 'Free Prompts' : 'Calculate'}
         </a>
       </div>
     </div>

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -160,11 +160,11 @@ export default function SEOPage({ pageData }) {
             <p className="text-xl mb-8">
               Access our full library of templates and start creating better prompts today.
             </p>
-            <Link 
-              href="/#pricing" 
+            <Link
+              href="/ai-prompt-examples"
               className="bg-white text-indigo-600 px-8 py-3 rounded-lg font-bold hover:bg-gray-100 transition inline-block"
             >
-              View Pricing Plans
+              Browse Free Prompt Examples
             </Link>
           </div>
         </div>

--- a/pages/ai-models.js
+++ b/pages/ai-models.js
@@ -22,8 +22,8 @@ export default function AIModels() {
     "@context": "https://schema.org",
     "@type": "TechArticle",
     "headline": "AI Models Compared: Claude, GPT, Gemini, Llama, Mistral & More",
-    "description": "Up-to-date comparison of the major AI models — Claude Opus 4.7, Sonnet 4.6, Haiku 4.5, GPT-5, GPT-4o, Gemini 2.5 Pro, Llama 3.3, Mistral Large and more — with context windows, pricing, and feature differences.",
-    "keywords": "AI models, Claude Opus 4.7, Claude Sonnet 4.6, GPT-5, GPT-4o, Gemini 2.5 Pro, Llama 3.3, Mistral, LLM comparison",
+    "description": "Up-to-date comparison of the major AI models — Claude Opus 4.8, Sonnet 4.6, Haiku 4.5, GPT-5, GPT-4o, Gemini 2.5 Pro, Llama 3.3, Mistral Large and more — with context windows, pricing, and feature differences.",
+    "keywords": "AI models, Claude Opus 4.8, Claude Sonnet 4.6, GPT-5, GPT-4o, Gemini 2.5 Pro, Llama 3.3, Mistral, LLM comparison",
     "datePublished": "2025-01-15T00:00:00+00:00",
     "dateModified": `${AI_MODELS_META.lastVerified}T00:00:00+00:00`,
     "author": {
@@ -68,7 +68,7 @@ export default function AIModels() {
     },
     {
       question: "What are the notable flagship text and multimodal AI models?",
-      answer: "Claude Opus 4.7 (Anthropic) for agentic coding and long-horizon reasoning with a 1M context window; Claude Sonnet 4.6 (Anthropic) for the best price-performance day-to-day with a 1M context window; GPT-5 (OpenAI) as a flagship multimodal model; and Gemini 2.5 Pro (Google) with a 1M+ token context window."
+      answer: "Claude Opus 4.8 (Anthropic) for agentic coding and long-horizon reasoning with a 1M context window; Claude Sonnet 4.6 (Anthropic) for the best price-performance day-to-day with a 1M context window; GPT-5 (OpenAI) as a flagship multimodal model; and Gemini 2.5 Pro (Google) with a 1M+ token context window."
     },
     {
       question: "What are the notable specialized and open-source AI models?",
@@ -178,7 +178,7 @@ export default function AIModels() {
   return (
     <Layout
       title="AI Models Compared — Claude, GPT, Gemini, Llama & More (2026)"
-      description="Up-to-date comparison of the major AI models — Claude Opus 4.7, Sonnet 4.6, Haiku 4.5, GPT-5, GPT-4o, Gemini 2.5 Pro, Llama 3.3, Mistral Large, DeepSeek V3 — with context windows, pricing, and feature differences."
+      description="Up-to-date comparison of the major AI models — Claude Opus 4.8, Sonnet 4.6, Haiku 4.5, GPT-5, GPT-4o, Gemini 2.5 Pro, Llama 3.3, Mistral Large, DeepSeek V3 — with context windows, pricing, and feature differences."
     >
       <script
         type="application/ld+json"
@@ -202,7 +202,7 @@ export default function AIModels() {
                 AI Models Guide
               </h1>
               <p className="text-xl md:text-2xl mb-8 max-w-3xl mx-auto">
-                Side-by-side look at the major AI models — Claude Opus 4.7, Sonnet 4.6, Haiku 4.5, GPT-5, GPT-4o,
+                Side-by-side look at the major AI models — Claude Opus 4.8, Sonnet 4.6, Haiku 4.5, GPT-5, GPT-4o,
                 Gemini 2.5 Pro, Llama 3.3, Mistral Large, DeepSeek V3 — with context windows, pricing, and what each is best at.
               </p>
               <div className="flex flex-wrap justify-center gap-4 text-lg">
@@ -480,7 +480,7 @@ export default function AIModels() {
                     </tr>
                     <tr className="bg-gray-50">
                       <td className="border border-gray-300 px-4 py-3 font-medium">Large Language Models</td>
-                      <td className="border border-gray-300 px-4 py-3">Claude Opus 4.7, Claude Sonnet 4.6, GPT-5, Gemini 2.5 Pro, Llama 3.3</td>
+                      <td className="border border-gray-300 px-4 py-3">Claude Opus 4.8, Claude Sonnet 4.6, GPT-5, Gemini 2.5 Pro, Llama 3.3</td>
                       <td className="border border-gray-300 px-4 py-3">Chatbots, research, text generation, code generation</td>
                     </tr>
                     <tr>
@@ -505,7 +505,7 @@ export default function AIModels() {
                 <div className="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg border-l-4 border-blue-500">
                   <h4 className="text-lg font-semibold mb-3 text-blue-800">Text & Multimodal</h4>
                   <ul className="text-sm text-gray-700 space-y-2">
-                    <li><strong>Claude Opus 4.7 (Anthropic):</strong> Agentic coding + long-horizon reasoning, 1M context</li>
+                    <li><strong>Claude Opus 4.8 (Anthropic):</strong> Agentic coding + long-horizon reasoning, 1M context</li>
                     <li><strong>Claude Sonnet 4.6 (Anthropic):</strong> Best price-performance for day-to-day, 1M context</li>
                     <li><strong>GPT-5 (OpenAI):</strong> Flagship multimodal model</li>
                     <li><strong>Gemini 2.5 Pro (Google):</strong> 1M+ token context window</li>

--- a/pages/ai-prompt-quiz.js
+++ b/pages/ai-prompt-quiz.js
@@ -161,7 +161,7 @@ const resultProfiles = {
       "Learn basic prompt structure and formatting",
       "Experiment with different AI tools"
     ],
-    courseMatch: "Perfect for our Basic Plan - learn the fundamentals step by step."
+    courseMatch: "Next step: explore our free AI prompt examples library to learn the fundamentals step by step."
   },
   intermediate: {
     title: "🚀 Prompt Writing Practitioner", 
@@ -173,7 +173,7 @@ const resultProfiles = {
       "Practice iterative prompt refinement",
       "Develop your unique voice and style"
     ],
-    courseMatch: "Ready for our Pro Plan - advanced techniques and workflows."
+    courseMatch: "Next step: work through our free ChatGPT prompt templates to build advanced techniques and workflows."
   },
   advanced: {
     title: "⭐ Prompt Writing Expert",
@@ -185,7 +185,7 @@ const resultProfiles = {
       "Master brand voice consistency techniques",
       "Explore advanced AI model capabilities"
     ],
-    courseMatch: "Perfect for our Elite Plan - specialized business strategies and 1-on-1 coaching."
+    courseMatch: "Next step: dive into our free Claude Code guide for business-grade AI workflows."
   },
   expert: {
     title: "🏆 Prompt Writing Master",
@@ -197,7 +197,7 @@ const resultProfiles = {
       "Develop custom prompt frameworks",
       "Focus on industry-specific applications"
     ],
-    courseMatch: "You might enjoy our Elite Plan for the community and advanced business applications."
+    courseMatch: "Next step: explore the Prompt Observatory to see how top prompts are scored and benchmarked."
   }
 };
 

--- a/pages/calculators/ai-cost-comparison.js
+++ b/pages/calculators/ai-cost-comparison.js
@@ -344,7 +344,7 @@ export default function AICostComparisonPage() {
               Ready to Implement AI in Your Business?
             </h2>
             <p className="text-lg mb-4 opacity-90">
-              Our PromptWritingStudio course teaches you the exact prompts and processes 
+              Our free AI prompt examples show you the exact prompts and processes
               to achieve the cost savings shown in your calculation.
             </p>
             <div className="bg-white bg-opacity-20 rounded-lg p-4 mb-6">
@@ -357,14 +357,12 @@ export default function AICostComparisonPage() {
               </p>
             </div>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+              <Link
+                href="/ai-prompt-examples"
                 className="bg-white text-blue-600 px-8 py-4 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors duration-200"
-                target="_blank"
-                rel="noopener noreferrer"
               >
-                Start Learning Now
-              </a>
+                Browse Free Prompt Examples
+              </Link>
               <Link
                 href="/roi-calculator"
                 className="border border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-blue-600 transition-colors duration-200"

--- a/pages/calculators/business-ai-readiness.js
+++ b/pages/calculators/business-ai-readiness.js
@@ -355,19 +355,17 @@ const BusinessAIReadinessPage = () => {
                 Ready to Begin Your AI Journey?
               </h2>
               <p className="text-xl mb-6 opacity-90">
-                Get expert guidance on AI implementation strategy and execution with Prompt Writing Studio.
+                Use our free AI prompts and guides to plan your implementation strategy and execution.
               </p>
               <div className="space-y-4">
                 <a
-                  href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                  href="/ai-prompt-examples"
                   className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors"
-                  target="_blank"
-                  rel="noopener noreferrer"
                 >
-                  Join Prompt Writing Studio
+                  Browse Free AI Prompts
                 </a>
                 <div className="text-sm opacity-75">
-                  ✓ AI Strategy Development ✓ Implementation Roadmap ✓ Change Management ✓ ROI Tracking
+                  ✓ Free Prompt Examples ✓ Implementation Guides ✓ Business Calculators ✓ ROI Tracking
                 </div>
               </div>
             </div>

--- a/pages/calculators/claude-code-vs-cursor-cost.js
+++ b/pages/calculators/claude-code-vs-cursor-cost.js
@@ -39,7 +39,7 @@ const faqs = [
   },
   {
     question: "Why does Opus usage blow up the cost?",
-    answer: "Claude Opus 4.7 is ~1.7x the price of Sonnet 4.6 per token ($5/$25 vs $3/$15 per MTok). If your workflow leans heavily on Opus (complex reasoning, deep code review, long-document analysis), API costs scale fast. For Opus-heavy work, Claude Max's $100 or $200 flat tier is often the economical choice over pure API billing."
+    answer: "Claude Opus 4.8 is ~1.7x the price of Sonnet 4.6 per token ($5/$25 vs $3/$15 per MTok). If your workflow leans heavily on Opus (complex reasoning, deep code review, long-document analysis), API costs scale fast. For Opus-heavy work, Claude Max's $100 or $200 flat tier is often the economical choice over pure API billing."
   },
   {
     question: "Is the token-per-hour estimate realistic?",

--- a/pages/calculators/claude-plan-picker.js
+++ b/pages/calculators/claude-plan-picker.js
@@ -40,7 +40,7 @@ const faqs = [
   },
   {
     question: "What does 'API-equivalent cost' mean?",
-    answer: "It's the price you'd pay if you ran the same workload through the Anthropic API instead of a subscription. We calculate it from current Claude Opus 4.7, Sonnet 4.6, and Haiku 4.5 per-token rates. The subscription is only a good deal if the flat price is lower than your API-equivalent spend — otherwise you're subsidising Anthropic."
+    answer: "It's the price you'd pay if you ran the same workload through the Anthropic API instead of a subscription. We calculate it from current Claude Opus 4.8, Sonnet 4.6, and Haiku 4.5 per-token rates. The subscription is only a good deal if the flat price is lower than your API-equivalent spend — otherwise you're subsidising Anthropic."
   },
   {
     question: "Are Anthropic's usage limits really 5x / 25x / 100x?",

--- a/pages/calculators/claude-prompt-cost.js
+++ b/pages/calculators/claude-prompt-cost.js
@@ -30,7 +30,7 @@ const faqs = [
   },
   {
     question: "How much cheaper is Haiku than Opus?",
-    answer: "Haiku 4.5 is 5x cheaper than Opus 4.7 on both input and output — $1/M in vs $5/M in, and $5/M out vs $25/M out. For high-volume routine tasks (classification, short Q&A, simple transforms), running Haiku instead of Opus is one of the biggest cost optimisations available. The quality difference is often invisible for easy tasks. (Note: older Opus 4 and 4.1 were $15/$75 per MTok — a 15x gap — but current-generation Opus dropped to $5/$25 with the 4.5 release.)"
+    answer: "Haiku 4.5 is 5x cheaper than Opus 4.8 on both input and output — $1/M in vs $5/M in, and $5/M out vs $25/M out. For high-volume routine tasks (classification, short Q&A, simple transforms), running Haiku instead of Opus is one of the biggest cost optimisations available. The quality difference is often invisible for easy tasks. (Note: older Opus 4 and 4.1 were $15/$75 per MTok — a 15x gap — but current-generation Opus dropped to $5/$25 with the 4.5 release.)"
   },
   {
     question: "How do I cut my Claude API costs?",
@@ -71,7 +71,7 @@ export default function ClaudePromptCost() {
     <>
       <Head>
         <title>Claude Prompt Cost Calculator (Opus, Sonnet, Haiku) | PromptWritingStudio</title>
-        <meta name="description" content="Calculate the cost of a single Claude API call — or a million of them. Supports Claude Opus 4.7, Sonnet 4.6, and Haiku 4.5 at current Anthropic pricing. Free, no signup." />
+        <meta name="description" content="Calculate the cost of a single Claude API call — or a million of them. Supports Claude Opus 4.8, Sonnet 4.6, and Haiku 4.5 at current Anthropic pricing. Free, no signup." />
         <link rel="canonical" href="https://promptwritingstudio.com/calculators/claude-prompt-cost" />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
       </Head>
@@ -81,7 +81,7 @@ export default function ClaudePromptCost() {
           <div className="container mx-auto px-4 md:px-6 text-center">
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">Claude Prompt Cost Calculator</h1>
             <p className="text-xl text-gray-200 max-w-3xl mx-auto">
-              Work out what a Claude API call will cost — one call, a thousand, or a million — across Haiku 4.5, Sonnet 4.6, and Opus 4.7.
+              Work out what a Claude API call will cost — one call, a thousand, or a million — across Haiku 4.5, Sonnet 4.6, and Opus 4.8.
             </p>
             <LastVerified date={MODELS_META.lastVerified} source={MODELS_META.source} className="mt-4 text-gray-300" />
           </div>
@@ -192,7 +192,7 @@ export default function ClaudePromptCost() {
             <div className="space-y-4">
               <div className="bg-[#F9F9F9] p-5 rounded-lg border-l-4 border-[#FFDE59]">
                 <h3 className="font-bold text-[#1A1A1A] mb-1">1. Pick the smallest model that works</h3>
-                <p className="text-[#333333]">Start with Haiku. Escalate only when quality suffers. Dropping from Opus 4.7 to Sonnet 4.6 cuts cost by 40%; dropping from Sonnet to Haiku cuts another 67%.</p>
+                <p className="text-[#333333]">Start with Haiku. Escalate only when quality suffers. Dropping from Opus 4.8 to Sonnet 4.6 cuts cost by 40%; dropping from Sonnet to Haiku cuts another 67%.</p>
               </div>
               <div className="bg-[#F9F9F9] p-5 rounded-lg border-l-4 border-[#FFDE59]">
                 <h3 className="font-bold text-[#1A1A1A] mb-1">2. Use prompt caching for repeated context</h3>

--- a/pages/calculators/content-creation-speed.js
+++ b/pages/calculators/content-creation-speed.js
@@ -290,19 +290,17 @@ export default function ContentCreationSpeedPage() {
                   Ready to Actually Implement These Time Savings?
                 </h2>
                 <p className="text-xl mb-6 opacity-90">
-                  Get the exact AI prompts, workflows, and strategies that top content creators use to 4-8x their output
+                  Browse the free AI prompts, workflows, and strategies that top content creators use to 4-8x their output
                 </p>
                 <div className="text-sm opacity-75 mb-6">
-                  ✓ 50+ Proven AI Prompts ✓ Step-by-Step Workflows ✓ Industry-Specific Templates
+                  ✓ Free AI Prompt Examples ✓ Step-by-Step Workflows ✓ Copy-Paste Templates
                 </div>
-                <a
-                  href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <Link
+                  href="/ai-prompt-examples"
                   className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors"
                 >
-                  Join Prompt Writing Studio
-                </a>
+                  Browse Free Prompt Examples
+                </Link>
               </div>
             </div>
 

--- a/pages/calculators/content-creation-speed.js
+++ b/pages/calculators/content-creation-speed.js
@@ -37,7 +37,7 @@ export default function ContentCreationSpeedPage() {
     },
     {
       question: "What AI tools do I need to achieve these results?",
-      answer: "You can achieve significant results with ChatGPT, Claude, or similar AI writing assistants. The key is knowing the right prompts and workflows, which our course teaches in detail.",
+      answer: "You can achieve significant results with ChatGPT, Claude, or similar AI writing assistants. The key is knowing the right prompts and workflows — start with our free AI prompt examples and ChatGPT templates.",
       relatedLinks: [
         { text: "AI Prompt Examples", url: "/ai-prompt-examples" },
         { text: "ChatGPT Templates", url: "/chatgpt-prompt-templates" }

--- a/pages/calculators/customer-service-ai-savings.js
+++ b/pages/calculators/customer-service-ai-savings.js
@@ -334,18 +334,16 @@ const CustomerServiceAIPage = () => {
                 Ready to Transform Your Customer Service?
               </h2>
               <p className="text-xl mb-6 opacity-90">
-                Learn advanced AI strategies for customer service optimization in Prompt Writing Studio.
+                Learn advanced AI strategies for customer service optimization with our free prompts and guides.
               </p>
               <div className="text-sm opacity-75 mb-6">
-                ✓ AI Strategy Development ✓ Implementation Roadmap ✓ Change Management ✓ ROI Tracking
+                ✓ Free Prompt Examples ✓ Implementation Guides ✓ Business Calculators ✓ ROI Tracking
               </div>
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                href="/ai-prompt-examples"
                 className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors"
-                target="_blank"
-                rel="noopener noreferrer"
               >
-                Join Prompt Writing Studio
+                Browse Free AI Prompts
               </a>
             </div>
           </div>

--- a/pages/calculators/ecommerce-ai-savings.js
+++ b/pages/calculators/ecommerce-ai-savings.js
@@ -25,7 +25,7 @@ export default function EcommerceAISavingsPage() {
     },
     {
       question: "Will AI-generated product descriptions hurt my SEO?",
-      answer: "No, when properly prompted, AI creates SEO-optimized, unique content that search engines love. The key is using the right prompts and review processes, which our course teaches in detail.",
+      answer: "No, when properly prompted, AI creates SEO-optimized, unique content that search engines love. The key is using the right prompts and review processes — our free AI prompt examples and ChatGPT templates show the patterns that work.",
       relatedLinks: [
         { text: "AI Prompt Examples", url: "/ai-prompt-examples" },
         { text: "ChatGPT Templates", url: "/chatgpt-prompt-templates" }

--- a/pages/calculators/ecommerce-ai-savings.js
+++ b/pages/calculators/ecommerce-ai-savings.js
@@ -434,19 +434,17 @@ export default function EcommerceAISavingsPage() {
                   Ready to Implement E-commerce AI Automation?
                 </h2>
                 <p className="text-xl mb-6 opacity-90">
-                  Get the complete toolkit of AI prompts, workflows, and strategies specifically designed for e-commerce stores
+                  Browse free AI prompts, workflows, and strategies you can adapt for your e-commerce store
                 </p>
                 <div className="text-sm opacity-75 mb-6">
-                  ✓ Platform-Specific Prompts ✓ Automation Workflows ✓ Customer Service Scripts ✓ Marketing Templates
+                  ✓ Free Prompt Examples ✓ Automation Workflows ✓ Customer Service Scripts ✓ Marketing Templates
                 </div>
-                <a
-                  href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                <Link
+                  href="/ai-prompt-examples"
                   className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors"
-                  target="_blank"
-                  rel="noopener noreferrer"
                 >
-                  Join Prompt Writing Studio
-                </a>
+                  Browse Free AI Prompts
+                </Link>
               </div>
             </div>
 

--- a/pages/calculators/index.js
+++ b/pages/calculators/index.js
@@ -70,7 +70,7 @@ export default function CalculatorsHub() {
     },
     {
       title: 'Claude Model Selector',
-      description: 'Pick the right Claude model (Opus 4.7, Sonnet 4.6, Haiku 4.5) for your task with live monthly cost estimates',
+      description: 'Pick the right Claude model (Opus 4.8, Sonnet 4.6, Haiku 4.5) for your task with live monthly cost estimates',
       url: '/calculators/claude-model-selector',
       keywords: ['Claude model', 'Claude pricing', 'Opus vs Sonnet'],
       color: 'from-amber-500 to-yellow-400',
@@ -88,7 +88,7 @@ export default function CalculatorsHub() {
     },
     {
       title: 'Claude Prompt Cost Calculator',
-      description: 'Calculate the cost of a single Claude API call (or a million), across Haiku 4.5, Sonnet 4.6, and Opus 4.7',
+      description: 'Calculate the cost of a single Claude API call (or a million), across Haiku 4.5, Sonnet 4.6, and Opus 4.8',
       url: '/calculators/claude-prompt-cost',
       keywords: ['Claude API cost', 'token pricing', 'prompt cost'],
       color: 'from-emerald-500 to-teal-600',

--- a/pages/calculators/index.js
+++ b/pages/calculators/index.js
@@ -430,21 +430,13 @@ export default function CalculatorsHub() {
               Ready to Implement Your AI Strategy?
             </h2>
             <p className="text-lg mb-8 opacity-90">
-              After calculating your potential savings, learn how to implement AI in your business 
-              with our comprehensive PromptWritingStudio course.
+              After calculating your potential savings, explore our free AI prompt tools
+              and guides to start implementing AI in your business.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
-                className="bg-white text-blue-600 px-8 py-4 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors duration-200"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Start Learning Now
-              </a>
               <Link
                 href="/ai-prompt-generator"
-                className="border border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-blue-600 transition-colors duration-200"
+                className="bg-white text-blue-600 px-8 py-4 rounded-lg font-bold text-lg hover:bg-gray-100 transition-colors duration-200"
               >
                 Try Free Tools
               </Link>

--- a/pages/chatgpt-prompt-templates.js
+++ b/pages/chatgpt-prompt-templates.js
@@ -288,38 +288,20 @@ export default function ChatGPTPromptTemplates({ modifiers }) {
         </div>
       </section>
       
-      {/* Teachable Course CTA */}
-      <section className="py-16 md:py-24 bg-white">
-        <div className="container mx-auto px-4 md:px-6">
-          <div className="max-w-3xl mx-auto text-center border border-[#E5E5E5] rounded-lg p-8 md:p-12">
-            <h2 className="text-3xl md:text-4xl font-bold mb-4 text-[#1A1A1A]">Want ChatGPT prompts that actually convert?</h2>
-            <p className="text-lg text-[#333333] mb-8">
-              Prompt Writing Studio teaches you how to turn these templates into repeatable ChatGPT workflows for your writing, marketing, and client work.
-            </p>
-            <a
-              href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
-              className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-md font-bold hover:bg-[#E5C84F] transition inline-block"
-            >
-              Join Now
-            </a>
-          </div>
-        </div>
-      </section>
-
       {/* CTA Section */}
       <section className="py-16 md:py-24 gradient-bg text-white">
         <div className="container mx-auto px-4 md:px-6">
           <div className="max-w-3xl mx-auto text-center">
             <h2 className="text-3xl md:text-4xl font-bold mb-6">Ready to Master AI Prompt Writing?</h2>
             <p className="text-xl mb-8">
-              Get access to our full library of premium prompt templates, personalized guidance, and expert techniques to create content that truly sounds like you.
+              Get access to our full library of free prompt templates and expert techniques to create content that truly sounds like you.
             </p>
             <div className="flex flex-wrap justify-center gap-4">
-              <Link 
-                href="/#pricing" 
+              <Link
+                href="/ai-prompt-examples"
                 className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition-colors duration-200 inline-block"
               >
-                View Pricing Plans
+                Browse Prompt Examples
               </Link>
               <Link 
                 href="/ai-prompt-generator" 

--- a/pages/chatgpt-prompts-for/[modifier].js
+++ b/pages/chatgpt-prompts-for/[modifier].js
@@ -645,14 +645,14 @@ export default function ModifierPage({ modifierData }) {
           <div className="max-w-3xl mx-auto text-center">
             <h2 className="text-3xl md:text-4xl font-bold mb-6">Ready to Master ChatGPT for {modifierName}?</h2>
             <p className="text-xl mb-8">
-              Get access to our full library of premium prompt templates and start creating content that truly sounds like you.
+              Get access to our full library of free prompt templates and start creating content that truly sounds like you.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link 
-                href="/#pricing" 
+              <Link
+                href="/ai-prompt-examples"
                 className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition"
               >
-                View Pricing Plans
+                Browse Free Prompt Examples
               </Link>
               <Link
                 href="/chatgpt-prompt-templates"

--- a/pages/claude-code-skills/build-your-own.js
+++ b/pages/claude-code-skills/build-your-own.js
@@ -39,7 +39,7 @@ const faqs = [
 const frontmatterFields = [
   { field: "description", required: true, desc: "One-line plain-English summary of what the skill does. Claude Code shows this in autocomplete." },
   { field: "allowed-tools", required: false, desc: "Array of tool names the skill can use (e.g. [Bash, Read, Edit]). Omit to allow all tools." },
-  { field: "model", required: false, desc: "Force a specific Claude model — 'claude-haiku-4-5' for lightweight tasks, 'claude-opus-4-7' for deep reasoning." },
+  { field: "model", required: false, desc: "Force a specific Claude model — 'claude-haiku-4-5' for lightweight tasks, 'claude-opus-4-8' for deep reasoning." },
   { field: "argument-hint", required: false, desc: "What input, if any, the skill expects. Shown in autocomplete after the slash command." }
 ]
 

--- a/pages/cookie-policy.js
+++ b/pages/cookie-policy.js
@@ -140,12 +140,6 @@ export default function CookiePolicy() {
                       <td className="px-4 py-2">_gtm</td>
                       <td className="px-4 py-2">Session</td>
                     </tr>
-                    <tr className="border-t">
-                      <td className="px-4 py-2">Teachable</td>
-                      <td className="px-4 py-2">Course platform</td>
-                      <td className="px-4 py-2">_teachable_session</td>
-                      <td className="px-4 py-2">Session</td>
-                    </tr>
                   </tbody>
                 </table>
               </div>

--- a/pages/disclosure.js
+++ b/pages/disclosure.js
@@ -32,9 +32,9 @@ export default function Disclosure() {
                   buy a product or subscribe to a service, we may earn a commission at no extra cost to you.
                 </li>
                 <li>
-                  <strong>Course + digital product sales.</strong> We sell educational products — including
-                  the Prompt Writing Studio course — hosted through Teachable under the Become a Writer Today
-                  brand. Those purchases are a direct relationship between you and Teachable.
+                  <strong>Course + digital product sales (historical).</strong> We previously sold the
+                  Prompt Writing Studio course, hosted through Teachable under the Become a Writer Today
+                  brand. That course is now closed to new enrollment and is no longer sold on this site.
                 </li>
                 <li>
                   <strong>Referral credits.</strong> Some tools (for example, Anthropic's Claude referral
@@ -49,7 +49,7 @@ export default function Disclosure() {
                 the whole site. You should assume that any outbound link to a paid AI tool, course, or software
                 product on Prompt Writing Studio <strong>may</strong> be an affiliate or referral link. That
                 currently includes, but is not limited to: Anthropic (Claude), OpenAI (ChatGPT), Jasper,
-                Grammarly, Teachable, and various tools we recommend in our reviews and calculators.
+                Grammarly, and various tools we recommend in our reviews and calculators.
               </p>
               <p className="mb-6">
                 If a link is <em>not</em> an affiliate link — for example, a link to official documentation, a

--- a/pages/gemini-prompt-generator.js
+++ b/pages/gemini-prompt-generator.js
@@ -316,11 +316,11 @@ export default function GeminiPromptGenerator() {
               Learn advanced prompt engineering techniques for Gemini, ChatGPT, and Claude. 
               Get access to 100+ professional templates and expert strategies.
             </p>
-            <Link 
-              href="/#pricing"
+            <Link
+              href="/ai-prompt-examples"
               className="inline-block bg-gradient-to-r from-blue-600 to-purple-600 text-white px-8 py-3 rounded-lg font-semibold hover:from-blue-700 hover:to-purple-700 transition-all duration-200"
             >
-              View Course Details
+              Browse Free Prompt Examples
             </Link>
           </div>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -243,7 +243,7 @@ export default function Home() {
       <Instructor />
       <TestimonialEmbed />
 
-      {/* Course CTA — single Teachable purchase path */}
+      {/* Free tools CTA */}
       <section className="py-16 md:py-24 bg-[#F9F9F9] border-t border-[#E5E5E5]">
         <div className="container mx-auto px-4 md:px-6">
           <div className="max-w-3xl mx-auto text-center">
@@ -251,17 +251,15 @@ export default function Home() {
               Ready to write better prompts that actually work?
             </h2>
             <p className="text-lg text-[#333333] mb-8">
-              The PromptWritingStudio course walks you through the same prompt patterns and workflows
-              used in the guides on this site — applied to real email, content, and business tasks.
+              The free guides and tools on this site walk you through proven prompt patterns and workflows
+              — applied to real email, content, and business tasks.
             </p>
-            <a
-              href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/ai-prompt-generator"
               className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200"
             >
-              Join Now
-            </a>
+              Try the Free Prompt Generator
+            </Link>
           </div>
         </div>
       </section>

--- a/pages/privacy-policy.js
+++ b/pages/privacy-policy.js
@@ -31,7 +31,6 @@ export default function PrivacyPolicy() {
                 <li><strong>Contact Information:</strong> Email address, name when you subscribe to our newsletter or contact us</li>
                 <li><strong>Communication Data:</strong> Messages you send us through contact forms or email</li>
                 <li><strong>Survey Data:</strong> Responses to surveys or feedback forms you complete voluntarily</li>
-                <li><strong>Course Enrollment:</strong> Information provided when enrolling in courses through our partner Teachable</li>
               </ul>
 
               <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">1.2 Information Automatically Collected</h3>
@@ -55,13 +54,13 @@ export default function PrivacyPolicy() {
               <ul className="mb-4">
                 <li>Providing and improving our calculators and AI tools</li>
                 <li>Processing your requests and responding to inquiries</li>
-                <li>Delivering newsletter content and course information</li>
+                <li>Delivering newsletter content</li>
                 <li>Technical support and customer service</li>
               </ul>
 
               <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">2.2 Communication</h3>
               <ul className="mb-4">
-                <li>Sending educational content and course promotions</li>
+                <li>Sending educational content and newsletters</li>
                 <li>Notifying you about updates to our services</li>
                 <li>Responding to your questions and feedback</li>
               </ul>
@@ -77,7 +76,6 @@ export default function PrivacyPolicy() {
 
               <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">3.1 Third-Party Service Providers</h3>
               <ul className="mb-4">
-                <li><strong>Teachable:</strong> Course platform for enrollment and delivery</li>
                 <li><strong>Email Service Providers:</strong> For newsletter and email marketing</li>
                 <li><strong>Google Analytics:</strong> For website analytics and performance tracking</li>
                 <li><strong>AI Services:</strong> Claude (Anthropic) and Perplexity for AI optimization features</li>

--- a/pages/prompts/content-creators.js
+++ b/pages/prompts/content-creators.js
@@ -212,16 +212,16 @@ export default function ContentCreatorsPage() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                href="/tools/mad-libs-prompt-creator"
                 className="bg-white text-purple-600 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-100 transition-colors"
               >
-                Get the Complete Course
+                Create Custom Prompts
               </a>
               <a
-                href="/tools/mad-libs-prompt-creator"
+                href="/ai-prompt-examples"
                 className="bg-purple-800 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-purple-900 transition-colors"
               >
-                Create Custom Prompts
+                Browse Free Prompt Examples
               </a>
             </div>
           </div>

--- a/pages/prompts/hr-managers.js
+++ b/pages/prompts/hr-managers.js
@@ -212,16 +212,16 @@ export default function HRManagersPage() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                href="/tools/mad-libs-prompt-creator"
                 className="bg-white text-green-600 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-100 transition-colors"
               >
-                Get the Complete Course
+                Create Custom Prompts
               </a>
               <a
-                href="/tools/mad-libs-prompt-creator"
+                href="/ai-prompt-examples"
                 className="bg-green-800 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-green-900 transition-colors"
               >
-                Create Custom Prompts
+                Browse Free Prompt Examples
               </a>
             </div>
           </div>

--- a/pages/prompts/marketing-professionals.js
+++ b/pages/prompts/marketing-professionals.js
@@ -334,15 +334,15 @@ export default function MarketingProfessionalsPage() {
               Ready to 10x Your Marketing Results?
             </h2>
             <p className="text-xl mb-8 text-blue-100">
-              Get access to 100+ advanced marketing prompts, templates, and exclusive training
+              Get access to 100+ advanced marketing prompts, templates, and free guides
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+              <Link
+                href="/ai-prompt-examples"
                 className="bg-white text-blue-600 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-100 transition-colors"
               >
-                Upgrade to PromptWritingStudio Pro
-              </a>
+                Browse Free Prompt Examples
+              </Link>
               <Link
                 href="/claude-code-guide"
                 className="bg-blue-800 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-blue-900 transition-colors"

--- a/pages/prompts/sales-teams.js
+++ b/pages/prompts/sales-teams.js
@@ -212,16 +212,16 @@ export default function SalesTeamsPage() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                href="/tools/mad-libs-prompt-creator"
                 className="bg-white text-blue-600 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-100 transition-colors"
               >
-                Get the Complete Course
+                Create Custom Prompts
               </a>
               <a
-                href="/tools/mad-libs-prompt-creator"
+                href="/ai-prompt-examples"
                 className="bg-blue-800 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-blue-900 transition-colors"
               >
-                Create Custom Prompts
+                Browse Free Prompt Examples
               </a>
             </div>
           </div>

--- a/pages/prompts/small-business-owners.js
+++ b/pages/prompts/small-business-owners.js
@@ -212,16 +212,16 @@ export default function SmallBusinessOwnersPage() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
-                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                href="/tools/mad-libs-prompt-creator"
                 className="bg-white text-orange-600 px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-100 transition-colors"
               >
-                Get the Complete Course
+                Create Custom Prompts
               </a>
               <a
-                href="/tools/mad-libs-prompt-creator"
+                href="/ai-prompt-examples"
                 className="bg-orange-800 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-orange-900 transition-colors"
               >
-                Create Custom Prompts
+                Browse Free Prompt Examples
               </a>
             </div>
           </div>

--- a/pages/terms-of-service.js
+++ b/pages/terms-of-service.js
@@ -54,13 +54,6 @@ export default function TermsOfService() {
                 <li><strong>Performance Analytics:</strong> Usage tracking and effectiveness metrics</li>
               </ul>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">2.3 Educational Courses</h3>
-              <ul className="mb-4">
-                <li><strong>Teachable Integration:</strong> Access to prompt writing courses and training materials</li>
-                <li><strong>Email Newsletter:</strong> Regular updates, tips, and course information</li>
-                <li><strong>Premium Content:</strong> Advanced guides and exclusive resources</li>
-              </ul>
-
               <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">3. User Accounts and Registration</h2>
 
               <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">3.1 Account Creation</h3>
@@ -135,52 +128,37 @@ export default function TermsOfService() {
                 <li>We implement security measures to protect your data</li>
               </ul>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">7. Course Sales and Teachable Integration</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">7. Third-Party Services</h2>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">7.1 Course Enrollment</h3>
-              <p className="mb-4">
-                Course sales and enrollment are processed through our partner Teachable. When you purchase a course, you are subject to both our Terms and Teachable's Terms of Service.
-              </p>
-
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">7.2 Refund Policy</h3>
-              <ul className="mb-4">
-                <li><strong>Course Refunds:</strong> Governed by Teachable's refund policy</li>
-                <li><strong>Satisfaction Guarantee:</strong> We offer a 30-day money-back guarantee for courses</li>
-                <li><strong>Refund Process:</strong> Contact us or Teachable support for refund requests</li>
-                <li><strong>Digital Products:</strong> Courses are digital products delivered instantly</li>
-              </ul>
-
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">8. Third-Party Services</h2>
-
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">8.1 AI Service Providers</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">7.1 AI Service Providers</h3>
               <ul className="mb-4">
                 <li><strong>Anthropic (Claude):</strong> AI optimization and chat services</li>
                 <li><strong>Perplexity AI:</strong> Research and information services</li>
                 <li><strong>Future Integrations:</strong> OpenAI, Google, and other AI providers</li>
               </ul>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">8.2 Analytics and Marketing</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">7.2 Analytics and Marketing</h3>
               <ul className="mb-4">
                 <li><strong>Google Analytics:</strong> Website usage analysis</li>
-                <li><strong>Email Marketing:</strong> Newsletter and course promotion services</li>
+                <li><strong>Email Marketing:</strong> Newsletter services</li>
                 <li><strong>Social Media:</strong> Integration with social platforms</li>
               </ul>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">8.3 Disclaimer</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">7.3 Disclaimer</h3>
               <p className="mb-4">
                 We are not responsible for the availability, content, or practices of third-party services. Your use of third-party services is subject to their respective terms and conditions.
               </p>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">9. Disclaimers and Limitations</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">8. Disclaimers and Limitations</h2>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">9.1 Service Availability</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">8.1 Service Availability</h3>
               <div className="bg-yellow-50 border border-yellow-200 p-4 rounded-lg mb-4">
                 <p className="text-yellow-800">
                   Our Service is provided "as is" and "as available." We do not guarantee uninterrupted or error-free operation. We reserve the right to modify, suspend, or discontinue the Service at any time.
                 </p>
               </div>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">9.2 AI-Generated Content</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">8.2 AI-Generated Content</h3>
               <ul className="mb-4">
                 <li>AI optimization results are suggestions, not guarantees</li>
                 <li>Users are responsible for verifying AI-generated content</li>
@@ -188,15 +166,15 @@ export default function TermsOfService() {
                 <li>AI models may produce biased or inappropriate content</li>
               </ul>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">9.3 Educational Content</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">8.3 Educational Content</h3>
               <ul className="mb-4">
-                <li>Courses and content are for educational purposes only</li>
+                <li>Content is for educational purposes only</li>
                 <li>Results may vary based on individual effort and circumstances</li>
                 <li>We do not guarantee specific outcomes or earnings</li>
                 <li>Content is based on current best practices and may become outdated</li>
               </ul>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">10. Limitation of Liability</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">9. Limitation of Liability</h2>
 
               <div className="bg-gray-50 border border-gray-300 p-4 rounded-lg mb-6">
                 <p className="font-semibold mb-2">IMPORTANT LIMITATION:</p>
@@ -205,12 +183,12 @@ export default function TermsOfService() {
                 </p>
               </div>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">10.1 Maximum Liability</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">9.1 Maximum Liability</h3>
               <p className="mb-4">
                 Our total liability to you for all claims arising from or relating to the Service shall not exceed the amount you paid us in the twelve (12) months preceding the claim, or $100, whichever is greater.
               </p>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">11. Indemnification</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">10. Indemnification</h2>
 
               <p className="mb-4">
                 You agree to indemnify, defend, and hold harmless Prompt Writing Studio and its officers, directors, employees, and agents from any claims, damages, losses, or expenses arising from:
@@ -223,33 +201,33 @@ export default function TermsOfService() {
                 <li>Content you create or share using our tools</li>
               </ul>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">12. Termination</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">11. Termination</h2>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">12.1 Termination by You</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">11.1 Termination by You</h3>
               <p className="mb-4">
-                You may stop using our Service at any time. If you have a paid subscription or course access, termination does not automatically entitle you to a refund.
+                You may stop using our Service at any time. If you have a paid subscription, termination does not automatically entitle you to a refund.
               </p>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">12.2 Termination by Us</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">11.2 Termination by Us</h3>
               <p className="mb-4">
                 We may suspend or terminate your access to the Service immediately, without prior notice, for any reason, including breach of these Terms.
               </p>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">12.3 Effect of Termination</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">11.3 Effect of Termination</h3>
               <ul className="mb-4">
                 <li>Your right to use the Service ceases immediately</li>
                 <li>We may delete your account and associated data</li>
                 <li>Provisions regarding liability, indemnification, and dispute resolution survive</li>
               </ul>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">13. Dispute Resolution</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">12. Dispute Resolution</h2>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">13.1 Governing Law</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">12.1 Governing Law</h3>
               <p className="mb-4">
                 These Terms are governed by and construed in accordance with the laws of [Your Jurisdiction], without regard to conflict of law principles.
               </p>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">13.2 Dispute Resolution Process</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">12.2 Dispute Resolution Process</h3>
               <ol className="mb-4">
                 <li><strong>Informal Resolution:</strong> Contact us first to attempt informal resolution</li>
                 <li><strong>Mediation:</strong> If informal resolution fails, disputes may be subject to mediation</li>
@@ -257,7 +235,7 @@ export default function TermsOfService() {
                 <li><strong>Class Action Waiver:</strong> You waive the right to participate in class actions</li>
               </ol>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">14. Changes to Terms</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">13. Changes to Terms</h2>
 
               <p className="mb-4">
                 We reserve the right to modify these Terms at any time. We will notify users of material changes by:
@@ -274,29 +252,29 @@ export default function TermsOfService() {
                 Your continued use of the Service after changes take effect constitutes acceptance of the new Terms.
               </p>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">15. Miscellaneous</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">14. Miscellaneous</h2>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">15.1 Entire Agreement</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">14.1 Entire Agreement</h3>
               <p className="mb-4">
                 These Terms, together with our Privacy Policy and Cookie Policy, constitute the entire agreement between you and Prompt Writing Studio.
               </p>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">15.2 Severability</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">14.2 Severability</h3>
               <p className="mb-4">
                 If any provision of these Terms is found to be unenforceable, the remaining provisions will remain in full force and effect.
               </p>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">15.3 Waiver</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">14.3 Waiver</h3>
               <p className="mb-4">
                 Our failure to enforce any provision of these Terms does not constitute a waiver of that provision or any other provision.
               </p>
 
-              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">15.4 Assignment</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-3">14.4 Assignment</h3>
               <p className="mb-4">
                 You may not assign or transfer your rights under these Terms without our written consent. We may assign our rights and obligations under these Terms without restriction.
               </p>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">16. Contact Information</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">15. Contact Information</h2>
 
               <p className="mb-4">
                 If you have questions about these Terms, please contact us:
@@ -309,7 +287,7 @@ export default function TermsOfService() {
                 <p><strong>Response Time:</strong> We aim to respond within 48 hours</p>
               </div>
 
-              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">17. Acknowledgment</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">16. Acknowledgment</h2>
 
               <p className="mb-6">
                 By using our Service, you acknowledge that you have read these Terms, understand them, and agree to be bound by them. You also acknowledge that these Terms may be updated from time to time, and you are responsible for reviewing them periodically.

--- a/pages/vibe-coding.js
+++ b/pages/vibe-coding.js
@@ -242,13 +242,13 @@ export default function VibeCoding() {
               <div className="bg-indigo-50 p-6 rounded-lg mt-12">
                 <h3 className="text-xl font-bold mb-3">Ready to Enhance Your Coding Experience?</h3>
                 <p className="mb-4">
-                  Discover how AI can help you achieve the perfect coding vibe with our powerful prompt writing platform.
+                  Discover how AI can help you achieve the perfect coding vibe with our free Claude Code guide.
                 </p>
-                <Link 
-                  href="/#pricing" 
+                <Link
+                  href="/claude-code-guide"
                   className="inline-block bg-indigo-600 text-white px-6 py-3 rounded-md hover:bg-indigo-700 transition"
                 >
-                  Explore PromptWritingStudio
+                  Read the Claude Code Guide
                 </Link>
               </div>
             </article>

--- a/pages/vision-ai-prompts.js
+++ b/pages/vision-ai-prompts.js
@@ -8,11 +8,11 @@ import EmailCapture from '../components/ui/EmailCapture'
 const faqs = [
   {
     question: "What is vision AI prompting and how is it different from image generation?",
-    answer: "Vision AI prompting is about using AI to analyze and understand images you provide, not about creating new images. When you upload a photo, screenshot, chart, or document to models like GPT-4 Vision, Claude, or Gemini, you can ask the AI to describe what it sees, extract data, interpret charts, read handwriting, analyze designs, and much more. Image generation (like DALL-E or Midjourney) creates images from text. Vision AI does the opposite: it creates text understanding from images."
+    answer: "Vision AI prompting is about using AI to analyze and understand images you provide, not about creating new images. When you upload a photo, screenshot, chart, or document to multimodal models like GPT-5, Claude, or Gemini, you can ask the AI to describe what it sees, extract data, interpret charts, read handwriting, analyze designs, and much more. Image generation (like DALL-E or Midjourney) creates images from text. Vision AI does the opposite: it creates text understanding from images."
   },
   {
     question: "Which AI models support vision and image understanding?",
-    answer: "As of 2026, the major models with strong vision capabilities are: GPT-5 and GPT-4o (OpenAI/ChatGPT), Claude Opus 4.7 and Claude Sonnet 4.6 (Anthropic), and Gemini 2.5 Pro (Google). All three platforms allow you to upload images alongside text prompts. Each has slightly different strengths: GPT-4o is fast and versatile, Claude excels at detailed document analysis, and Gemini handles very large images and videos well."
+    answer: "As of 2026, the major models with strong vision capabilities are: GPT-5 and GPT-4o (OpenAI/ChatGPT), Claude Opus 4.8 and Claude Sonnet 4.6 (Anthropic), and Gemini 2.5 Pro (Google). All three platforms allow you to upload images alongside text prompts. Each has slightly different strengths: GPT-4o is fast and versatile, Claude excels at detailed document analysis, and Gemini handles very large images and videos well."
   },
   {
     question: "What types of images can vision AI analyze?",
@@ -36,7 +36,7 @@ const faqs = [
   },
   {
     question: "Can vision AI read handwriting accurately?",
-    answer: "Modern vision AI models are surprisingly good at reading handwriting, especially when the writing is reasonably legible. GPT-4 Vision and Claude both handle printed handwriting well and can manage cursive with moderate accuracy. For best results, ensure good lighting and contrast in the image, and tell the AI in your prompt that the image contains handwriting and what type of content to expect. Very messy handwriting or unusual scripts may still be challenging."
+    answer: "Modern vision AI models are surprisingly good at reading handwriting, especially when the writing is reasonably legible. GPT-5 and Claude both handle printed handwriting well and can manage cursive with moderate accuracy. For best results, ensure good lighting and contrast in the image, and tell the AI in your prompt that the image contains handwriting and what type of content to expect. Very messy handwriting or unusual scripts may still be challenging."
   }
 ]
 
@@ -118,19 +118,19 @@ export default function VisionAIPrompts() {
   const faqSchema = generateFAQSchema(faqs)
   const articleSchema = generateArticleSchema({
     title: 'Vision AI Prompts | How to Write Prompts for Image Understanding in ChatGPT, Claude & Gemini',
-    description: 'Learn how to write effective prompts for vision AI and image understanding. Extract data from charts, analyze screenshots, read documents, and review designs using GPT-4 Vision, Claude, and Gemini multimodal capabilities.',
+    description: 'Learn how to write effective prompts for vision AI and image understanding. Extract data from charts, analyze screenshots, read documents, and review designs using GPT-5, Claude, and Gemini multimodal capabilities.',
     url: 'https://promptwritingstudio.com/vision-ai-prompts',
     datePublished: '2025-06-01',
     dateModified: '2026-02-01',
-    keywords: ['vision AI prompts', 'GPT-4 vision prompts', 'Claude vision', 'Gemini multimodal prompts', 'image analysis AI', 'AI image understanding', 'vision prompting', 'multimodal AI prompts', 'chart reading AI', 'screenshot analysis AI']
+    keywords: ['vision AI prompts', 'GPT-5 vision prompts', 'Claude vision', 'Gemini multimodal prompts', 'image analysis AI', 'AI image understanding', 'vision prompting', 'multimodal AI prompts', 'chart reading AI', 'screenshot analysis AI']
   })
 
   return (
     <>
       <Head>
         <title>Vision AI Prompts | How to Write Prompts for Image Understanding in ChatGPT, Claude &amp; Gemini</title>
-        <meta name="description" content="Learn to write effective vision AI prompts for image analysis. Extract chart data, read documents, analyze screenshots, and review designs using GPT-4 Vision, Claude, and Gemini multimodal features." />
-        <meta name="keywords" content="vision AI prompts, GPT-4 vision prompts, Claude vision, Gemini multimodal prompts, image analysis AI, AI image understanding, vision prompting, multimodal AI prompts" />
+        <meta name="description" content="Learn to write effective vision AI prompts for image analysis. Extract chart data, read documents, analyze screenshots, and review designs using GPT-5, Claude, and Gemini multimodal features." />
+        <meta name="keywords" content="vision AI prompts, GPT-5 vision prompts, Claude vision, Gemini multimodal prompts, image analysis AI, AI image understanding, vision prompting, multimodal AI prompts" />
         <link rel="canonical" href="https://promptwritingstudio.com/vision-ai-prompts" />
         <script
           type="application/ld+json"
@@ -170,7 +170,7 @@ export default function VisionAIPrompts() {
             </div>
             <div className="text-white text-lg">
               <p>Not about generating images. About using AI to understand them.</p>
-              <p>Works with GPT-5/GPT-4o, Claude Opus 4.7 / Sonnet 4.6, and Gemini 2.5 Pro</p>
+              <p>Works with GPT-5/GPT-4o, Claude Opus 4.8 / Sonnet 4.6, and Gemini 2.5 Pro</p>
             </div>
           </div>
         </section>
@@ -200,7 +200,7 @@ export default function VisionAIPrompts() {
                 </div>
               </div>
               <p className="text-lg text-[#333333]">
-                Modern AI models from OpenAI (GPT-5, GPT-4o), Anthropic (Claude Opus 4.7, Claude Sonnet 4.6, Claude Haiku 4.5), and Google (Gemini 2.5 Pro, Gemini 2.5 Flash) all support multimodal input. This means you can upload an image alongside your text prompt and the AI will analyze both together. The quality of your results depends almost entirely on how well you write your vision prompt.
+                Modern AI models from OpenAI (GPT-5, GPT-4o), Anthropic (Claude Opus 4.8, Claude Sonnet 4.6, Claude Haiku 4.5), and Google (Gemini 2.5 Pro, Gemini 2.5 Flash) all support multimodal input. This means you can upload an image alongside your text prompt and the AI will analyze both together. The quality of your results depends almost entirely on how well you write your vision prompt.
               </p>
             </div>
           </div>

--- a/scripts/observatory/_lib/pricing.py
+++ b/scripts/observatory/_lib/pricing.py
@@ -4,14 +4,15 @@ Numbers reflect published list prices as of contract v1 lock (2026-05-23).
 Used for:
   - cost_usd computation post-call
   - worst-case pre-call estimate for the hard cost cap
-The cron should keep these in sync with `data/ai-models.json` when models drift;
+The cron should keep these in sync with `data/claude-models.json` (Claude rows)
+and `data/ai-models.json` (non-Claude rows) when models drift;
 out-of-date pricing here only affects cost accounting, not pipeline correctness.
 """
 from __future__ import annotations
 
 # (input_per_million_usd, output_per_million_usd)
 PRICE_TABLE: dict[str, tuple[float, float]] = {
-    "claude-opus-4-7":   (15.00, 75.00),
+    "claude-opus-4-7":   ( 5.00, 25.00),
     "claude-sonnet-4-6": ( 3.00, 15.00),
     "claude-haiku-4-5":  ( 1.00,  5.00),
     "gpt-4o":            ( 2.50, 10.00),


### PR DESCRIPTION
**PRD:** `~/.claude/handoff/portfolio-audit-fixes-2026-06-09/pws-PRD-6-pivot-debt-pass.md`

PWS stops selling the closed course and finishes the stale-model tail. Branch cut fresh off post-#44/post-#47 `origin/main` (37cf84d); all targets re-grepped on this branch before editing.

## Definition of Done — evidence

- [x] **PASS** — `grep -rn "our course teaches\|Elite Plan" pages/` → 0 matches
  ```
  $ grep -rn "our course teaches\|Elite Plan" pages/
  (no output, exit 1)
  ```
- [x] **PASS** — `grep -n "Educational Courses" pages/terms-of-service.js` → 0
  ```
  $ grep -n "Educational Courses" pages/terms-of-service.js
  (no output, exit 1)
  ```
  §2.3 Educational Courses and §7 Course Sales and Teachable Integration removed (removal-only); sections 8–17 renumbered to 7–16; residual course mentions trimmed in Email Marketing (7.2), Educational Content (8.3), and Termination (11.1) clauses.
- [x] **PASS** — `BUSINESS_STRATEGY.md` starts with an ARCHIVED header
  ```
  $ head -1 BUSINESS_STRATEGY.md
  > **ARCHIVED — 2026-06-11.** The course described in this document is closed (PWS sunset, strategy v0.6 §0.7); this strategy is superseded by the Claude-resource pivot. Kept for history only — do not use it to guide site content, CTAs, or monetisation.
  ```
- [x] **PASS** — pricing.py rows == claude-models.json values (values-only edit; PRICE_TABLE keys untouched per locked v1 enum)
  ```
  $ python3 -c "<map PRICE_TABLE Claude rows against data/claude-models.json current+legacy>"
  claude-opus-4-7: pricing.py=(5.0, 25.0) claude-models.json=(5, 25) match=True
  claude-sonnet-4-6: pricing.py=(3.0, 15.0) claude-models.json=(3, 15) match=True
  claude-haiku-4-5: pricing.py=(1.0, 5.0) claude-models.json=(1, 5) match=True
  ```
  Source per row: `claude-opus-4-7` ← claude-models.json `legacy[0]` (inputPricePerMTok=5, outputPricePerMTok=25). Sonnet/Haiku rows already matched. Observatory test suite: **52 passed**.
- [x] **PASS** — `grep -rn "GPT-4 Vision" pages/vision-ai-prompts.js` → 0
  ```
  $ grep -rn "GPT-4 Vision" pages/vision-ai-prompts.js
  (no output, exit 1)
  ```
- [x] **PASS** — fresh grep: no page asserts Opus 4.7 as current (prose)
  ```
  $ grep -rni "opus 4.7" pages/ components/ | grep -v "claude-opus-4-7"
  (no output, exit 1)
  $ grep -rn "claude-opus-4-7" pages/
  pages/observatory/prompts/[id].js:26:  'claude-opus-4-7': 'Claude Opus 4.7',
  ```
  The single remaining hit is `MODEL_DISPLAY` id→name machinery for the locked observatory enum — exempt per PRD. `scripts/observatory/*` model ids (judge.py, providers.py, tests) also left untouched for the same reason.
- [x] **PASS** — retire/redirect recommendation list below (needs-Bryan, **not executed**)
- [x] **PASS** — `npm install --no-audit --no-fund && npm run build` exits 0 (`BUILD_EXIT=0`, all pages compile)

## Needs-Bryan: recommended retire/redirect list (not executed)

Weakest old business-era pages, per audit §3 framing (unverifiable-claim calculators + industry pages). No deletions or redirects performed in this PR.

| Page | Why it's weak | Suggested action |
|---|---|---|
| `/calculators/customer-service-ai-savings` | "Based on industry averages and real-world AI implementation data" — no source; invented 60-80% accuracy ranges | Retire or 301 → `/calculators` |
| `/calculators/ecommerce-ai-savings` | Same pattern: unsourced savings %s and "platform-specific bonuses"; course-funnel artifact | Retire or 301 → `/calculators` |
| `/calculators/content-creation-speed` | "Based on real-world data from content creators" — unverifiable 3-6x claims | Retire or 301 → `/calculators` |
| `/calculators/business-ai-readiness` | Generic readiness quiz from the course-funnel era; no fact-source backing | Retire or 301 → `/ai-prompt-quiz` |
| `/calculators/ai-cost-comparison` | Overlaps the fact-sourced Claude calculators; weakest of the cost pages | Merge into `/calculators/claude-prompt-cost` or retire |
| Industry pages: `/ecommerce-ai`, `/real-estate-ai`, `/service-business-ai`, `/healthcare-ai`, `/legal-ai`, `/education-ai`, `/content-creators-ai` | Course-funnel TOFU pages ("testimonials from real customers" without named sources); off-pivot vs the Claude-resource positioning | Keep only those with real GSC traffic; 301 the rest → `/chatgpt-prompt-templates` or `/ai-prompt-examples` |
| `/chatgpt-prompts-for/[modifier]` programmatic set | Thin programmatic SEO from the business era; review for index bloat | Audit in GSC; prune non-performers |
| `/business-name-generator` | Off-topic for the pivot | Retire or leave as harmless utility — Bryan's call |

## Deviations / judgement calls (flagged for review)

1. **Quiz Basic/Pro Plan copy also replaced.** PRD names the Elite Plan lines; the same `resultProfiles` block recommends the equally-closed Basic and Pro Plans. All four `courseMatch` strings now point at free on-site next steps (prompt examples, ChatGPT templates, Claude Code guide, Prompt Observatory). Scoring logic and rendering untouched (the field is currently defined but not rendered).
2. **ToS §7 removed in addition to §2.3.** Mission line requires "ToS describes only services actually offered"; §7 described course sales/refunds as current. Removal-only, sections renumbered, no new claims added.
3. **pricing.py docstring** now names `data/claude-models.json` as the sync source for Claude rows (PRD flagged the old docstring as pointing at the wrong file; comment-only change, table keys untouched).
4. **`claude-code-skills/build-your-own.js`** doc example for the skill `model` field updated `claude-opus-4-7` → `claude-opus-4-8` — it recommends a model as the current deep-reasoning pick, so treated as prose-adjacent rather than locked-enum machinery. Trivial to revert if you'd rather keep it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
