### PR TITLE
fix(cron): disable observatory weekly schedule until secrets and providers are live

### DIFF
--- a/.github/workflows/observatory-weekly.yml
+++ b/.github/workflows/observatory-weekly.yml
@@ -4,8 +4,17 @@ name: Observatory weekly run
 # Step 6 (draft_report) and step 7 (open_pr) MUST NOT call any LLM.
 
 on:
-  schedule:
-    - cron: '0 3 * * 0'  # Sunday 03:00 UTC
+  # Schedule disabled 2026-06-11 (issue #42): the Sunday cron failed on every
+  # run since launch and cannot succeed yet. Two blockers before re-enabling:
+  #   1. The OBSERVATORY_PR_TOKEN repo secret is not set, so checkout fails
+  #      with "Input required and not supplied: token".
+  #   2. The real providers in scripts/observatory/_lib/providers.py are stubs
+  #      that raise NotImplementedError, and the OPENAI_API_KEY, GEMINI_API_KEY
+  #      and GROQ_API_KEY secrets are also unset, so [2/7] run_models would
+  #      fail even with the token in place.
+  # Re-enable by restoring:
+  #   schedule:
+  #     - cron: '0 3 * * 0'  # Sunday 03:00 UTC
   workflow_dispatch:
     inputs:
       run_id:
@@ -36,7 +45,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.OBSERVATORY_PR_TOKEN }}
+          # Fall back to the default token so a manual dispatch can at least
+          # check out; an empty explicit token makes actions/checkout hard-fail.
+          token: ${{ secrets.OBSERVATORY_PR_TOKEN || github.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Root cause
- The Observatory weekly cron (.github/workflows/observatory-weekly.yml) failed on both scheduled runs to date (2026-05-31 and 2026-06-07), each within seconds at the checkout step: 'Input required and not supplied: token'.
- The workflow passes token: ${{ secrets.OBSERVATORY_PR_TOKEN }} to actions/checkout, but that secret does not exist (the repo has zero repo-level secrets; only the org-level ANTHROPIC_API_KEY resolves). An explicit empty token overrides checkout's default and hard-fails.
- Setting the secret alone would not make the cron green: the real providers in scripts/observatory/_lib/providers.py are stubs that raise NotImplementedError, and OPENAI_API_KEY, GEMINI_API_KEY and GROQ_API_KEY are also unset, so [2/7] run_models would fail next.

## Fix
- Remove the schedule trigger and keep workflow_dispatch, with an inline re-enable checklist (set OBSERVATORY_PR_TOKEN plus the three model key secrets, wire the real providers, then restore the cron line). The pipeline cannot succeed by any code change, so a guaranteed-red weekly cron is pure alert noise.
- Checkout token now falls back to github.token so a manual dispatch reaches the real blocker instead of dying at checkout.

## Validation
- YAML parsed clean with python3 -c 'yaml.safe_load(...)'.
- Confirmed the dependent Observatory weekly email cron is green on its own (it skips gracefully), so no change needed there.

## Refs
- Failed runs: 26703243810, 27082696854
- Scaffold PR that shipped the workflow with stub providers: #31

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)