### PR TITLE
Add 19 net-new Claude/Claude Code AEO content pages

### DIFF
--- a/pages/anthropic-api-pricing.js
+++ b/pages/anthropic-api-pricing.js
@@ -1,0 +1,464 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import LastVerified from '../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import { CURRENT_MODELS, MODELS_META, API_PLAN } from '../lib/claude-data'
+
+// Cache + batch multipliers verified against platform.claude.com docs (see source link).
+const CACHE_READ_MULTIPLIER = 0.1
+const CACHE_WRITE_5M_MULTIPLIER = 1.25
+const CACHE_WRITE_1H_MULTIPLIER = 2
+const BATCH_DISCOUNT = 0.5
+
+const fmt = (n) =>
+  n < 1 ? `$${n.toFixed(2)}` : `$${n.toLocaleString('en-US', { maximumFractionDigits: 2 })}`
+
+// Worked cost examples — all computed from the model rates, nothing hardcoded.
+const sonnet = CURRENT_MODELS.find((m) => m.tier === 'workhorse')
+const opus = CURRENT_MODELS.find((m) => m.tier === 'flagship')
+const haiku = CURRENT_MODELS.find((m) => m.tier === 'fast')
+
+function callCost(model, inTokens, outTokens) {
+  return (
+    (inTokens / 1_000_000) * model.inputPricePerMTok +
+    (outTokens / 1_000_000) * model.outputPricePerMTok
+  )
+}
+
+// Example A: a single support-chatbot reply (2k in, 500 out) on Sonnet, x10k/mo
+const chatbotPerCall = callCost(sonnet, 2000, 500)
+const chatbotMonthly = chatbotPerCall * 10_000
+
+// Example B: same volume but on Haiku
+const chatbotHaikuMonthly = callCost(haiku, 2000, 500) * 10_000
+
+// Example C: a long-doc summariser on Opus (50k in, 2k out), x1k/mo
+const summariserPerCall = callCost(opus, 50_000, 2000)
+const summariserMonthly = summariserPerCall * 1000
+
+// Caching example: chatbot with a 1,800-token system prompt cached on every call
+const cachedSystemTokens = 1800
+const freshSystemMonthly = (cachedSystemTokens / 1_000_000) * sonnet.inputPricePerMTok * 10_000
+const cachedSystemMonthly =
+  (cachedSystemTokens / 1_000_000) * sonnet.inputPricePerMTok * CACHE_READ_MULTIPLIER * 10_000
+const cacheSavingsPct = Math.round((1 - cachedSystemMonthly / freshSystemMonthly) * 100)
+
+const faqs = [
+  {
+    question: 'How does Anthropic API pricing work?',
+    answer:
+      'The Anthropic API is pay-as-you-go by token. You are billed separately for input tokens (everything you send: your prompt, system instructions, and conversation history) and output tokens (everything Claude generates). Prices are quoted per million tokens (MTok) and differ by model. There is no monthly fee, no minimum spend, and no seat cost — you pay only for the tokens each request consumes.'
+  },
+  {
+    question: 'How much does the Claude API cost per token?',
+    answer: `Per the current model lineup: ${opus.name} is ${fmt(
+      opus.inputPricePerMTok
+    )} per million input tokens and ${fmt(
+      opus.outputPricePerMTok
+    )} per million output tokens. ${sonnet.name} is ${fmt(
+      sonnet.inputPricePerMTok
+    )} input / ${fmt(sonnet.outputPricePerMTok)} output. ${haiku.name} is ${fmt(
+      haiku.inputPricePerMTok
+    )} input / ${fmt(
+      haiku.outputPricePerMTok
+    )} output. Output tokens cost 5x input across every model, so terse responses are cheaper than verbose ones.`
+  },
+  {
+    question: 'Is the Anthropic API cheaper than a Claude subscription?',
+    answer:
+      'For building applications, yes — the API is the only option, and you pay only for what you ship. For your own personal Claude use (chat, Claude Code), no. A flat $20/mo Pro subscription almost always beats metered API tokens once you use Claude daily. Most developers run both: a subscription for personal work, API billing for the apps they build.'
+  },
+  {
+    question: 'How much can prompt caching save?',
+    answer: `Cache reads cost ${CACHE_READ_MULTIPLIER}x (10%) of the base input price, so re-sending a large fixed context — a system prompt, a knowledge base, a long instruction set — drops to a tenth of its normal cost on every cached call. Writing to the cache carries a small premium (${CACHE_WRITE_5M_MULTIPLIER}x for the 5-minute cache, ${CACHE_WRITE_1H_MULTIPLIER}x for the 1-hour cache), so caching pays off whenever the same context is reused more than a couple of times. In the worked example on this page, caching a 1,800-token system prompt cuts that portion of the bill by about ${cacheSavingsPct}%.`
+  },
+  {
+    question: 'What is the Message Batches API discount?',
+    answer: `The Message Batches API processes requests asynchronously (results within 24 hours) at ${
+      BATCH_DISCOUNT * 100
+    }% off standard token rates — input and output both. Use it for anything that does not need a real-time reply: bulk classification, content generation pipelines, dataset labelling, overnight summarisation. Batch and prompt caching stack, so a cached batch job is cheaper still.`
+  },
+  {
+    question: 'Do input and output tokens cost the same?',
+    answer:
+      'No. Output tokens are priced at 5x input tokens on every current model. That is why long input context (documents, history) is relatively cheap to send, but asking for long generated answers is the expensive part of a bill. Capping max output tokens and prompting for concise responses is the single biggest lever on cost.'
+  },
+  {
+    question: 'How do I estimate my monthly Claude API bill?',
+    answer:
+      'Estimate average input tokens per call, average output tokens per call, and calls per month. Multiply input tokens by the model input rate (per MTok) and output tokens by the output rate, add them for a per-call cost, then multiply by monthly call volume. The fill-in-the-blank template on this page walks through the arithmetic with a real example.'
+  }
+]
+
+const article = generateArticleSchema({
+  title: 'Anthropic API Pricing: Per-Model Token Rates and Real Cost Examples (2026)',
+  description:
+    'How Anthropic API pricing works — per-model input/output token rates, how billing is calculated, worked cost examples, and how prompt caching and the Batch API cut the bill.',
+  slug: 'anthropic-api-pricing',
+  datePublished: '2026-06-16'
+})
+
+export default function AnthropicApiPricing() {
+  const faqSchema = generateFAQSchema(faqs)
+
+  return (
+    <>
+      <Head>
+        <title>Anthropic API Pricing: Per-Model Token Rates and Cost Examples (2026) | PromptWritingStudio</title>
+        <meta
+          name="description"
+          content="Anthropic API pricing explained: per-model input and output token rates, how token billing works, worked monthly cost examples, and how prompt caching and the Batch API cut your bill."
+        />
+        <link rel="canonical" href="https://promptwritingstudio.com/anthropic-api-pricing" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-4xl">
+            <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">Claude · API</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
+              Anthropic API Pricing: Per-Model Token Rates and Real Cost Examples
+            </h1>
+            <p className="text-xl text-gray-200 max-w-3xl mx-auto">
+              How Anthropic API pricing actually works — what each model costs per token, how a bill is
+              calculated, worked monthly examples, and the two levers that cut spend the most.
+            </p>
+            <LastVerified date={MODELS_META.lastVerified} source={MODELS_META.source} className="mt-4 text-gray-300" />
+          </div>
+        </section>
+
+        <section className="py-10 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
+              <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                The Anthropic API is <strong>pay-as-you-go by token</strong> — no monthly fee, no seats. You pay
+                separately for <strong>input tokens</strong> (what you send) and <strong>output tokens</strong> (what
+                Claude generates), priced per million tokens and differing by model. Current rates run from{' '}
+                <strong>{fmt(haiku.inputPricePerMTok)}/{fmt(haiku.outputPricePerMTok)}</strong> per MTok on{' '}
+                {haiku.name} up to <strong>{fmt(opus.inputPricePerMTok)}/{fmt(opus.outputPricePerMTok)}</strong> on{' '}
+                {opus.name}. <strong>Output costs 5x input</strong> on every model. Prompt caching ({CACHE_READ_MULTIPLIER}x
+                on cache reads) and the Batch API ({BATCH_DISCOUNT * 100}% off) are the biggest cost levers.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Per-model rate table — pulled live from claude-data.js */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-3 text-center">
+              How much does each Claude model cost per token?
+            </h2>
+            <p className="text-[#333333] mb-8 text-center max-w-2xl mx-auto">
+              Standard API rates, quoted per million tokens (MTok). Input and output are billed separately.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full bg-white rounded-lg border border-gray-200 text-sm">
+                <thead className="bg-[#1A1A1A] text-white">
+                  <tr>
+                    <th className="p-3 text-left">Model</th>
+                    <th className="p-3 text-left">Tier</th>
+                    <th className="p-3 text-left">Input / MTok</th>
+                    <th className="p-3 text-left">Output / MTok</th>
+                    <th className="p-3 text-left">Context window</th>
+                    <th className="p-3 text-left">Best for</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {CURRENT_MODELS.map((m) => (
+                    <tr key={m.id}>
+                      <td className="p-3 font-semibold text-[#1A1A1A]">{m.name}</td>
+                      <td className="p-3 text-[#333333] capitalize">{m.tier}</td>
+                      <td className="p-3 text-[#333333]">{fmt(m.inputPricePerMTok)}</td>
+                      <td className="p-3 text-[#333333]">{fmt(m.outputPricePerMTok)}</td>
+                      <td className="p-3 text-[#333333]">{(m.contextTokens / 1000).toLocaleString()}K</td>
+                      <td className="p-3 text-[#333333]">{m.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-gray-500 mt-3 text-center">
+              Rates verified against the Anthropic model overview on {MODELS_META.lastVerified}. Model lineup and
+              pricing change often — check the source before forecasting a large budget.
+            </p>
+          </div>
+        </section>
+
+        {/* How billing works */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">How does Anthropic API billing work?</h2>
+            <p className="text-[#333333] mb-4">
+              Every API request has two billable parts. <strong>Input tokens</strong> are everything you send to
+              the model on that call: your prompt, the system instructions, and — in a multi-turn conversation —
+              the entire prior history you replay. <strong>Output tokens</strong> are everything Claude writes back.
+            </p>
+            <p className="text-[#333333] mb-4">
+              Both are counted in tokens (roughly 3-4 characters of English each) and billed per million. The
+              formula for a single call is simple:
+            </p>
+            <div className="bg-[#1A1A1A] text-gray-100 rounded-lg p-5 font-mono text-sm leading-relaxed mb-4">
+              call cost = (input tokens ÷ 1,000,000 × input rate)
+              <br />
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;+ (output tokens ÷ 1,000,000 × output rate)
+            </div>
+            <p className="text-[#333333] mb-4">
+              The thing most people miss: <strong>output is 5x the price of input on every model.</strong> Sending
+              a 50,000-token document is cheap; asking for a 5,000-token essay back is where the bill grows. In a
+              chat app, the replayed history also compounds — each new turn re-sends every previous turn as input.
+            </p>
+            <p className="text-[#333333]">
+              There is no monthly minimum and no per-seat cost. You add credit to a billing account at{' '}
+              <a
+                href="https://console.anthropic.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#1A1A1A] underline font-semibold"
+              >
+                console.anthropic.com
+              </a>{' '}
+              and tokens draw it down. This is the opposite model from the{' '}
+              <Link href="/claude-pro-vs-max-vs-api" className="text-[#1A1A1A] underline font-semibold">
+                Pro, Max, and Team subscriptions
+              </Link>
+              , which are flat monthly prices for personal use of the Claude apps.
+            </p>
+          </div>
+        </section>
+
+        {/* Worked examples */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-3">What does the API actually cost? Three worked examples</h2>
+            <p className="text-[#333333] mb-8">
+              Numbers below are calculated from the live rates above, so they stay correct when the data updates.
+            </p>
+
+            <div className="space-y-6">
+              <div className="bg-[#F9F9F9] rounded-lg border border-gray-200 p-6">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">1. Support chatbot on {sonnet.name}</h3>
+                <p className="text-[#333333] mb-3">
+                  Assume 2,000 input tokens (system prompt + question + a little history) and 500 output tokens per
+                  reply, at 10,000 replies a month.
+                </p>
+                <ul className="space-y-1 text-[#333333] mb-3">
+                  <li>Per reply: <strong>{fmt(chatbotPerCall)}</strong></li>
+                  <li>10,000 replies/month: <strong>{fmt(chatbotMonthly)}/mo</strong></li>
+                </ul>
+                <p className="text-sm text-[#333333]">
+                  Swap to {haiku.name} for the same volume and it drops to{' '}
+                  <strong>{fmt(chatbotHaikuMonthly)}/mo</strong> — the biggest single saving on most apps is using
+                  the smallest model that holds quality.
+                </p>
+              </div>
+
+              <div className="bg-[#F9F9F9] rounded-lg border border-gray-200 p-6">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">2. Long-document summariser on {opus.name}</h3>
+                <p className="text-[#333333] mb-3">
+                  A 50,000-token document in, a 2,000-token summary out, 1,000 documents a month.
+                </p>
+                <ul className="space-y-1 text-[#333333]">
+                  <li>Per document: <strong>{fmt(summariserPerCall)}</strong></li>
+                  <li>1,000 documents/month: <strong>{fmt(summariserMonthly)}/mo</strong></li>
+                </ul>
+              </div>
+
+              <div className="bg-[#F9F9F9] rounded-lg border border-gray-200 p-6">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">3. The same chatbot, with prompt caching</h3>
+                <p className="text-[#333333] mb-3">
+                  Of those 2,000 input tokens, say 1,800 are a fixed system prompt sent on every call. Cache it and
+                  cache reads cost {CACHE_READ_MULTIPLIER}x the input rate.
+                </p>
+                <ul className="space-y-1 text-[#333333]">
+                  <li>System prompt, uncached, 10k calls: <strong>{fmt(freshSystemMonthly)}/mo</strong></li>
+                  <li>System prompt, cached, 10k calls: <strong>{fmt(cachedSystemMonthly)}/mo</strong></li>
+                  <li>Saving on that portion: <strong>~{cacheSavingsPct}%</strong></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Cost levers: caching + batch */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-8 text-center">Two levers that cut the bill</h2>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white rounded-lg border border-gray-200 p-6">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">Prompt caching</h3>
+                <p className="text-[#333333] mb-3">
+                  Cache a large, reused chunk of context — a system prompt, a knowledge base, a style guide — and
+                  every subsequent call reads it at {CACHE_READ_MULTIPLIER}x the input price.
+                </p>
+                <ul className="space-y-1 text-sm text-[#333333]">
+                  <li>Cache read: <strong>{CACHE_READ_MULTIPLIER}x</strong> input rate (a 90% discount)</li>
+                  <li>5-minute cache write: <strong>{CACHE_WRITE_5M_MULTIPLIER}x</strong> input rate</li>
+                  <li>1-hour cache write: <strong>{CACHE_WRITE_1H_MULTIPLIER}x</strong> input rate</li>
+                </ul>
+                <p className="text-sm text-[#333333] mt-3">
+                  Worth it whenever the same context is reused more than a couple of times before it expires.
+                </p>
+              </div>
+              <div className="bg-white rounded-lg border border-gray-200 p-6">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">Message Batches API</h3>
+                <p className="text-[#333333] mb-3">
+                  Submit requests asynchronously (results within 24 hours) for <strong>{BATCH_DISCOUNT * 100}% off</strong>{' '}
+                  standard rates on both input and output.
+                </p>
+                <p className="text-sm text-[#333333]">
+                  Use it for anything that does not need a live reply: bulk classification, content pipelines,
+                  dataset labelling, overnight reports. Batch and caching stack — a cached batch job is cheaper
+                  again.
+                </p>
+              </div>
+            </div>
+            <p className="text-xs text-gray-500 mt-4 text-center">
+              Caching and batch multipliers per Anthropic&apos;s prompt-caching and Batches API docs ·{' '}
+              <a
+                href="https://platform.claude.com/docs/en/build-with-claude/prompt-caching"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-gray-700"
+              >
+                source
+              </a>
+            </p>
+          </div>
+        </section>
+
+        {/* Fill-in-the-blank estimation template — the practical moat */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-3">Estimate your own bill: a fill-in-the-blank template</h2>
+            <p className="text-[#333333] mb-6">
+              Drop your own numbers into the blanks. The arithmetic is the same per-call formula from above, scaled
+              to monthly volume.
+            </p>
+            <div className="bg-[#1A1A1A] text-gray-100 rounded-lg p-6 font-mono text-sm leading-relaxed">
+              Model: ______ (input rate $___ / MTok, output rate $___ / MTok)
+              <br />
+              Avg input tokens per call: ______
+              <br />
+              Avg output tokens per call: ______
+              <br />
+              Calls per month: ______
+              <br />
+              <br />
+              Per-call cost = (input ÷ 1,000,000 × input rate)
+              <br />
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;+ (output ÷ 1,000,000 × output rate)
+              <br />
+              Monthly cost = per-call cost × calls per month
+              <br />
+              <br />
+              If a fixed chunk of input repeats every call:
+              <br />
+              &nbsp;&nbsp;cached portion cost × {CACHE_READ_MULTIPLIER} (cache read)
+              <br />
+              If replies can wait up to 24h: × {BATCH_DISCOUNT} (Batch API)
+            </div>
+            <div className="bg-[#FFDE59]/10 border-l-4 border-[#FFDE59] p-4 rounded-r mt-5">
+              <p className="text-sm text-[#1A1A1A]">
+                <strong>Failure mode to avoid:</strong> people forecast on input tokens and forget that output is
+                5x the price, then get a bill double their estimate. Always size the output side first, and cap{' '}
+                <code>max_tokens</code> so a runaway generation can&apos;t blow the budget.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* API vs subscription steer */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">API or subscription — which do you actually need?</h2>
+            <p className="text-[#333333] mb-4">
+              These are different products for different jobs. The <strong>{API_PLAN.name}</strong> is for software
+              you build: apps, agents, automations, pipelines. You pay per token and control cost per request.
+            </p>
+            <p className="text-[#333333] mb-4">
+              For your <em>own</em> daily Claude use — chatting, Claude Code in the terminal — a flat subscription
+              wins almost every time. Metering your personal use through the API is usually more expensive and far
+              more stressful.
+            </p>
+            <p className="text-[#333333]">
+              Most builders run both. If you are weighing the consumer tiers, the{' '}
+              <Link href="/claude-pro-vs-max-vs-api" className="text-[#1A1A1A] underline font-semibold">
+                Claude Pro vs Max vs API comparison
+              </Link>{' '}
+              breaks down when each subscription wins, and the{' '}
+              <Link href="/claude-code-pricing" className="text-[#1A1A1A] underline font-semibold">
+                Claude Code pricing guide
+              </Link>{' '}
+              covers what running Claude Code costs on each plan.
+            </p>
+            <p className="text-[#333333] mt-5">
+              Token rates differ by model, so the choice drives your bill. See{' '}
+              <Link href="/claude-sonnet-vs-opus" className="text-[#1A1A1A] underline font-semibold">Sonnet vs Opus</Link>{' '}
+              for the price-versus-capability trade-off, and the{' '}
+              <Link href="/claude-context-window" className="text-[#1A1A1A] underline font-semibold">Claude context window guide</Link>{' '}
+              for how prompt size affects input cost.
+            </p>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6 text-center">Frequently asked questions</h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-4 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-4 pb-4">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Monetisation CTA */}
+        <section className="py-16 bg-[#1A1A1A] text-center">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-white mb-4">The cheapest token is the one you don&apos;t waste</h2>
+            <p className="text-gray-300 mb-6">
+              Most API bills are inflated by sloppy prompts — bloated system instructions, vague asks that force
+              long outputs, retries from prompts that didn&apos;t work the first time. PromptWritingStudio teaches
+              the prompt patterns that get the right answer on the first call, which is the same thing as cutting
+              your token spend. Run the numbers with the calculators, then tighten the prompts.
+            </p>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-4 justify-center">
+              <a
+                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition"
+              >
+                Join Now
+              </a>
+              <Link
+                href="/calculators/claude-code-vs-cursor-cost"
+                className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition"
+              >
+                Claude Code vs Cursor cost
+              </Link>
+              <Link
+                href="/claude-pro-vs-max-vs-api"
+                className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition"
+              >
+                Pro vs Max vs API
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-artifacts.js
+++ b/pages/claude-artifacts.js
@@ -1,0 +1,481 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+const faqs = [
+  {
+    question: "What are Claude Artifacts?",
+    answer: "Claude Artifacts are standalone, editable outputs that Claude generates in a dedicated panel next to your chat. Instead of burying a long document, a code file, or a working app inside the conversation, Claude opens it in its own window where you can preview it, run it, edit it, and reuse it. Anthropic creates an artifact automatically when the content is significant and self-contained, typically more than 15 lines, and is something you are likely to want to edit or iterate on. Supported types include Markdown documents, code snippets, single-page HTML sites, SVG images, diagrams, and interactive React components."
+  },
+  {
+    question: "How do I turn Claude Artifacts on?",
+    answer: "Open Claude, go to Settings, then Capabilities, and toggle Artifacts on. To build artifacts that run code or create downloadable files, also enable 'Code execution and file creation'. Once enabled, you do not have to ask for an artifact by name. When you prompt Claude to write a document, build a tool, or generate code, it opens the result in the artifact panel on its own."
+  },
+  {
+    question: "Are Claude Artifacts free?",
+    answer: "Yes. Artifacts are available on the Free, Pro, Max, Team, and Enterprise plans. Some advanced behaviour is gated to paid tiers: persistent storage for stateful apps (up to 20 MB per artifact) and MCP connections to external services require Pro or above. For writers building documents, outlines, and simple interactive tools, the free tier covers most of what you need."
+  },
+  {
+    question: "How do I share or publish a Claude Artifact?",
+    answer: "Open the artifact, then use the publish option in the panel header to generate a public link. Anyone with the link can view and interact with the artifact, and you can embed it on a website. You can also download the source if it is a code or document artifact. Published artifacts are public, so do not publish anything containing private data, client information, or unreleased work."
+  },
+  {
+    question: "What is the difference between Claude Artifacts and Claude Projects?",
+    answer: "An artifact is a single output: one document, one app, one diagram. A Project is a workspace that holds many chats and reference files around a shared goal, with persistent context across conversations. You create artifacts inside chats; you organise those chats inside Projects. Use an artifact when you want one deliverable. Use a Project when you want Claude to remember the context behind a whole body of work. See our Claude Projects guide for the workspace side."
+  },
+  {
+    question: "Can Claude Artifacts edit a document in place?",
+    answer: "Yes. In a Markdown document artifact you can highlight a section of text and choose 'Edit with Claude' to revise just that passage without regenerating the whole document. Every change is versioned, so you can switch between earlier versions using the version selector if a rewrite goes the wrong way. This makes artifacts far better than chat for any draft you expect to revise more than once."
+  },
+  {
+    question: "Why is Claude not creating an artifact for my request?",
+    answer: "Claude only opens an artifact when the output is substantial and self-contained, usually more than 15 lines, and reusable. Short answers, quick explanations, and conversational replies stay in the chat. If you want an artifact and are not getting one, ask explicitly: 'Put this in an artifact so I can edit it.' If artifacts still do not appear, confirm the feature is toggled on in Settings, Capabilities."
+  }
+]
+
+const artifactTypes = [
+  { type: "Markdown documents", forWriters: "Drafts, outlines, briefs, and SOPs you can edit in place and version." },
+  { type: "Single-page HTML sites", forWriters: "Landing pages, lead-magnet pages, and one-page portfolios without a code editor." },
+  { type: "Interactive React components", forWriters: "Quizzes, calculators, and small interactive tools to embed or share." },
+  { type: "Code snippets", forWriters: "Scripts and automations you can copy out and run elsewhere." },
+  { type: "SVG images", forWriters: "Simple logos, icons, and social graphics defined in editable code." },
+  { type: "Diagrams and flowcharts", forWriters: "Content workflows, funnel maps, and process diagrams from a plain-text description." }
+]
+
+const examplePrompts = [
+  {
+    id: 'doc',
+    label: 'Editable document you can iterate on',
+    command: 'Create an artifact: a 700-word blog post outline on [TOPIC] for an audience of [AUDIENCE]. Use H2 sections, one sentence of intent per section, and a list of 3 supporting points under each. Keep it as an editable Markdown document so I can revise sections in place.'
+  },
+  {
+    id: 'tool',
+    label: 'Interactive tool to share',
+    command: 'Build an artifact: a single-page interactive [TOOL TYPE, e.g. headline analyzer] as a React component. Inputs: [INPUTS]. Output: [WHAT IT SHOULD RETURN]. Style it clean and mobile-friendly. I want to publish it as a shareable link.'
+  },
+  {
+    id: 'page',
+    label: 'Landing page without a code editor',
+    command: 'Create an artifact: a single-page HTML landing page for [OFFER]. Sections: hero with headline and subhead, three benefit blocks, one testimonial placeholder, and a single email-capture call to action. Inline CSS only, no external files. I will publish and embed it.'
+  },
+  {
+    id: 'diagram',
+    label: 'Process diagram from plain text',
+    command: 'Create an artifact: a flowchart of my content production process. Steps: [LIST YOUR STEPS]. Show decision points where I [DESCRIBE THE DECISION]. Render it as a diagram I can screenshot.'
+  }
+]
+
+export default function ClaudeArtifacts() {
+  const [copiedCommand, setCopiedCommand] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopiedCommand(id)
+    setTimeout(() => setCopiedCommand(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Artifacts: What They Are and How to Use Them (2026)',
+    description: 'A practical guide to Claude Artifacts for writers and builders. What they are, how to turn them on, what they can build, the prompts that produce good ones, and the failure modes to avoid.',
+    url: 'https://promptwritingstudio.com/claude-artifacts',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['Claude Artifacts', 'how to use Claude Artifacts', 'what are Claude Artifacts', 'Claude Artifacts for writers', 'Claude Artifacts examples', 'Claude AI artifacts']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Artifacts: What They Are and How to Use Them (2026) | PromptWritingStudio</title>
+        <meta name="description" content="What are Claude Artifacts and how do you use them? A practical 2026 guide for writers and builders: how to turn artifacts on, what they can build, copy-paste prompts, and the failure modes to avoid." />
+        <meta name="keywords" content="Claude Artifacts, how to use Claude Artifacts, what are Claude Artifacts, Claude Artifacts examples, Claude Artifacts for writers, Claude AI artifacts, Claude Artifacts free" />
+        <meta property="og:title" content="Claude Artifacts: What They Are and How to Use Them (2026)" />
+        <meta property="og:description" content="A practical guide to Claude Artifacts for writers and builders. What they are, how to turn them on, what they build, and the prompts that produce good ones." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-artifacts" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-artifacts" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+        />
+      </Head>
+
+      <Layout>
+        {/* Hero */}
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Artifacts:
+              <span className="block text-[#FFDE59]">What They Are and How to Use Them</span>
+            </h1>
+
+            {/* Answer Block - AEO */}
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                Claude Artifacts are standalone, editable outputs that Claude generates in a panel next to your chat. Instead of leaving a long document, a code file, or a working app stuck inside the conversation, Claude opens it in its own window where you can preview it, edit it in place, version it, and publish it as a shareable link. They work on the free plan, support documents, code, HTML sites, diagrams, and interactive React components, and are most useful for any output you expect to revise more than once.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              This guide is written for people who produce things: writers, marketers, and solo builders. The focus is the prompts that turn artifacts into useful work, not just the buttons.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a
+                href="#how-to-use"
+                className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200"
+              >
+                How to Use Them
+              </a>
+              <a
+                href="#prompts"
+                className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200"
+              >
+                Copy the Prompts
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* What are Claude Artifacts */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              What Are Claude Artifacts?
+            </h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-6">
+                A Claude Artifact is a dedicated window that holds a single, self-contained output. When you ask Claude for a long document, a piece of code, a diagram, or a small app, it does not dump the result into the chat. It opens an artifact panel beside the conversation. That panel has a Preview tab that shows the output running or rendered, and a Code or source view you can read and copy.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                Anthropic triggers an artifact when the content is, in its words, <strong>significant and self-contained, typically more than 15 lines, and something you are likely to want to edit, iterate on, or reuse.</strong> A two-line answer stays in the chat. A 600-word draft becomes an artifact you can revise.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                The reason this matters: chat is where ideas are messy and disposable. An artifact is where a deliverable lives. You can edit a passage in place, switch between versions if a rewrite goes wrong, and publish the finished thing as a link. For anyone who writes or builds, that is the difference between talking about the work and actually shipping it.
+              </p>
+              <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+                <p className="text-[#333333]">
+                  <strong>One-sentence definition:</strong> Claude Artifacts are editable, versioned, shareable outputs that open in their own panel beside the chat, so a draft or tool becomes a deliverable instead of a buried message.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* How to use */}
+        <section id="how-to-use" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              How Do You Use Claude Artifacts?
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Setup takes under a minute. The skill is in the prompting, which comes after.
+            </p>
+
+            <div className="space-y-6">
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">1</span>
+                  <div className="flex-1">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Turn artifacts on</h3>
+                    <p className="text-[#333333]">
+                      Open Claude, go to Settings, then Capabilities, and toggle Artifacts on. If you want artifacts that run code or produce downloadable files, also enable Code execution and file creation. Artifacts are available on every plan, including the free tier.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">2</span>
+                  <div className="flex-1">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Prompt for something substantial</h3>
+                    <p className="text-[#333333]">
+                      You do not have to say the word artifact. Ask for a draft, a tool, a page, or a diagram. When the output is long enough and self-contained, Claude opens it in the panel automatically. If it stays in the chat and you want it as an artifact, add: <em>Put this in an artifact so I can edit it.</em>
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">3</span>
+                  <div className="flex-1">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Preview, then edit in place</h3>
+                    <p className="text-[#333333]">
+                      Toggle between Preview and the source view in the panel. In a Markdown document, highlight a passage and choose Edit with Claude to rewrite just that section. Every change is versioned, so you can roll back with the version selector if a rewrite goes the wrong way.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">4</span>
+                  <div className="flex-1">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Publish or download</h3>
+                    <p className="text-[#333333]">
+                      Use the publish option in the panel header to generate a public link anyone can open and interact with, or embed it on a site. For code and document artifacts you can download the source. Published artifacts are public, so keep private data out of anything you publish.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* What they can build */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              What Can Claude Artifacts Build?
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Six artifact types matter most. Here is what each one is good for if your work is content rather than software.
+            </p>
+
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Artifact type</th>
+                    <th className="p-4 text-left font-semibold">What it is good for</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {artifactTypes.map((row, index) => (
+                    <tr key={index} className={index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}>
+                      <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A]">{row.type}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333]">{row.forWriters}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="mt-8 bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>The pattern that holds across all six:</strong> use an artifact for anything you will touch more than once. A throwaway answer belongs in the chat. A draft, a page, a tool, or a workflow map belongs in an artifact where you can version and publish it.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Before / after */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              Weak Prompt vs Strong Prompt
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              The artifact feature is only as good as the prompt behind it. Most disappointing artifacts trace back to a vague request. Here is the same goal asked two ways.
+            </p>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white p-6 rounded-lg border-2 border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-3">Weak prompt</h3>
+                <p className="text-[#333333] font-mono text-sm bg-gray-50 p-4 rounded mb-4">
+                  Make me a content calendar.
+                </p>
+                <p className="text-[#666666] text-sm">
+                  Claude guesses the format, the timeframe, the channels, and the columns. You get a generic table you have to rebuild. No clear deliverable, so it may not even become an artifact.
+                </p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border-2 border-[#FFDE59]">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-3">Strong prompt</h3>
+                <p className="text-[#333333] font-mono text-sm bg-gray-50 p-4 rounded mb-4">
+                  Create an artifact: an interactive 4-week content calendar as a React component. Columns: date, channel, hook, status. Pre-fill 3 LinkedIn posts and 1 newsletter per week on the theme of AI for writers. Let me edit cells and tick status. Mobile-friendly. I will publish the link.
+                </p>
+                <p className="text-[#666666] text-sm">
+                  Format, scope, columns, sample content, interactivity, and the end goal are all specified. You get a working tool on the first pass, with little rework.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>The rule:</strong> name the artifact type, the structure, a sample of the content, and what you will do with it. Specificity is what separates a usable artifact from one you throw away.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Prompts */}
+        <section id="prompts" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+                Copy-Paste Artifact Prompts
+              </h2>
+              <p className="text-xl text-[#333333] max-w-3xl mx-auto">
+                Fill-in-the-blank templates for the four artifacts writers and builders reach for most. Replace the bracketed slots and paste into Claude.
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              {examplePrompts.map((example) => (
+                <div key={example.id} className="bg-[#F9F9F9] rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="flex justify-between items-center px-6 py-3 bg-gray-100 border-b border-gray-200">
+                    <span className="font-semibold text-[#1A1A1A] text-sm">{example.label}</span>
+                    <button
+                      onClick={() => copyToClipboard(example.command, example.id)}
+                      className="text-sm font-medium px-3 py-1 rounded bg-[#FFDE59] text-[#1A1A1A] hover:bg-[#E5C84F] transition-colors duration-200"
+                    >
+                      {copiedCommand === example.id ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <div className="px-6 py-4">
+                    <p className="text-[#333333] font-mono text-sm">{example.command}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                Want a full library of fill-in-the-blank prompts like these, organised by task? The <Link href="/chatgpt-prompt-templates" className="text-[#1A1A1A] font-semibold underline hover:no-underline">prompt template library</Link> has more, and the <a href={COURSE_URL} className="text-[#1A1A1A] font-semibold underline hover:no-underline">Prompt Writing Studio course</a> teaches the framework behind why the strong versions work.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Failure modes */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              Four Failure Modes (and How to Avoid Them)
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Most artifact frustration comes from a handful of avoidable mistakes. Here they are.
+            </p>
+
+            <div className="space-y-6">
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">1. No artifact appears</h3>
+                <p className="text-[#333333]">
+                  Claude only opens an artifact when the output is substantial and self-contained, usually more than 15 lines. Short requests stay in the chat. Fix: make the deliverable bigger or ask explicitly, <em>Put this in an artifact.</em> If nothing ever appears, the feature is off in Settings, Capabilities.
+                </p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">2. Regenerating the whole thing for a small change</h3>
+                <p className="text-[#333333]">
+                  Asking Claude to redo the entire artifact to fix one paragraph wastes time and risks changing parts you liked. Fix: in a document, highlight the passage and use Edit with Claude. For other types, tell Claude exactly which section to change and leave the rest untouched.
+                </p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">3. Publishing private data</h3>
+                <p className="text-[#333333]">
+                  A published artifact is public to anyone with the link. Writers paste client names, draft pricing, or unreleased work into an artifact and then publish it. Fix: treat publish as posting to the open web. Strip anything confidential before you generate the link.
+                </p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">4. Treating an artifact like a project workspace</h3>
+                <p className="text-[#333333]">
+                  An artifact is one output. It does not carry context across separate chats. If you keep re-explaining your brand, audience, or style every session, you want a workspace, not an artifact. Fix: use a <Link href="/claude-projects" className="text-[#1A1A1A] font-semibold underline hover:no-underline">Claude Project</Link> to hold the persistent context, and create artifacts inside it.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl text-center">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+              The Feature Is Free. The Skill Is the Prompt.
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Artifacts turn Claude into a place where your drafts and tools actually ship. But the gap between a throwaway artifact and a useful one is entirely in how you ask. Prompt Writing Studio teaches the framework behind every strong prompt on this page, with a library you can use across writing, marketing, and building.
+            </p>
+            <a
+              href={COURSE_URL}
+              className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200"
+            >
+              Join Now
+            </a>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">
+              Frequently Asked Questions
+            </h2>
+            <p className="text-xl text-[#333333] text-center mb-12">
+              Common questions about Claude Artifacts, answered
+            </p>
+
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Related guides */}
+        <section className="py-16 bg-white border-t border-gray-100">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+                More Claude Guides
+              </h2>
+              <p className="text-lg text-[#333333] max-w-2xl mx-auto">
+                Keep going with the rest of our practical Claude coverage.
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Link href="/claude-projects" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Projects Guide</h3>
+                <p className="text-sm text-[#666666]">Workspaces that hold context across many chats. The companion to artifacts.</p>
+              </Link>
+              <Link href="/claude-code-guide" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Guide</h3>
+                <p className="text-sm text-[#666666]">Anthropic's agentic coding CLI for building in the terminal.</p>
+              </Link>
+              <Link href="/chatgpt-prompt-templates" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Prompt Template Library</h3>
+                <p className="text-sm text-[#666666]">Fill-in-the-blank prompts organised by task.</p>
+              </Link>
+              <Link href="/content-creators-ai" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">AI for Content Creators</h3>
+                <p className="text-sm text-[#666666]">How writers and creators put AI to work day to day.</p>
+              </Link>
+              <Link href="/claude-vs-chatgpt" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude vs ChatGPT</h3>
+                <p className="text-sm text-[#666666]">Which model fits which task, side by side.</p>
+              </Link>
+              <a href={COURSE_URL} className="block p-6 bg-[#1A1A1A] rounded-lg border border-[#1A1A1A] hover:bg-[#333333] transition">
+                <h3 className="font-bold text-white mb-2">Prompt Writing Studio</h3>
+                <p className="text-sm text-gray-300">The course behind every prompt framework on this site. Join Now.</p>
+              </a>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-alternatives.js
+++ b/pages/claude-code-alternatives.js
@@ -1,0 +1,387 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const faqs = [
+  {
+    question: "What is the best Claude Code alternative?",
+    answer: "There is no single best one — it depends on where you work and how you pay. If you want the closest like-for-like terminal agent, OpenAI Codex CLI and Gemini CLI are the nearest matches. If you want a visual IDE instead of a terminal, Cursor and Windsurf are the strongest. If you want a free, open-source option you control, Cline and Aider win. Claude Code still leads adoption (46% most-loved in the Pragmatic Engineer 2026 survey), so the honest framing is: alternatives that fit your workflow better, not alternatives that are simply better."
+  },
+  {
+    question: "Is there a free alternative to Claude Code?",
+    answer: "Yes. Gemini CLI gives you 1,000 requests per day at no cost. Cline, Aider, and Continue.dev are open source and free to install — you only pay your model provider's API costs (bring your own key). If you already pay for a model API you use elsewhere, these three are effectively free to run on top of it."
+  },
+  {
+    question: "Which Claude Code alternative is best for the terminal?",
+    answer: "Codex CLI (OpenAI), Gemini CLI (Google), Aider, and Cline CLI are the terminal-first agents most comparable to Claude Code. Codex CLI leads SWE-bench Verified at 88.7% on GPT-5.5, just ahead of Claude Opus 4.7 at 87.6%. Aider is the original open-source CLI coding agent and predates Claude Code by over a year. All four run in your terminal and commit to git, so the choice comes down to which model and pricing model you prefer."
+  },
+  {
+    question: "Cursor vs Claude Code — which should I use?",
+    answer: "Different tools, not strictly better or worse. Cursor is a VS Code-forked IDE with AI in the editor UI; it wins on inline tab-complete and visual diff review. Claude Code is a terminal-first agent; it wins on multi-file refactors, git workflows, hooks, and sub-agents. Many developers run both. We cover this head-to-head in detail in the Claude Code vs Cursor deep dive — start there if those two are your shortlist."
+  },
+  {
+    question: "How much do Claude Code alternatives cost?",
+    answer: "The $20/month tier has become the standard: Cursor Pro, Windsurf Pro (actually $15), and Claude Code Pro all sit around there. GitHub Copilot Pro is cheaper at $10/month. Codex and Gemini CLI bill via API tokens or subscription. The open-source agents (Cline, Aider, Continue.dev) are free to install and cost only your API usage. The real difference is flat quota versus token-based billing — heavy users prefer a flat fee, light users come out ahead on tokens."
+  },
+  {
+    question: "Do I have to leave Claude Code to use an alternative?",
+    answer: "No. The most common real-world setup is running two tools side by side — for example, Claude Code in a terminal for agentic and git work, and Cursor or Windsurf as the editor for interactive coding. Because they all operate on the same files on disk, they do not conflict. Treat 'alternative' as 'second tool with a clear job', not 'replacement'."
+  },
+  {
+    question: "Which alternative is best for beginners?",
+    answer: "Cursor or Windsurf. A visual IDE with inline suggestions and a composer is easier to learn than a terminal-first agent. Start there, get comfortable with AI-assisted coding, then add a terminal agent like Claude Code, Codex CLI, or Cline once you want deeper automation, hooks, and sub-agents."
+  },
+  {
+    question: "Is the best alternative the one with the highest benchmark score?",
+    answer: "No — and this trips up a lot of buyers. Codex leads SWE-bench Verified (88.7%) and Claude Opus is a point behind (87.6%), but a one-point benchmark gap rarely changes your day-to-day output. Workflow fit, pricing model, and how the tool handles your codebase matter far more than a leaderboard. Pick for fit first, benchmark second."
+  }
+]
+
+const tools = [
+  {
+    name: 'Cursor',
+    form: 'VS Code-forked IDE',
+    free: 'Free Hobby tier; Pro $20/mo',
+    forWho: 'Developers who want AI inside a familiar visual editor with inline tab-complete and a composer for multi-file edits.',
+    vsClaude: 'Trades Claude Code\'s terminal-first automation (hooks, sub-agents, headless runs) for a polished editor UI and model choice across Claude, GPT, and Gemini.'
+  },
+  {
+    name: 'GitHub Copilot',
+    form: 'IDE extension (VS Code, JetBrains)',
+    free: 'Pro $10/mo; Business $19/seat',
+    forWho: 'Teams already in the GitHub and VS Code ecosystem who want the cheapest, most-integrated autocomplete plus an agent mode.',
+    vsClaude: 'Cheapest entry point and deepest IDE integration, but its agent mode is less mature than Claude Code\'s sub-agent and background-task model.'
+  },
+  {
+    name: 'Windsurf',
+    form: 'VS Code fork (by Codeium)',
+    free: 'Pro $15/mo; Teams $30/seat',
+    forWho: 'Cursor-style IDE users who want a slightly cheaper plan and the Cascade agent for flow-based multi-file editing.',
+    vsClaude: 'A direct Cursor competitor rather than a Claude Code competitor — same trade-off: editor UI over terminal automation, undercutting Cursor by $5/mo.'
+  },
+  {
+    name: 'OpenAI Codex CLI',
+    form: 'Terminal agent',
+    free: 'API tokens / ChatGPT subscription',
+    forWho: 'Terminal-first developers who want the closest like-for-like Claude Code experience but on OpenAI models.',
+    vsClaude: 'The nearest match in form factor. Codex on GPT-5.5 leads SWE-bench Verified at 88.7% vs Claude Opus 4.7 at 87.6% — a near-tie. Choose on which model and ecosystem you prefer.'
+  },
+  {
+    name: 'Gemini CLI',
+    form: 'Terminal agent',
+    free: 'Free — 1,000 requests/day',
+    forWho: 'Developers who want a capable terminal agent at zero cost and are happy on Google\'s models.',
+    vsClaude: 'The strongest free terminal option. Gemini 3.1 Pro scores 80.6% on SWE-bench Verified — behind Claude and Codex, but the generous free tier makes it the easiest no-risk alternative to try.'
+  },
+  {
+    name: 'Aider',
+    form: 'Open-source terminal CLI',
+    free: 'Free (BYOK — pay your API costs)',
+    forWho: 'Developers who want a model-agnostic, git-native CLI they fully control, with no vendor lock-in.',
+    vsClaude: 'The original open-source CLI coding agent, predating Claude Code by over a year. Battle-tested for refactors and automation, but no IDE extension, no autocomplete, and a steeper setup.'
+  },
+  {
+    name: 'Cline',
+    form: 'Open-source (VS Code + CLI)',
+    free: 'Free; Teams $20/mo (first 10 seats free)',
+    forWho: 'Developers who want open-source freedom and full provider portability inside VS Code, plus a terminal mode.',
+    vsClaude: 'Apache 2.0 licensed with 5M+ VS Code installs and full BYOK model choice. Cline CLI 2.0 added parallel terminal agents — the closest open-source answer to Claude Code\'s sub-agents.'
+  },
+  {
+    name: 'Continue.dev',
+    form: 'Open-source IDE extension',
+    free: 'Free (BYOK)',
+    forWho: 'Developers who want a free, customisable AI assistant inside their existing IDE without committing to one model vendor.',
+    vsClaude: 'A configurable open-source layer rather than a full agent. Lighter than Claude Code on autonomy, but free and fully under your control.'
+  }
+]
+
+const comparisonRows = [
+  { tool: 'Claude Code', form: 'Terminal agent', cost: 'API / Pro $20/mo / Max', open: 'No', best: 'Multi-file refactors, git, hooks, sub-agents' },
+  { tool: 'Cursor', form: 'IDE (VS Code fork)', cost: 'Free / Pro $20/mo', open: 'No', best: 'Interactive coding with inline AI' },
+  { tool: 'GitHub Copilot', form: 'IDE extension', cost: 'Pro $10/mo', open: 'No', best: 'Cheap autocomplete in GitHub/VS Code stack' },
+  { tool: 'Windsurf', form: 'IDE (VS Code fork)', cost: 'Pro $15/mo', open: 'No', best: 'Cursor-style editing, slightly cheaper' },
+  { tool: 'Codex CLI', form: 'Terminal agent', cost: 'API / ChatGPT sub', open: 'No', best: 'Closest terminal match (top SWE-bench)' },
+  { tool: 'Gemini CLI', form: 'Terminal agent', cost: 'Free — 1,000 req/day', open: 'No', best: 'Best free terminal agent' },
+  { tool: 'Aider', form: 'Terminal CLI', cost: 'Free (BYOK)', open: 'Yes', best: 'Model-agnostic, git-native, no lock-in' },
+  { tool: 'Cline', form: 'VS Code + CLI', cost: 'Free / Teams $20/mo', open: 'Yes', best: 'Open-source with provider portability' },
+  { tool: 'Continue.dev', form: 'IDE extension', cost: 'Free (BYOK)', open: 'Yes', best: 'Free customisable in-IDE assistant' }
+]
+
+const pickerVariables = [
+  { slot: '[WHERE I WORK]', example: 'a terminal / a visual IDE / VS Code with extensions' },
+  { slot: '[BUDGET]', example: 'free only / under $20 a month / flat fee preferred' },
+  { slot: '[MAIN JOB]', example: 'inline autocomplete / multi-file refactors / autonomous agents / git workflows' },
+  { slot: '[MODEL PREFERENCE]', example: 'any / Claude / GPT / Gemini / open weights' },
+  { slot: '[LOCK-IN TOLERANCE]', example: 'fine with a vendor / want open source I control' }
+]
+
+export default function ClaudeCodeAlternatives() {
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Code Alternatives (2026): 8 Honest Options and Who Each One Is For',
+    description: 'An honest roundup of Claude Code alternatives — Cursor, Copilot, Windsurf, Codex CLI, Gemini CLI, Aider, Cline, and Continue.dev — with Claude Code as the benchmark and a clear who-each-is-for recommendation.',
+    url: 'https://promptwritingstudio.com/claude-code-alternatives',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude code alternatives', 'claude code alternative', 'claude code vs cursor', 'best claude code alternative', 'free claude code alternative', 'AI coding tools 2026']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Alternatives (2026): 8 Honest Options and Who Each Is For | PromptWritingStudio</title>
+        <meta name="description" content="Claude Code alternatives compared honestly: Cursor, Copilot, Windsurf, Codex CLI, Gemini CLI, Aider, Cline, Continue.dev. Claude Code as the benchmark, plus who each alternative is for and a pick-your-tool prompt." />
+        <meta name="keywords" content="claude code alternatives, claude code alternative, claude code vs cursor, best claude code alternative, free claude code alternative, AI coding tools" />
+        <meta property="og:title" content="Claude Code Alternatives (2026): 8 Honest Options and Who Each Is For" />
+        <meta property="og:description" content="An honest roundup of Claude Code alternatives with a clear who-each-is-for recommendation and a pick-your-tool prompt." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-code-alternatives" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-alternatives" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Code Alternatives
+              <span className="block text-[#FFDE59]">8 honest options, and who each one is for</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                The best Claude Code alternative depends on where you work and how you pay — not on a leaderboard. For a terminal agent like Claude Code, look at Codex CLI and Gemini CLI. For a visual IDE instead, look at Cursor and Windsurf. For free and open source, look at Cline and Aider. Claude Code still leads adoption at 46% most-loved (Pragmatic Engineer 2026), so we use it as the benchmark and judge every alternative against it.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              No hype, no "this one tool beats them all." Just a clear read on which alternative fits your workflow.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#comparison" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                See the comparison table
+              </a>
+              <a href="#picker" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Get the pick-your-tool prompt
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The short answer by situation</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Most "best Claude Code alternative" lists rank tools head to head. That is the wrong question. The right question is which alternative fits your situation. Here is the fast read.
+            </p>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-[#F9F9F9] p-8 rounded-lg border-2 border-[#FFDE59]">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">If you want a terminal agent...</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Codex CLI</strong> — closest like-for-like, top SWE-bench score</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Gemini CLI</strong> — best free option, 1,000 requests/day</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Aider / Cline</strong> — open source, you control the models</span></li>
+                </ul>
+              </div>
+              <div className="bg-[#F9F9F9] p-8 rounded-lg border-2 border-gray-200">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">If you want a visual IDE...</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Cursor</strong> — the most popular IDE alternative</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Windsurf</strong> — Cursor-style, $5/mo cheaper</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>GitHub Copilot</strong> — cheapest, deepest IDE integration</span></li>
+                </ul>
+              </div>
+            </div>
+            <p className="text-center text-[#666666] mt-8">
+              For the two most-searched matchup, read the full <Link href="/claude-code-vs-cursor" className="text-[#1A1A1A] font-semibold underline">Claude Code vs Cursor deep dive</Link> — we do not repeat it here.
+            </p>
+          </div>
+        </section>
+
+        <section id="comparison" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-6xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Claude Code alternatives at a glance</h2>
+            <p className="text-lg text-[#333333] mb-8">Claude Code is the top row — the benchmark. Everything below is judged against it.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Tool</th>
+                    <th className="p-4 text-left font-semibold">Form</th>
+                    <th className="p-4 text-left font-semibold">Cost</th>
+                    <th className="p-4 text-left font-semibold">Open source</th>
+                    <th className="p-4 text-left font-semibold">Best for</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {comparisonRows.map((row, index) => (
+                    <tr key={index} className={index === 0 ? 'bg-[#FFF8DC]' : index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                      <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A] text-sm">{row.tool}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{row.form}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{row.cost}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{row.open}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{row.best}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-sm text-[#666666] mt-4">
+              SWE-bench Verified (2026): Codex on GPT-5.5 88.7%, Claude Opus 4.7 87.6%, Gemini 3.1 Pro 80.6%, Cursor Composer 2.5 79.8%. Pricing as of June 2026 and subject to change.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-8">The 8 alternatives, one by one</h2>
+            <div className="space-y-6">
+              {tools.map((t, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 md:p-8 rounded-lg border border-gray-200">
+                  <div className="flex flex-wrap items-center gap-3 mb-4">
+                    <h3 className="text-2xl font-bold text-[#1A1A1A]">{i + 1}. {t.name}</h3>
+                    <span className="bg-[#1A1A1A] text-white text-xs font-semibold px-3 py-1 rounded-full">{t.form}</span>
+                    <span className="bg-[#FFDE59] text-[#1A1A1A] text-xs font-semibold px-3 py-1 rounded-full">{t.free}</span>
+                  </div>
+                  <p className="text-[#333333] mb-3"><strong>Who it is for:</strong> {t.forWho}</p>
+                  <p className="text-[#333333]"><strong>Versus Claude Code:</strong> {t.vsClaude}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="picker" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Pick your tool with this prompt</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Reading nine tool descriptions still leaves you choosing. Skip that. Fill in the five slots below, paste the prompt into Claude or ChatGPT, and let it match a tool to your actual constraints. This is the kind of fill-in-the-blank prompt we teach across the whole studio.
+            </p>
+
+            <div className="bg-[#1A1A1A] text-gray-100 p-6 md:p-8 rounded-lg font-mono text-sm leading-relaxed mb-8">
+              <p className="mb-4">I am choosing an AI coding tool. Recommend one primary tool and one backup from this list: Claude Code, Cursor, GitHub Copilot, Windsurf, OpenAI Codex CLI, Gemini CLI, Aider, Cline, Continue.dev.</p>
+              <p className="mb-2">My constraints:</p>
+              <p className="mb-1">- I mostly work in <span className="text-[#FFDE59]">[WHERE I WORK]</span></p>
+              <p className="mb-1">- My budget is <span className="text-[#FFDE59]">[BUDGET]</span></p>
+              <p className="mb-1">- My main job for the tool is <span className="text-[#FFDE59]">[MAIN JOB]</span></p>
+              <p className="mb-1">- My model preference is <span className="text-[#FFDE59]">[MODEL PREFERENCE]</span></p>
+              <p className="mb-4">- My lock-in tolerance is <span className="text-[#FFDE59]">[LOCK-IN TOLERANCE]</span></p>
+              <p>For each recommendation, give me one sentence on why it fits and one trade-off I am accepting. Do not recommend a tool that violates my budget or lock-in constraint.</p>
+            </div>
+
+            <h3 className="text-xl font-bold text-[#1A1A1A] mb-4">What goes in each slot</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Slot</th>
+                    <th className="p-4 text-left font-semibold">Example values</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pickerVariables.map((v, i) => (
+                    <tr key={i} className={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                      <td className="p-4 border-b border-gray-200 font-mono text-sm text-[#1A1A1A]">{v.slot}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{v.example}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="bg-white p-6 rounded-lg border-l-4 border-red-300 mt-8">
+              <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Common failure mode</h3>
+              <p className="text-[#333333]">
+                If you leave <span className="font-mono text-sm">[MAIN JOB]</span> vague ("coding"), the model defaults to the most popular tool and ignores your budget. Be specific — "autonomous multi-file refactors with git commits" produces a different, better answer than "help me code". A weak slot makes a weak prompt.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Should you actually leave Claude Code?</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-5">
+                Probably not entirely. The honest pattern across most developers is not switching — it is pairing. Keep Claude Code in a terminal for agentic and git work, and add an IDE like Cursor or Windsurf for interactive editing. Because every tool here reads and writes the same files on disk, running two does not cause conflicts.
+              </p>
+              <p className="text-lg text-[#333333] mb-5">
+                The cases where a true switch makes sense are narrow and specific: you need a free tool (Gemini CLI, Cline, Aider), you are committed to OpenAI or Google models (Codex CLI, Gemini CLI), or you need open source you fully control with no vendor lock-in (Cline, Aider, Continue.dev). Outside those, "alternative" usually means "second tool with a clear job."
+              </p>
+              <p className="text-lg text-[#333333]">
+                Whatever you land on, the tool is only half the equation. The prompts you give it decide the output. A precise, well-structured prompt gets a better result out of Gemini CLI than a lazy one gets out of Claude Opus.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions people actually ask when shopping for a Claude Code alternative.</p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-50 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6 text-center">Keep going with Claude Code</h2>
+            <p className="text-lg text-[#333333] text-center mb-8">
+              Staying with Claude Code, or running it alongside an alternative? These guides cover setup, cost, and the daily workflow.
+            </p>
+            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
+              <Link href="/claude-code-guide" className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200 hover:border-[#FFDE59] transition-colors text-center">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Guide</h3>
+                <p className="text-sm text-[#666666]">Install, auth, and the full daily workflow.</p>
+              </Link>
+              <Link href="/claude-code-review" className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200 hover:border-[#FFDE59] transition-colors text-center">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Review</h3>
+                <p className="text-sm text-[#666666]">Our hands-on verdict on what it does well and badly.</p>
+              </Link>
+              <Link href="/claude-code-vs-cursor" className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200 hover:border-[#FFDE59] transition-colors text-center">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code vs Cursor</h3>
+                <p className="text-sm text-[#666666]">The head-to-head and a 30-day switch plan.</p>
+              </Link>
+              <Link href="/claude-code-pricing" className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200 hover:border-[#FFDE59] transition-colors text-center">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Pricing</h3>
+                <p className="text-sm text-[#666666]">API vs Pro vs Max, and what each costs.</p>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              The tool matters less than the prompt
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              Whichever coding agent you pick, your output is only as good as the instructions you give it. PromptWritingStudio teaches the fill-in-the-blank prompt system that gets sharper results from any AI tool — Claude Code, Cursor, or anything on this list.
+            </p>
+            <div className="flex justify-center">
+              <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="bg-[#FFDE59] text-[#1A1A1A] px-10 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-generator.js
+++ b/pages/claude-code-generator.js
@@ -1,0 +1,307 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+const faqs = [
+  {
+    question: "Can Claude generate code?",
+    answer: "Yes. Claude can generate working code from a plain-English description. In the Claude chat app you describe what you want and paste the result into your editor. With Claude Code, the command-line tool, Claude writes the files directly into your project, runs them, and fixes its own errors. The quality of the output depends almost entirely on how specific your prompt is."
+  },
+  {
+    question: "Is Claude good at generating code?",
+    answer: "Claude is strong across JavaScript, TypeScript, Python, Go, Rust, Java, and SQL, and handles most other languages well. It is best at scoped, well-described tasks: a function, a component, a script, a query. Vague one-line prompts produce generic code. The prompt templates on this page are built to give Claude the constraints it needs to generate code you can actually ship."
+  },
+  {
+    question: "What is the difference between Claude and Claude Code as a code generator?",
+    answer: "Claude (claude.ai) generates code as text in a chat window that you copy into your project. Claude Code is a terminal tool that generates code straight into your files, runs it, and iterates until tests pass. Use the chat app for one-off snippets and learning. Use Claude Code when you want the generated code applied across a real codebase."
+  },
+  {
+    question: "How do I get Claude to generate better code?",
+    answer: "Give it three things: the exact language and framework version, the inputs and expected outputs, and the constraints (error handling, naming, no external libraries, etc.). Then ask it to explain its approach before writing. Specificity beats length. A weak prompt like 'write a login function' produces guesswork; a strong prompt that names the framework, the auth method, and the return shape produces code you can paste in."
+  },
+  {
+    question: "Is Claude code generation free?",
+    answer: "The Claude chat app has a free tier you can use to generate code, with usage limits. Claude Pro is $20/month for higher limits. Claude Code, the terminal tool, runs on either an Anthropic API key (billed per token, roughly $5-20/month for light use) or a Claude Pro/Max subscription. Verify current pricing on Anthropic's site, as plans change."
+  }
+]
+
+const promptTemplates = [
+  {
+    id: 'function',
+    label: 'Generate a single function',
+    template: `Write a [LANGUAGE] function called [NAME] that [WHAT IT DOES].
+
+Inputs: [LIST PARAMETERS AND TYPES]
+Returns: [RETURN TYPE AND SHAPE]
+Constraints:
+- Handle [EDGE CASE] by [BEHAVIOUR]
+- Do not use external libraries
+- Add a one-line comment above each block
+
+Explain your approach in one sentence before writing the code.`
+  },
+  {
+    id: 'component',
+    label: 'Generate a UI component',
+    template: `Generate a [FRAMEWORK] component named [NAME] that [WHAT IT DOES].
+
+Props: [LIST PROPS AND TYPES]
+Styling: [TAILWIND / CSS MODULES / STYLED-COMPONENTS]
+State: [WHAT IT TRACKS]
+Behaviour: [INTERACTIONS]
+
+Match this existing file's conventions: [PASTE A SAMPLE COMPONENT].
+Return only the component file, no explanation.`
+  },
+  {
+    id: 'script',
+    label: 'Generate a utility script',
+    template: `Write a [LANGUAGE] script that [TASK].
+
+Input: [FILE / API / STDIN — describe the format]
+Output: [WHAT IT SHOULD PRODUCE AND WHERE]
+Steps: [NUMBER THE STEPS IF ORDER MATTERS]
+Error handling: print a clear message and exit non-zero on [FAILURE CASE].
+
+Use only the standard library. Add usage instructions as a comment at the top.`
+  },
+  {
+    id: 'sql',
+    label: 'Generate a SQL query',
+    template: `Write a [POSTGRES / MYSQL / SQLITE] query that [GOAL].
+
+Tables and columns: [PASTE SCHEMA]
+Filters: [CONDITIONS]
+Grouping / ordering: [REQUIREMENTS]
+
+Optimise for readability over cleverness. Explain any join in one sentence.`
+  },
+  {
+    id: 'build',
+    label: 'Build a small project (Claude Code)',
+    template: `Build a [PROJECT TYPE] in [FRAMEWORK].
+
+Goal: [WHAT THE USER SHOULD BE ABLE TO DO]
+Stack: [LANGUAGES, LIBRARIES, VERSIONS]
+File structure: [HOW YOU WANT IT ORGANISED, OR "you decide"]
+
+Work in plan mode first. Show me the file plan before writing anything,
+then build it one file at a time and run it when done.`
+  }
+]
+
+export default function ClaudeCodeGenerator() {
+  const [copiedId, setCopiedId] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopiedId(id)
+    setTimeout(() => setCopiedId(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Code Generator: How to Use Claude to Generate Code (2026)',
+    description: 'How to use Claude and Claude Code as a code generator, with copy-paste prompt templates for functions, components, scripts, SQL, and small builds.',
+    url: 'https://promptwritingstudio.com/claude-code-generator',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude code generator', 'claude code builder', 'generate code with claude', 'claude code prompts', 'claude ai code generation']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Generator: How to Use Claude to Generate Code (2026) | PromptWritingStudio</title>
+        <meta name="description" content="Use Claude as a code generator. Copy-paste prompt templates for generating functions, UI components, scripts, and SQL — plus how Claude Code builds straight into your project." />
+        <meta name="keywords" content="claude code generator, claude code builder, generate code with claude, claude code prompts, claude ai code generation, claude code examples" />
+        <meta property="og:title" content="Claude Code Generator: How to Use Claude to Generate Code (2026)" />
+        <meta property="og:description" content="Copy-paste prompt templates that turn Claude into a reliable code generator for functions, components, scripts, SQL, and small builds." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-code-generator" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-generator" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        {/* Hero */}
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Updated June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Code Generator
+              <span className="block text-[#FFDE59] text-3xl md:text-4xl mt-3">Prompts that turn Claude into a reliable code generator</span>
+            </h1>
+
+            {/* AEO answer block */}
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                A Claude code generator is using Claude to write working code from a plain-English description. You can do this two ways: in the Claude chat app, where Claude returns code you copy into your editor, or with Claude Code, the terminal tool that writes code straight into your project and runs it. The prompt templates below give Claude the constraints it needs to generate code you can ship, not generic placeholder snippets.
+              </p>
+            </div>
+
+            <a href="#templates" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+              Get the Prompt Templates
+            </a>
+          </div>
+        </section>
+
+        {/* Two ways */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Two ways to generate code with Claude</h2>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Claude chat app (claude.ai)</h3>
+                <p className="text-[#333333]">You describe the code, Claude returns it as text, and you paste it into your editor. Best for one-off functions, learning a new pattern, or generating a snippet you will adapt by hand. Has a free tier.</p>
+              </div>
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Claude Code (terminal)</h3>
+                <p className="text-[#333333]">Claude writes generated code directly into your project files, runs it, and fixes its own errors. This is the "builder" workflow — best when you want generated code applied across a real codebase. See the <Link href="/claude-code-guide" className="text-[#1A1A1A] font-semibold underline hover:no-underline">full Claude Code guide</Link>.</p>
+              </div>
+            </div>
+            <p className="text-lg text-[#333333] mt-8">
+              Both run on the same Claude models, so the prompting principles are identical. The difference is only where the code lands.
+            </p>
+          </div>
+        </section>
+
+        {/* The rule */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Weak prompt vs strong prompt</h2>
+            <p className="text-lg text-[#333333] mb-6">The single biggest factor in code-generation quality is specificity. Compare these two prompts for the same task.</p>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white p-6 rounded-lg border-l-4 border-red-400">
+                <p className="font-semibold text-red-600 mb-2">Weak — produces guesswork</p>
+                <p className="font-mono text-sm text-[#333333]">"Write a function to validate an email."</p>
+                <p className="text-sm text-[#666666] mt-3">Claude guesses the language, the return type, and how strict to be. You get generic code you have to rewrite.</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border-l-4 border-green-500">
+                <p className="font-semibold text-green-600 mb-2">Strong — produces shippable code</p>
+                <p className="font-mono text-sm text-[#333333]">"Write a TypeScript function isValidEmail(input: string): boolean. Trim whitespace, reject empty strings, and use a single RFC-5322-pragmatic regex. No external libraries."</p>
+                <p className="text-sm text-[#666666] mt-3">Named language, signature, edge cases, and constraint. Claude returns exactly what you asked for.</p>
+              </div>
+            </div>
+            <p className="text-lg text-[#333333] mt-8 font-semibold">
+              The rule: name the language and version, the inputs and outputs, and the constraints. The templates below do this for you.
+            </p>
+          </div>
+        </section>
+
+        {/* Templates */}
+        <section id="templates" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Claude code generator prompt templates</h2>
+            <p className="text-lg text-[#333333] mb-8">Copy a template, fill the bracketed slots, and paste it into Claude or Claude Code. Each one is built to give Claude the constraints it needs.</p>
+            <div className="space-y-6">
+              {promptTemplates.map((t) => (
+                <div key={t.id} className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                  <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">{t.label}</h3>
+                  <div className="bg-[#1A1A1A] text-green-400 p-4 rounded-lg font-mono text-sm relative whitespace-pre-wrap">
+                    {t.template}
+                    <button
+                      onClick={() => copyToClipboard(t.template, t.id)}
+                      className="absolute top-2 right-2 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded"
+                    >
+                      {copiedId === t.id ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Common failure */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The most common code-generation failure</h2>
+            <p className="text-lg text-[#333333] mb-4">
+              Generated code that looks correct but uses a library version you do not have, or a pattern that does not match your codebase. Claude defaults to the most common convention it has seen, which may not be yours.
+            </p>
+            <p className="text-lg text-[#333333]">
+              <strong>The fix:</strong> paste a sample file from your project and add "match this file's conventions" to your prompt. In Claude Code, this is automatic — it reads your existing files first. In the chat app you have to supply the context yourself.
+            </p>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-8 text-center">Claude code generator FAQ</h2>
+            <div className="space-y-4">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-[#F9F9F9] rounded-lg border border-gray-200 group">
+                  <summary className="px-5 py-4 font-semibold text-[#1A1A1A] cursor-pointer">{faq.question}</summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Course CTA */}
+        <section className="py-16 gradient-bg">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl text-center">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">Write prompts that get it right the first time</h2>
+            <p className="text-lg text-gray-100 mb-8">
+              Code generation is just one place specific prompts pay off. PromptWritingStudio teaches the prompting system behind every template on this page — so you stop rewriting AI output and start shipping it.
+            </p>
+            <a href={COURSE_URL} className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200 inline-block">
+              Join Now
+            </a>
+          </div>
+        </section>
+
+        {/* Related Claude Code pages */}
+        <section className="py-16 bg-white border-t border-gray-100">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-2xl md:text-3xl font-bold text-[#1A1A1A] mb-8 text-center">Go deeper on Claude Code</h2>
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Link href="/claude-code-guide" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Guide</h3>
+                <p className="text-sm text-[#666666]">Install it, learn the features, and set up a real development workflow.</p>
+              </Link>
+              <Link href="/claude-md-playbook" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">CLAUDE.md Playbook</h3>
+                <p className="text-sm text-[#666666]">Give Claude Code persistent project context so it generates on-convention code.</p>
+              </Link>
+              <Link href="/claude-code-vs-cursor" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code vs Cursor</h3>
+                <p className="text-sm text-[#666666]">Which agentic coding tool fits your workflow and budget.</p>
+              </Link>
+              <Link href="/claude-code-pricing" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Pricing</h3>
+                <p className="text-sm text-[#666666]">What it actually costs to run Claude Code at your usage level.</p>
+              </Link>
+              <Link href="/claude-code-review" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Review</h3>
+                <p className="text-sm text-[#666666]">Our hands-on verdict on where the generator workflow shines and stalls.</p>
+              </Link>
+              <Link href="/claude-code-alternatives" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Alternatives</h3>
+                <p className="text-sm text-[#666666]">Other code-generation tools worth comparing before you commit.</p>
+              </Link>
+              <Link href="/claude-code-mcp-stack" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Minimum Viable MCP Stack</h3>
+                <p className="text-sm text-[#666666]">Five MCP servers worth installing, with copy-paste config.</p>
+              </Link>
+              <Link href="/calculators" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude + AI Calculators</h3>
+                <p className="text-sm text-[#666666]">Cost and plan calculators for Claude, Claude Code, and the API.</p>
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-pricing.js
+++ b/pages/claude-code-pricing.js
@@ -1,0 +1,455 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import LastVerified from '../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import {
+  CONSUMER_PLANS,
+  TEAM_PLANS,
+  API_PLAN,
+  PLANS_META,
+  CURRENT_MODELS,
+  MODELS_META,
+  getConsumerPlan,
+  getCurrentModelByTier
+} from '../lib/claude-data'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+const pro = getConsumerPlan('pro')
+const max5x = getConsumerPlan('max-5x')
+const max20x = getConsumerPlan('max-20x')
+const freePlan = getConsumerPlan('free')
+const opus = getCurrentModelByTier('flagship')
+const sonnet = getCurrentModelByTier('workhorse')
+
+const faqs = [
+  {
+    question: "How much does Claude Code cost?",
+    answer: `Claude Code itself is free to install via npm. To run it you need either a Claude subscription — Pro at $${pro.pricePerMonth}/month ($${pro.pricePerMonthAnnual}/mo billed annually), Max 5x at $${max5x.pricePerMonth}/month, or Max 20x at $${max20x.pricePerMonth}/month — or pay-as-you-go API billing charged per token. For one developer, a subscription is almost always cheaper than API. Pro covers light-to-moderate daily use; Max plans are for people running Claude Code for hours every day.`
+  },
+  {
+    question: "Is Claude Code free?",
+    answer: `The Claude Code CLI is free to download and install. But the AI behind it is not. There is no free tier that powers Claude Code — the Claude Free plan does not include it. You need a Pro ($${pro.pricePerMonth}/mo) or Max subscription, or API credits. The one genuinely free route is Anthropic's Claude for Open Source program, which qualifying open-source maintainers can apply to. For everyone else, the cheapest real entry point is one month of Pro.`
+  },
+  {
+    question: "Is there a Claude Code discount or coupon?",
+    answer: `Anthropic does not run public coupon codes for Claude Code. The only built-in discount is annual billing on Pro, which drops the effective price from $${pro.pricePerMonth}/mo to $${pro.pricePerMonthAnnual}/mo — about ${Math.round((1 - pro.pricePerMonthAnnual / pro.pricePerMonth) * 100)}% off. Max 5x and Max 20x are billed monthly only, with no annual discount. Students, startups, and open-source maintainers should check Anthropic's program pages: the Claude for Open Source program can mean free access for eligible projects. Be sceptical of third-party sites advertising "Claude Code coupons" — there is no legitimate code.`
+  },
+  {
+    question: "Do Claude Code subscriptions have usage limits?",
+    answer: "Yes. Subscription Claude Code runs on a rolling five-hour session limit plus weekly limits shared between Claude Code and Claude chat. On May 6, 2026, Anthropic doubled the five-hour limits for Pro, Max, Team, and Enterprise and removed the peak-hours reduction. On May 13 it raised weekly limits by 50% as a promotion running through July 13, 2026. Max plans carry two weekly limits — one across all models, one for Sonnet only. If you hit limits daily on Pro, that is the signal to move to Max 5x, not before."
+  },
+  {
+    question: "Did Claude Code billing change on June 15, 2026?",
+    answer: "Anthropic had planned to split autonomous usage (Agent SDK, headless `claude -p` runs, GitHub Actions, third-party apps) onto a separate monthly Agent SDK credit starting June 15, 2026. On that date Anthropic confirmed the change is no longer happening — autonomous and interactive usage continue to draw from the same subscription limits. Several pricing articles still describe the split as live; it is not. Always check Anthropic's own pages before budgeting around it."
+  },
+  {
+    question: "When is the Claude Code API cheaper than a subscription?",
+    answer: `The API is per-token: Claude ${sonnet.name} costs $${sonnet.inputPricePerMTok} per million input tokens and $${sonnet.outputPricePerMTok} per million output; Claude ${opus.name} costs $${opus.inputPricePerMTok} input and $${opus.outputPricePerMTok} output. For your own daily Claude Code use, those tokens add up fast — a few hours of agentic work can burn through more than the $${pro.pricePerMonth} Pro covers. The API only wins for light, predictable, or programmatic use (apps and automations you ship). For hands-on-keyboard developers, a subscription is the cheaper, more predictable choice.`
+  },
+  {
+    question: "What does heavy daily Claude Code use actually cost?",
+    answer: `Two honest reference points from building this site with Claude Code: a light day (small edits, a few file changes) lands around $2–$5 in API credits; a heavy refactoring day leaning on Opus can run $15–$40. Sustained at that pace, API spend overtakes the $${max5x.pricePerMonth} Max 5x subscription within a couple of weeks — which is exactly why daily users move to a flat-fee Max plan. The break-even is roughly: if you run Claude Code more than two focused hours most days, a subscription is cheaper.`
+  },
+  {
+    question: "What is the cheapest way to start with Claude Code?",
+    answer: `One month of Claude Pro at $${pro.pricePerMonth}. It includes Claude Code, the web and desktop apps, Projects, and access to Opus, Sonnet, and Haiku. It is cheaper than the equivalent API token spend for almost any first month of real use, and you can upgrade to Max instantly the first time you hit limits daily. Start on Pro, prove the workflow, then scale the plan to your actual usage — never the other way round.`
+  }
+]
+
+const profiles = [
+  {
+    id: 'evaluating',
+    label: 'Just evaluating',
+    plan: 'Claude Pro',
+    price: `$${pro.pricePerMonth}/mo`,
+    cost: `~$${pro.pricePerMonthAnnual}/mo annual`,
+    fit: [
+      'You want to try Claude Code before committing',
+      'A side project or occasional professional task',
+      'You will not run it for hours every day yet',
+      'You want a flat fee, no token-bill anxiety'
+    ],
+    verdict: `The default starting point. ${pro.bestFor}. Includes Claude Code, the apps, and all current models. Annual billing drops it to $${pro.pricePerMonthAnnual}/mo.`
+  },
+  {
+    id: 'daily',
+    label: 'Daily builder',
+    plan: 'Claude Max 5x',
+    price: `$${max5x.pricePerMonth}/mo`,
+    cost: 'flat, no per-token billing',
+    fit: [
+      'You run Claude Code 2–5 focused hours a day',
+      'You hit "usage limit reached" on Pro most days',
+      'Multiple active projects, frequent context switches',
+      'Opus is your default for hard reasoning'
+    ],
+    verdict: `${max5x.usageLimit}. ${max5x.bestFor}. This is where API spend would overtake the subscription — move here once Pro limits are a daily annoyance, not before.`
+  },
+  {
+    id: 'agentic',
+    label: 'Agentic operator',
+    plan: 'Claude Max 20x',
+    price: `$${max20x.pricePerMonth}/mo`,
+    cost: 'flat, highest consumer ceiling',
+    fit: [
+      'You run Claude Code in multiple terminals at once',
+      'Heavy sub-agents, background tasks, long sessions',
+      'Opus is your default model all day',
+      'You bill your time — $200 pays for itself fast'
+    ],
+    verdict: `${max20x.usageLimit}. ${max20x.bestFor}. Overkill for solo chat use; essential if you run Claude like a team of five.`
+  },
+  {
+    id: 'builder',
+    label: 'App / automation builder',
+    plan: 'Pay-as-you-go API',
+    price: 'Per token',
+    cost: `${sonnet.name}: $${sonnet.inputPricePerMTok}/$${sonnet.outputPricePerMTok} per MTok`,
+    fit: [
+      "You're shipping an app, agent, or automation",
+      'Volume is variable, predictable, or measurable',
+      'You want per-request cost control',
+      "You're not a heavy Claude user yourself"
+    ],
+    verdict: 'The API is for what you ship, not your own daily Claude Code use. Pair it with a Pro or Max subscription for your hands-on work.'
+  },
+  {
+    id: 'team',
+    label: 'Team (5+ people)',
+    plan: 'Claude Team',
+    price: `$${TEAM_PLANS[0].pricePerSeatPerMonth}–${TEAM_PLANS[1].pricePerSeatPerMonth}/seat/mo`,
+    cost: `min ${TEAM_PLANS[0].minSeats} seats`,
+    fit: [
+      'You have 5+ people who need Claude',
+      'You want SSO, central billing, admin controls',
+      'Engineers running Claude Code on production work',
+      'Shared workflows beat five personal Pro accounts'
+    ],
+    verdict: `Standard seats start at $${TEAM_PLANS[0].pricePerSeatPerMonth}/mo; Premium seats at $${TEAM_PLANS[1].pricePerSeatPerMonth}/mo carry the heavier Claude Code usage. Note: Claude Code ships with Premium seats — confirm seat type before assuming terminal access.`
+  }
+]
+
+const article = generateArticleSchema({
+  title: 'Claude Code Pricing (2026): Plans, API Costs, Free Tier & Discounts',
+  description: `What Claude Code actually costs in 2026. Pro at $${pro.pricePerMonth}, Max at $${max5x.pricePerMonth}/$${max20x.pricePerMonth}, pay-as-you-go API token rates, the truth about the free tier and discounts, and which plan fits your real usage.`,
+  slug: 'claude-code-pricing',
+  datePublished: '2026-06-16'
+})
+
+export default function ClaudeCodePricing() {
+  const faqSchema = generateFAQSchema(faqs)
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Pricing (2026): Plans, API Costs, Free Tier &amp; Discounts | PromptWritingStudio</title>
+        <meta name="description" content={`Claude Code pricing in 2026: Pro at $${pro.pricePerMonth}, Max at $${max5x.pricePerMonth} and $${max20x.pricePerMonth}, API token costs, the real free-tier and discount situation, and which plan fits your usage. Prices verified ${PLANS_META.lastVerified}.`} />
+        <meta name="keywords" content="claude code pricing, claude code cost, claude code free, claude code discount, claude code api pricing, claude code plans, how much does claude code cost" />
+        <meta property="og:title" content="Claude Code Pricing (2026): Plans, API Costs, Free Tier & Discounts" />
+        <meta property="og:description" content={`What Claude Code actually costs: Pro $${pro.pricePerMonth}, Max $${max5x.pricePerMonth}/$${max20x.pricePerMonth}, API per-token rates, free-tier truth, and the plan that fits your usage.`} />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-code-pricing" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-pricing" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      </Head>
+
+      <Layout>
+        {/* Hero */}
+        <section className="gradient-bg py-16">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-4xl">
+            <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">Claude · Pricing</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
+              Claude Code Pricing: What It Actually Costs in 2026
+            </h1>
+            <p className="text-xl text-gray-200 max-w-3xl mx-auto">
+              Plans, API token costs, the truth about the free tier and discounts, and which option is cheapest for your real usage — with numbers verified against Anthropic, not guessed.
+            </p>
+            <LastVerified date={PLANS_META.lastVerified} source={PLANS_META.source} className="mt-4 text-gray-300" />
+          </div>
+        </section>
+
+        {/* Direct answer block - AEO */}
+        <section className="py-10 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
+              <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                Claude Code is <strong>free to install</strong> but needs a paid plan to run. The cheapest real option is <strong>Claude Pro at ${pro.pricePerMonth}/mo</strong> (${pro.pricePerMonthAnnual}/mo annual). Daily users move to <strong>Max 5x at ${max5x.pricePerMonth}/mo</strong>; agentic operators to <strong>Max 20x at ${max20x.pricePerMonth}/mo</strong>. The <strong>pay-as-you-go API</strong> ({sonnet.name}: ${sonnet.inputPricePerMTok}/${sonnet.outputPricePerMTok} per million tokens) only wins for apps you ship, not your own use. There is <strong>no free tier</strong> for Claude Code and <strong>no public coupon</strong> — the only built-in discount is annual Pro billing.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Plan table from data */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-3 text-center">Claude Code plans and prices at a glance</h2>
+            <p className="text-[#333333] mb-8 text-center max-w-2xl mx-auto">Every plan that includes or powers Claude Code, with the price you actually pay. Subscriptions are flat monthly fees; the API is per token.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full bg-white rounded-lg border border-gray-200 text-sm">
+                <thead className="bg-[#1A1A1A] text-white">
+                  <tr>
+                    <th className="p-3 text-left">Plan</th>
+                    <th className="p-3 text-left">Price</th>
+                    <th className="p-3 text-left">Usage vs Free</th>
+                    <th className="p-3 text-left">Includes Claude Code</th>
+                    <th className="p-3 text-left">Best for</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {CONSUMER_PLANS.map(p => (
+                    <tr key={p.id}>
+                      <td className="p-3 font-semibold text-[#1A1A1A]">{p.name}</td>
+                      <td className="p-3 text-[#333333]">
+                        {p.pricePerMonth === 0 ? 'Free' : `$${p.pricePerMonth}/mo`}
+                        {p.pricePerMonthAnnual !== p.pricePerMonth && p.pricePerMonthAnnual > 0 && (
+                          <span className="block text-xs text-gray-500">${p.pricePerMonthAnnual}/mo annual</span>
+                        )}
+                      </td>
+                      <td className="p-3 text-[#333333]">{p.usageLimit}</td>
+                      <td className="p-3 text-[#333333]">{p.includesClaudeCode ? 'Yes' : 'No'}</td>
+                      <td className="p-3 text-[#333333]">{p.bestFor}</td>
+                    </tr>
+                  ))}
+                  {TEAM_PLANS.map(p => (
+                    <tr key={p.id} className="bg-gray-50">
+                      <td className="p-3 font-semibold text-[#1A1A1A]">{p.name}</td>
+                      <td className="p-3 text-[#333333]">
+                        ${p.pricePerSeatPerMonth}/seat/mo
+                        {p.pricePerSeatPerMonthAnnual && p.pricePerSeatPerMonthAnnual < p.pricePerSeatPerMonth && (
+                          <span className="block text-xs text-gray-500">${p.pricePerSeatPerMonthAnnual} annual</span>
+                        )}
+                      </td>
+                      <td className="p-3 text-[#333333]">{p.usageLimit}</td>
+                      <td className="p-3 text-[#333333]">Yes</td>
+                      <td className="p-3 text-[#333333]">{p.bestFor}</td>
+                    </tr>
+                  ))}
+                  <tr className="bg-yellow-50">
+                    <td className="p-3 font-semibold text-[#1A1A1A]">{API_PLAN.name}</td>
+                    <td className="p-3 text-[#333333]">Per-token</td>
+                    <td className="p-3 text-[#333333]">Unmetered (pay per call)</td>
+                    <td className="p-3 text-[#333333]">Via API only</td>
+                    <td className="p-3 text-[#333333]">Apps and automations you ship</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-gray-500 mt-3 text-center">Subscription prices verified against {PLANS_META.source.replace('https://', '')} on {PLANS_META.lastVerified}.</p>
+          </div>
+        </section>
+
+        {/* API token pricing from data */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-3">Claude Code API pricing (per token)</h2>
+            <p className="text-[#333333] mb-8">
+              If you run Claude Code on API billing instead of a subscription, you pay for every token — input (what Claude reads) and output (what it writes). These are the current model rates Claude Code can use.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full bg-white rounded-lg border border-gray-200 text-sm">
+                <thead className="bg-[#1A1A1A] text-white">
+                  <tr>
+                    <th className="p-3 text-left">Model</th>
+                    <th className="p-3 text-left">Input / million tokens</th>
+                    <th className="p-3 text-left">Output / million tokens</th>
+                    <th className="p-3 text-left">Context</th>
+                    <th className="p-3 text-left">Role in Claude Code</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {CURRENT_MODELS.map(m => (
+                    <tr key={m.id}>
+                      <td className="p-3 font-semibold text-[#1A1A1A]">{m.name}</td>
+                      <td className="p-3 text-[#333333]">${m.inputPricePerMTok}</td>
+                      <td className="p-3 text-[#333333]">${m.outputPricePerMTok}</td>
+                      <td className="p-3 text-[#333333]">{(m.contextTokens / 1000).toLocaleString()}K</td>
+                      <td className="p-3 text-[#333333]">{m.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-gray-500 mt-3">Model rates verified against {MODELS_META.source.replace('https://', '')} on {MODELS_META.lastVerified}.</p>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <h3 className="font-bold text-[#1A1A1A] mb-2">Worked example: what a single task costs</h3>
+              <p className="text-[#333333] mb-3">
+                Say Claude Code reads 50,000 tokens of your codebase and writes 8,000 tokens of edits and explanation using {sonnet.name}:
+              </p>
+              <ul className="space-y-1 text-[#333333] text-sm">
+                <li>Input: 50,000 tokens &times; ${sonnet.inputPricePerMTok}/M = <strong>${((50000 / 1000000) * sonnet.inputPricePerMTok).toFixed(3)}</strong></li>
+                <li>Output: 8,000 tokens &times; ${sonnet.outputPricePerMTok}/M = <strong>${((8000 / 1000000) * sonnet.outputPricePerMTok).toFixed(3)}</strong></li>
+                <li>Total for that one task: <strong>${(((50000 / 1000000) * sonnet.inputPricePerMTok) + ((8000 / 1000000) * sonnet.outputPricePerMTok)).toFixed(3)}</strong></li>
+              </ul>
+              <p className="text-[#333333] text-sm mt-3">
+                Cheap per task — but a real session runs dozens of those, re-reading context each turn, and Opus (${opus.inputPricePerMTok}/${opus.outputPricePerMTok} per million) costs more. That is why a few hours of agentic work can pass the ${pro.pricePerMonth} Pro covers. Run the exact numbers on your mix with the <Link href="/calculators/claude-prompt-cost" className="text-[#1A1A1A] underline font-semibold hover:no-underline">Claude API cost calculator</Link>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Is it free / free tier */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">Is Claude Code free? The honest answer</h2>
+            <p className="text-[#333333] mb-4">
+              The Claude Code CLI is free to download and install. The AI behind it is not. There is no free tier that powers Claude Code — the <strong>Claude Free plan does not include it</strong>. The free plan covers web and mobile chat with daily message caps, but not the terminal tool.
+            </p>
+            <p className="text-[#333333] mb-4">
+              That leaves three ways to actually run it:
+            </p>
+            <ul className="space-y-3 mb-6">
+              <li className="flex items-start gap-2 text-[#333333]">
+                <span className="text-[#FFDE59] font-bold mt-0.5">1.</span>
+                <span><strong>A subscription</strong> — Pro (${pro.pricePerMonth}/mo) and both Max tiers include Claude Code. This is the cheapest route for most people.</span>
+              </li>
+              <li className="flex items-start gap-2 text-[#333333]">
+                <span className="text-[#FFDE59] font-bold mt-0.5">2.</span>
+                <span><strong>API billing</strong> — pay per token with no monthly commitment. Flexible, but it adds up fast for hands-on use.</span>
+              </li>
+              <li className="flex items-start gap-2 text-[#333333]">
+                <span className="text-[#FFDE59] font-bold mt-0.5">3.</span>
+                <span><strong>Claude for Open Source</strong> — Anthropic's program that can grant qualifying open-source maintainers free access. The one genuinely free path, and only for eligible projects.</span>
+              </li>
+            </ul>
+            <p className="text-[#333333]">
+              If you just want to try it, treat one month of Pro as your "trial." It is cheaper than equivalent API spend for almost any first month, and you can cancel or upgrade instantly.
+            </p>
+          </div>
+        </section>
+
+        {/* Discounts / coupons */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">Claude Code discounts and coupons</h2>
+            <p className="text-[#333333] mb-4">
+              Anthropic does not run public coupon codes for Claude Code. If a site is advertising a "Claude Code coupon," treat it as a red flag — there is no legitimate code. What does exist:
+            </p>
+            <div className="space-y-4">
+              <div className="bg-white p-5 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Annual billing on Pro</h3>
+                <p className="text-[#333333]">The only built-in discount. Paying annually drops Pro from ${pro.pricePerMonth}/mo to ${pro.pricePerMonthAnnual}/mo — about {Math.round((1 - pro.pricePerMonthAnnual / pro.pricePerMonth) * 100)}% off. Max 5x and Max 20x are monthly-only, with no annual discount.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Claude for Open Source</h3>
+                <p className="text-[#333333]">Free access for qualifying open-source maintainers. Effectively a 100% discount if your project is eligible — apply through Anthropic's program pages.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Student, startup, and team programs</h3>
+                <p className="text-[#333333]">Anthropic periodically runs education and startup programs and annual Team pricing (${TEAM_PLANS[0].pricePerSeatPerMonthAnnual}/seat vs ${TEAM_PLANS[0].pricePerSeatPerMonth} monthly on Standard). These change — check Anthropic's current offers rather than relying on a third-party list.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Which plan fits which profile */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2">Which Claude Code plan fits your usage?</h2>
+            <p className="text-[#333333] mb-8">The right plan is the cheapest one that covers your actual usage. Find the profile that matches how you work, not how you hope to work.</p>
+            <div className="space-y-6">
+              {profiles.map(p => (
+                <div key={p.id} className="bg-[#F9F9F9] rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="bg-[#1A1A1A] text-white px-6 py-4 flex flex-wrap items-baseline gap-3">
+                    <span className="text-xs uppercase tracking-wide text-gray-400">{p.label}</span>
+                    <h3 className="text-xl font-bold">{p.plan}</h3>
+                    <span className="text-[#FFDE59] font-semibold">{p.price}</span>
+                    <span className="text-sm text-gray-400 ml-auto">{p.cost}</span>
+                  </div>
+                  <div className="p-6">
+                    <p className="text-sm font-semibold text-[#1A1A1A] mb-3">This fits you if:</p>
+                    <ul className="space-y-2 mb-5">
+                      {p.fit.map((f, i) => (
+                        <li key={i} className="flex items-start gap-2 text-[#333333]">
+                          <span className="text-[#FFDE59] font-bold mt-0.5">✓</span>
+                          <span>{f}</span>
+                        </li>
+                      ))}
+                    </ul>
+                    <div className="bg-[#FFDE59]/10 border-l-4 border-[#FFDE59] p-4 rounded-r">
+                      <p className="text-sm text-[#1A1A1A]"><strong>Verdict:</strong> {p.verdict}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 text-center">
+              <Link href="/calculators/claude-plan-picker" className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">
+                Run the plan picker on your usage →
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Usage limits / June change accuracy */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">Usage limits and the June 2026 billing change</h2>
+            <p className="text-[#333333] mb-4">
+              Price is only half the story — usage caps decide whether a plan actually covers you. Subscription Claude Code runs on a <strong>rolling five-hour session limit</strong> plus <strong>weekly limits</strong> shared between Claude Code and Claude chat. Two recent changes matter:
+            </p>
+            <div className="space-y-4 mb-6">
+              <div className="bg-white p-5 rounded-lg border-l-4 border-green-400">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">May 6, 2026 — five-hour limits doubled</h3>
+                <p className="text-[#333333]">Anthropic doubled Claude Code's five-hour rate limits for Pro, Max, Team, and seat-based Enterprise, and removed the peak-hours reduction. More usable headroom on the same prices.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border-l-4 border-green-400">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">May 13, 2026 — weekly limits up 50% (through July 13)</h3>
+                <p className="text-[#333333]">A promotion lifting weekly limits by 50%, running through July 13, 2026. Worth factoring in if you are deciding between Pro and Max right now.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border-l-4 border-red-400">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">June 15, 2026 — the autonomous-usage split that did NOT happen</h3>
+                <p className="text-[#333333]">Anthropic had planned to move autonomous usage (Agent SDK, headless <code className="bg-gray-100 px-1 rounded text-sm">claude -p</code> runs, GitHub Actions, third-party apps) onto a separate monthly credit. On June 15 it confirmed the change is <strong>no longer happening</strong> — autonomous and interactive usage still share the same subscription limits. Many pricing articles still describe the split as live. It is not.</p>
+              </div>
+            </div>
+            <p className="text-sm text-[#666666]">
+              Limits are token-weighted, so Anthropic publishes relative figures ("5x Pro", "20x Pro") rather than hard message caps. The practical rule stands: if you hit limits daily on Pro, upgrade to Max 5x.
+            </p>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6 text-center">Claude Code pricing FAQ</h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-4 cursor-pointer hover:bg-gray-50 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-4 pb-4"><p className="text-gray-600 leading-relaxed">{faq.answer}</p></div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Monetisation CTA + internal links */}
+        <section className="py-16 bg-[#1A1A1A] text-center">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-white mb-4">Make every Claude Code dollar work harder</h2>
+            <p className="text-gray-300 mb-6">
+              The fastest way to cut your Claude Code bill is not a cheaper plan — it is better prompts that get the result in one pass instead of five. Our prompt-writing course teaches the exact patterns that make agentic tools land the task first time, so you burn less of your session limit on retries.
+            </p>
+            <a href={COURSE_URL} className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition mb-8">
+              Join Now
+            </a>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-4 justify-center">
+              <Link href="/calculators/claude-plan-picker" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Claude plan picker</Link>
+              <Link href="/claude-pro-vs-max-vs-api" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Pro vs Max vs API</Link>
+              <Link href="/anthropic-api-pricing" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Anthropic API pricing</Link>
+              <Link href="/claude-code-guide" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Claude Code guide</Link>
+              <Link href="/calculators/claude-code-vs-cursor-cost" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Claude Code vs Cursor cost</Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-review.js
+++ b/pages/claude-code-review.js
@@ -1,0 +1,357 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema, generateRatingSchema } from '../lib/schemaGenerator'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+const RATING = { value: 4.5, count: 1 }
+
+const faqs = [
+  {
+    question: "Is Claude Code worth it in 2026?",
+    answer: "For developers who already have a working coding workflow and want to move faster on multi-file changes, git operations, and automation, yes — it is worth it. After building and maintaining a full Next.js site with it, my honest verdict is 4.5 out of 5. It is the strongest terminal-first agentic coding tool available right now, but it is not a beginner's tool and it is not free. You pay either through a Claude Pro or Max subscription or per-token API billing. If you are brand new to AI-assisted coding, a visual IDE like Cursor is a gentler start."
+  },
+  {
+    question: "What is Claude Code, in plain terms?",
+    answer: "Claude Code is Anthropic's terminal-based AI coding agent. You run it in your shell inside a project folder. It reads your whole codebase, edits files, runs commands, manages git, and can run long agentic loops with sub-agents and hooks. It is a command-line tool, not an editor — it works alongside whatever editor you already use rather than replacing it."
+  },
+  {
+    question: "What are the biggest downsides of Claude Code?",
+    answer: "Three real ones. First, usage limits: on a Pro subscription you can hit a five-hour session cap during heavy work, which interrupts flow. Second, cost unpredictability on the API — a heavy refactoring day leaning on Opus can run far more than a flat subscription. Third, it struggles with loosely documented, technically-indebted codebases, where you end up correcting its direction more often. None of these are dealbreakers, but pretending they do not exist would be dishonest."
+  },
+  {
+    question: "Who should not use Claude Code?",
+    answer: "Complete beginners who have never used a terminal, people who want inline tab-complete as they type, and anyone who needs image generation or heavy multimodal features. Claude Code does one thing — agentic, whole-codebase coding from the command line — and does it very well. If that is not the shape of your work, a different tool fits better."
+  },
+  {
+    question: "Does Claude Code work with my editor?",
+    answer: "Yes. Because it lives in the terminal and operates on files on disk, it works with VS Code, Cursor, Vim, JetBrains, or anything else. Many developers keep their editor open for visual review while Claude Code handles the heavy multi-file work in a terminal tab. They do not conflict."
+  },
+  {
+    question: "How much does Claude Code cost?",
+    answer: "The CLI is free to install via npm, but the model behind it is not. You need a Claude Pro or Max subscription, or pay-as-you-go API credits. There is no free tier that powers Claude Code. For a full breakdown of every plan, API token rates, and which one fits your usage, see the Claude Code pricing page linked in this review."
+  },
+  {
+    question: "Is Claude Code better than Cursor or Copilot?",
+    answer: "Not strictly better — different. Claude Code wins on multi-file refactors, git workflows, automation via hooks, and autonomous sub-agents. Cursor and Copilot win on inline suggestions and in-editor flow. The honest answer for most working developers is to use Claude Code for the heavy agentic work and keep an AI-enabled editor for interactive coding. They complement each other."
+  }
+]
+
+const verdict = {
+  score: '4.5 / 5',
+  oneLiner: 'The strongest terminal-first AI coding agent in 2026 — for developers who already know their way around a codebase, not for beginners.',
+  bestFor: 'Working developers who do multi-file refactors, git-heavy workflows, and want automation and agentic loops.',
+  notFor: 'Total beginners, people who want inline tab-complete, and anyone needing image or heavy multimodal features.'
+}
+
+const pros = [
+  {
+    title: 'It reads the whole codebase, not just the open file',
+    detail: 'This is the single biggest difference from autocomplete-style tools. Ask it to rename a concept across a project and it finds every reference, understands the architecture, and edits consistently with your existing conventions — without you pasting files in.'
+  },
+  {
+    title: 'Git and shell are first-class, not bolted on',
+    detail: 'It branches, commits, runs your test suite, and opens pull requests through the gh CLI. A full "branch, edit, test, commit, push, open PR" loop runs without you leaving the terminal. This is where it earns its keep for me.'
+  },
+  {
+    title: 'Real automation through hooks and slash commands',
+    detail: 'Hooks run code on events — format-on-save, block-a-dangerous-command, lint-before-commit. Slash commands turn repeated workflows into one word. This is the layer that turns it from "nice AI CLI" into a daily driver.'
+  },
+  {
+    title: 'Sub-agents and background tasks',
+    detail: 'You can hand a scoped job — QA across many pages, a research spike, a code review — to a sub-agent that works in parallel while you keep going. For larger jobs you run them in the background. No other coding tool does this as cleanly.'
+  },
+  {
+    title: 'Plan mode before it touches anything',
+    detail: 'For a change that spans several files, plan mode explores and proposes a plan you approve before any edit lands. It catches misunderstandings before they become a mess of bad diffs. I use it on anything touching five or more files.'
+  },
+  {
+    title: 'It snapshots state so you can rewind',
+    detail: 'It snapshots before changes, and you can rewind when something breaks. That safety net makes it far less stressful to let it work on real code than it sounds.'
+  }
+]
+
+const cons = [
+  {
+    title: 'Usage limits interrupt heavy days',
+    detail: 'On a Pro subscription there is a rolling five-hour session limit plus weekly caps shared with Claude chat. During an intense build day you can hit "usage limit reached" and lose momentum. Anthropic raised these limits in 2026, but if you run it for hours daily, Pro will frustrate you and you will need a Max plan.'
+  },
+  {
+    title: 'API cost is unpredictable',
+    detail: 'On pay-as-you-go, a light day building this site landed around a few dollars; a heavy Opus-led refactoring day ran into the tens of dollars. That is fine occasionally, but it adds up fast and is hard to forecast. For sustained daily use a flat subscription is both cheaper and calmer.'
+  },
+  {
+    title: 'It struggles with messy, undocumented code',
+    detail: 'On a clean codebase with a good context file it is excellent. On a sprawling, technically-indebted project with little documentation, it makes more wrong assumptions and you correct its direction more often. It amplifies the quality of the codebase it is dropped into.'
+  },
+  {
+    title: 'No inline completions',
+    detail: 'If you love tab-complete as you type, Claude Code will feel wrong — that is not what it does. This is a deliberate design choice, not a bug, but it surprises people coming from Copilot or Cursor.'
+  },
+  {
+    title: 'Support is email-only',
+    detail: 'For a tool in the $17 to $200 per month range, the email-only support and merely-okay response times are a fair criticism. Most issues you solve through docs and community, but do not expect fast hand-holding.'
+  }
+]
+
+const realUse = [
+  {
+    label: 'What I built with it',
+    text: 'This site — a Next.js 13 programmatic-SEO project with dozens of pages, data-driven routes, and a course funnel — is maintained day to day with Claude Code. Adding pages, refactoring components, running QA across many pages in parallel, and handling git all run through it.'
+  },
+  {
+    label: 'Where it saved the most time',
+    text: 'Multi-file refactors and parallel QA. Handing a tight, well-scoped job to a sub-agent — "check these 20 pages for broken links and report" — and getting a clean answer while I worked on something else is the workflow I would not give up.'
+  },
+  {
+    label: 'Where it cost me time',
+    text: 'Vague instructions. Under-scoped sub-agents that were told to "look at the codebase" burned tokens and produced muddled output. The fix was always on me: be specific, give it a context file, scope the task tightly.'
+  },
+  {
+    label: 'The one setting that changed everything',
+    text: 'A project context file (CLAUDE.md). The difference between Claude Code with 40 lines of project context and Claude Code with none is the difference between a sharp collaborator and a confused intern. Almost every disappointing experience I have seen traces back to skipping it.'
+  }
+]
+
+const scorecard = [
+  { area: 'Code quality on a clean codebase', score: '5 / 5', note: 'Consistent with existing conventions, strong reasoning on Opus.' },
+  { area: 'Multi-file refactors', score: '5 / 5', note: 'Reads the whole project first; this is its core strength.' },
+  { area: 'Git and automation', score: '5 / 5', note: 'Deep git, hooks, slash commands, gh CLI.' },
+  { area: 'Agentic / sub-agent work', score: '5 / 5', note: 'Best-in-class parallel and background tasks.' },
+  { area: 'Beginner friendliness', score: '2 / 5', note: 'Terminal-first, no hand-holding, no inline complete.' },
+  { area: 'Cost predictability', score: '3 / 5', note: 'Subscriptions fine; API spend hard to forecast.' },
+  { area: 'Handling messy codebases', score: '3 / 5', note: 'Amplifies whatever quality it is dropped into.' },
+  { area: 'Support', score: '3 / 5', note: 'Email-only; docs and community carry the load.' }
+]
+
+export default function ClaudeCodeReview() {
+  const faqSchema = generateFAQSchema(faqs)
+  const ratingSchema = generateRatingSchema('Claude Code', RATING)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Code Review (2026): An Honest, First-Hand Verdict',
+    description: 'A hands-on Claude Code review from a developer who built and maintains a full site with it. Pros, cons, a scorecard, who it is for, and a clear verdict — no comparison table.',
+    url: 'https://promptwritingstudio.com/claude-code-review',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['Claude Code review', 'Claude Code reviews', 'is Claude Code worth it', 'Claude Code pros and cons', 'Claude Code verdict 2026']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Review (2026): An Honest, First-Hand Verdict | PromptWritingStudio</title>
+        <meta name="description" content="A hands-on Claude Code review from a developer who maintains a full site with it. Honest pros and cons, a scorecard, who it is for, and a clear 4.5/5 verdict." />
+        <meta name="keywords" content="Claude Code review, Claude Code reviews, is Claude Code worth it, Claude Code pros and cons, Claude Code verdict, Claude Code honest review" />
+        <meta property="og:title" content="Claude Code Review (2026): An Honest, First-Hand Verdict" />
+        <meta property="og:description" content="Pros, cons, a scorecard, and a clear verdict from a developer who built a full site with Claude Code." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-code-review" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-review" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(ratingSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Code Review
+              <span className="block text-[#FFDE59]">An honest, first-hand verdict</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                <strong>Verdict: 4.5 / 5.</strong> Claude Code is the strongest terminal-first AI coding agent available in 2026. It reads your whole codebase, handles git and automation natively, and runs parallel sub-agents no other tool matches. It is not for beginners, it is not free, and its usage limits and API cost can bite. This review is based on building and maintaining a full Next.js site with it — not on aggregating star ratings.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              No comparison table, no affiliate fluff. Just what it is genuinely good at, where it falls down, and exactly who should buy it.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#scorecard" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Jump to the scorecard
+              </a>
+              <a href="#verdict" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Who it is for
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">What is Claude Code?</h2>
+            <p className="text-lg text-[#333333] mb-5">
+              Claude Code is Anthropic's terminal-based AI coding agent. You run it in your shell, inside a project folder, and it works on the files there. It reads the whole codebase, edits files, runs shell commands, manages git, and can run long agentic loops with sub-agents and hooks.
+            </p>
+            <p className="text-lg text-[#333333] mb-5">
+              The thing to understand before you judge it: <strong>it is a command-line tool, not an editor.</strong> It does not replace VS Code or Cursor — it works alongside whatever editor you already use. If you came expecting inline tab-complete, you will be confused. That is not what it does.
+            </p>
+            <p className="text-lg text-[#333333]">
+              As of mid-2026 it runs on Anthropic's latest models — Opus 4.8 as the default in the 2.1.x releases, with Sonnet 4.6 available — and ships features like plan mode, auto mode, automatic state snapshots, and a context-management system. New to it? The <Link href="/claude-code-guide" className="text-[#1A1A1A] underline font-semibold hover:no-underline">Claude Code guide</Link> covers install, auth, and daily workflow end to end.
+            </p>
+          </div>
+        </section>
+
+        <section id="scorecard" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The scorecard at a glance</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              How I rate Claude Code across the dimensions that actually matter to a working developer. These scores reflect daily use, not a one-afternoon trial.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Area</th>
+                    <th className="p-4 text-left font-semibold">Score</th>
+                    <th className="p-4 text-left font-semibold">Why</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {scorecard.map((row, index) => (
+                    <tr key={index} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                      <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A] text-sm">{row.area}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#1A1A1A] text-sm font-bold whitespace-nowrap">{row.score}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{row.note}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-center text-[#666666] mt-6">Overall: <strong className="text-[#1A1A1A]">4.5 / 5</strong> — exceptional at its core job, with honest weak spots around onboarding and cost.</p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-8">What Claude Code is genuinely good at</h2>
+            <div className="space-y-5">
+              {pros.map((p, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 rounded-lg border-l-4 border-[#FFDE59]">
+                  <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">{p.title}</h3>
+                  <p className="text-[#333333]">{p.detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-8">Where Claude Code falls down</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Every honest review needs a real cons section. These are the things that genuinely annoyed me, not token complaints invented for balance.
+            </p>
+            <div className="space-y-5">
+              {cons.map((c, i) => (
+                <div key={i} className="bg-white p-6 rounded-lg border-l-4 border-red-300">
+                  <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">{c.title}</h3>
+                  <p className="text-[#333333]">{c.detail}</p>
+                </div>
+              ))}
+            </div>
+            <p className="text-[#333333] mt-8">
+              On cost specifically: the picture is nuanced enough that it deserves its own page. The full plan breakdown, API token rates, and break-even maths are in the <Link href="/claude-code-pricing" className="text-[#1A1A1A] underline font-semibold hover:no-underline">Claude Code pricing guide</Link>.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-8">What it was like to actually use it</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Most "Claude Code reviews" aggregate star ratings or list features off a docs page. This section is the part you cannot fake: what daily use felt like.
+            </p>
+            <div className="space-y-6">
+              {realUse.map((r, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 md:p-8 rounded-lg border border-gray-200">
+                  <p className="text-sm font-bold text-[#FFB800] uppercase tracking-wide mb-2">{r.label}</p>
+                  <p className="text-lg text-[#333333]">{r.text}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="verdict" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Who Claude Code is for — and who should skip it</h2>
+            <div className="grid md:grid-cols-2 gap-6 mb-10">
+              <div className="bg-white p-8 rounded-lg border-2 border-[#FFDE59]">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">Buy it if...</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You already have a working coding workflow and want to move faster</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You do a lot of multi-file refactors, git work, or deployment</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You want automation: hooks, slash commands, sub-agents, background tasks</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You live in the terminal and want AI there, not in a separate IDE</span></li>
+                </ul>
+              </div>
+              <div className="bg-white p-8 rounded-lg border-2 border-gray-200">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">Skip it if...</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start"><span className="text-red-400 mr-2 mt-1 flex-shrink-0">&times;</span><span className="text-[#333333]">You are a complete beginner who has never used a terminal</span></li>
+                  <li className="flex items-start"><span className="text-red-400 mr-2 mt-1 flex-shrink-0">&times;</span><span className="text-[#333333]">You want inline tab-complete as you type</span></li>
+                  <li className="flex items-start"><span className="text-red-400 mr-2 mt-1 flex-shrink-0">&times;</span><span className="text-[#333333]">You need image generation or heavy multimodal features</span></li>
+                  <li className="flex items-start"><span className="text-red-400 mr-2 mt-1 flex-shrink-0">&times;</span><span className="text-[#333333]">A predictable flat monthly bill matters more than raw capability</span></li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="bg-[#1A1A1A] p-8 rounded-lg text-center">
+              <p className="text-[#FFDE59] font-bold text-2xl mb-3">Final verdict: {verdict.score}</p>
+              <p className="text-gray-200 text-lg max-w-2xl mx-auto">{verdict.oneLiner}</p>
+            </div>
+
+            <p className="text-[#333333] mt-8 text-center">
+              Weighing it against other agentic coding tools? See <Link href="/claude-code-vs-cursor" className="text-[#1A1A1A] underline font-semibold hover:no-underline">Claude Code vs Cursor</Link> for the head-to-head, or <Link href="/claude-code-alternatives" className="text-[#1A1A1A] underline font-semibold hover:no-underline">Claude Code alternatives</Link> for the wider field.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently asked questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions people ask before they decide whether Claude Code is worth it.</p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              The tool is only as good as the instructions you give it
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              The single biggest lever in this review was clear, well-scoped prompting — vague instructions wasted time, sharp ones did a day's work in an hour. That skill transfers to every AI tool you touch. Prompt Writing Studio teaches it in depth.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href={COURSE_URL} className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+              <Link href="/claude-code-guide" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Read the Claude Code Guide
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-slash-commands.js
+++ b/pages/claude-code-slash-commands.js
@@ -1,0 +1,562 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+const faqs = [
+  {
+    question: "What are slash commands in Claude Code?",
+    answer: "Slash commands are shortcuts you type at the start of a message, beginning with a forward slash, to control Claude Code or trigger a saved workflow. Type / in the prompt to see every command available to you. There are two kinds: built-in commands like /clear, /compact, and /init that are coded into the CLI, and custom commands you create yourself as reusable prompt templates. A command is only recognized at the start of your message; any text after the command name is passed to it as an argument."
+  },
+  {
+    question: "How do I create a custom slash command in Claude Code?",
+    answer: "Create a markdown file in a .claude/commands/ folder (for example .claude/commands/review.md) and the file becomes the command /review. The file's contents are the prompt Claude runs when you invoke it. As of the 2026 docs, custom commands have been merged into skills, so the recommended modern path is .claude/skills/review/SKILL.md instead, which produces the same /review command but adds support for a directory of supporting files and richer frontmatter. Both forms still work and you do not have to migrate existing command files."
+  },
+  {
+    question: "Where do project commands versus personal commands live?",
+    answer: "Project commands live in .claude/commands/ or .claude/skills/ inside the repository, so they are committed to version control and shared with everyone on the team. Personal commands live in ~/.claude/commands/ or ~/.claude/skills/ in your home directory, so they follow you across every project on your machine. When a skill and a command share the same name, the skill takes precedence. When the same name exists at multiple scopes, personal overrides project."
+  },
+  {
+    question: "How do I pass arguments to a custom slash command?",
+    answer: "Put the placeholder $ARGUMENTS in your command file and it gets replaced with whatever you type after the command name. For example, if /fix-issue contains 'Fix GitHub issue $ARGUMENTS', then running /fix-issue 123 sends 'Fix GitHub issue 123' to Claude. For individual positional arguments use $1, $2 (or $ARGUMENTS[0], $ARGUMENTS[1]), and wrap multi-word values in quotes. You can also declare named arguments in the frontmatter using the arguments field."
+  },
+  {
+    question: "What is the difference between a slash command and a skill?",
+    answer: "They overlap. A custom slash command is a markdown file you invoke by typing /name. A skill is a SKILL.md file in its own directory that you can also invoke with /name, but Claude can additionally load it automatically when your request matches its description. In the current Claude Code, custom commands have been folded into skills: a file at .claude/commands/deploy.md and a skill at .claude/skills/deploy/SKILL.md both create /deploy and behave the same way when you type the command. Skills add optional features like supporting files, invocation control, and subagent execution."
+  },
+  {
+    question: "Can Claude run a slash command automatically without me typing it?",
+    answer: "Yes, for skills with a clear description. When a skill's description matches what you are asking for, Claude can load and run it on its own. If you want a command to be manual-only, for example a deploy or commit workflow where timing matters, add disable-model-invocation: true to the frontmatter so only you can trigger it by typing /name."
+  },
+  {
+    question: "How do I run a shell command inside a custom slash command?",
+    answer: "Use the inline syntax with an exclamation mark and backticks, such as !`git diff HEAD`, on its own line in the command file. Claude Code runs that shell command before the prompt is sent and replaces the placeholder with the command's output, so the prompt arrives with live data already inlined. This is preprocessing, not something Claude decides to do. It is how you ground a command in your actual working tree, like injecting the current diff into a commit-message command."
+  },
+  {
+    question: "What built-in slash commands should I learn first?",
+    answer: "Start with /clear to begin a fresh task while keeping project memory, /compact to shrink a long conversation that is filling the context window, /init to generate a starter CLAUDE.md, /plan to enter plan mode before a large change, /model to switch models, and /review or /security-review for a read-only pass before you ship. /context shows where your context window is going, and /agents and /mcp set up subagents and MCP servers. Type /help to see the full list available in your session."
+  }
+]
+
+const builtInCommands = [
+  { command: '/clear', purpose: 'Start a new conversation with empty context (project memory is kept). Use it when you switch to an unrelated task.' },
+  { command: '/compact', purpose: 'Summarize the conversation so far to free up context when the window is filling up. Optionally pass focus instructions.' },
+  { command: '/init', purpose: 'Generate a starter CLAUDE.md for the current repo so Claude has persistent project context.' },
+  { command: '/plan', purpose: 'Enter plan mode before a large change. Pass a description to start immediately, e.g. /plan fix the auth bug.' },
+  { command: '/model', purpose: 'Switch the active model and save it as your default. With no argument, opens a picker.' },
+  { command: '/context', purpose: 'Visualize where your context window is being spent, with optimization suggestions.' },
+  { command: '/agents', purpose: 'Open the manager for subagents Claude can delegate side tasks to.' },
+  { command: '/mcp', purpose: 'Manage Model Context Protocol server connections and OAuth.' },
+  { command: '/permissions', purpose: 'Manage allow, ask, and deny rules for tool permissions.' },
+  { command: '/review', purpose: 'Review a pull request locally in your current session.' },
+  { command: '/security-review', purpose: 'Analyze pending changes on the branch for security vulnerabilities like injection or data exposure.' },
+  { command: '/skills', purpose: 'List the skills available in this session and hide ones you do not want Claude to use.' },
+  { command: '/resume', purpose: 'Resume an earlier conversation by ID or name, or open the session picker.' },
+  { command: '/doctor', purpose: 'Diagnose and verify your Claude Code installation and settings.' },
+  { command: '/help', purpose: 'Show help and every command available to you.' }
+]
+
+const exampleCommandFiles = [
+  {
+    id: 'review-cmd',
+    label: 'Code review command — .claude/commands/review.md',
+    command: `---
+description: Review the current diff for bugs, missing tests, and style issues
+argument-hint: [optional focus area]
+allowed-tools: Bash(git diff *) Read Grep
+---
+
+## Current changes
+!\`git diff HEAD\`
+
+## Your task
+Review the changes above. Focus on $ARGUMENTS if provided.
+Flag correctness bugs first, then missing tests, then style.
+Quote the file and line for each issue. Do not edit anything.`
+  },
+  {
+    id: 'commit-cmd',
+    label: 'Commit command (manual-only) — .claude/skills/commit/SKILL.md',
+    command: `---
+description: Stage and commit the current changes with a clear message
+disable-model-invocation: true
+allowed-tools: Bash(git add *) Bash(git commit *) Bash(git status *)
+---
+
+## Current status
+!\`git status --short\`
+
+## Your task
+Stage the relevant changes and write a commit message that
+describes what changed and why. Use the format: <type>: <description>.
+Do not push.`
+  },
+  {
+    id: 'fix-issue-cmd',
+    label: 'Fix-a-GitHub-issue command with arguments — .claude/commands/fix-issue.md',
+    command: `---
+description: Fix a GitHub issue by number, following our coding standards
+argument-hint: [issue-number]
+---
+
+Fix GitHub issue $ARGUMENTS following our coding standards.
+
+1. Read the issue with: gh issue view $ARGUMENTS
+2. Find the relevant files and understand the requirements
+3. Implement the fix
+4. Add or update tests
+5. Stop before committing so I can review`
+  },
+  {
+    id: 'new-page-cmd',
+    label: 'Scaffold-a-new-page command (positional args) — .claude/commands/new-page.md',
+    command: `---
+description: Scaffold a new Next.js page from our template
+argument-hint: [slug] [title]
+---
+
+Create a new page at pages/$1.js titled "$2".
+Match the structure and Tailwind classes of pages/claude-code-guide.js:
+Head with title and meta description, a Layout wrapper,
+a hero section, and an FAQ block. Use the brand colors
+#1A1A1A, #FFDE59, and #F9F9F9.`
+  }
+]
+
+const frontmatterFields = [
+  { field: 'description', use: 'What the command does and when to use it. Claude reads this to decide when to load a skill automatically. Recommended on every command.' },
+  { field: 'argument-hint', use: 'A hint shown in autocomplete for the arguments the command expects, e.g. [issue-number] or [filename] [format].' },
+  { field: 'allowed-tools', use: 'Tools Claude may use without asking for permission while this command is active, e.g. Bash(git diff *) Read Grep.' },
+  { field: 'disable-model-invocation', use: 'Set to true so only you can trigger the command by typing /name. Use it for workflows with side effects like deploy or commit.' },
+  { field: 'arguments', use: 'Declare named positional arguments so you can use $name placeholders instead of $1 and $2 in the command body.' },
+  { field: 'model', use: 'Force a specific model while the command runs, then return to your session model on the next prompt.' }
+]
+
+export default function ClaudeCodeSlashCommands() {
+  const [copied, setCopied] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopied(id)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Code Slash Commands: Built-In and Custom Commands (2026)',
+    description: 'A practical guide to Claude Code slash commands. Covers the built-in commands, how to create custom slash commands as reusable prompt templates, arguments, frontmatter, and when to use each.',
+    url: 'https://promptwritingstudio.com/claude-code-slash-commands',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude code slash commands', 'custom slash commands claude code', 'claude code commands', 'claude code custom commands', '.claude/commands', 'claude code skills']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Slash Commands: Built-In and Custom Commands (2026) | PromptWritingStudio</title>
+        <meta name="description" content="A practical guide to Claude Code slash commands. Learn the built-in commands, how to create custom slash commands as reusable prompt templates, how arguments and frontmatter work, and when to use each." />
+        <meta name="keywords" content="claude code slash commands, custom slash commands claude code, claude code commands, claude code custom commands, .claude/commands, claude code skills" />
+        <meta property="og:title" content="Claude Code Slash Commands: Built-In and Custom Commands (2026)" />
+        <meta property="og:description" content="Built-in slash commands plus copy-paste templates for creating your own custom Claude Code commands, with arguments, frontmatter, and shell injection." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-code-slash-commands" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-slash-commands" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+        />
+      </Head>
+
+      <Layout>
+        {/* Hero */}
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Code Slash Commands
+              <span className="block text-[#FFDE59]">Built-In and Custom Commands</span>
+            </h1>
+
+            {/* AEO answer block */}
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                Claude Code slash commands are shortcuts you type at the start of a message, beginning with a forward slash, to control the tool or trigger a saved workflow. There are built-in commands like <code>/clear</code>, <code>/compact</code>, and <code>/init</code> coded into the CLI, and custom commands you create yourself as reusable prompt templates. You make a custom command by saving a markdown file in a <code>.claude/commands/</code> folder (or a <code>SKILL.md</code> in <code>.claude/skills/</code>): the file becomes the command, and its contents become the prompt Claude runs.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              The fastest win in Claude Code is turning a prompt you keep retyping into a one-word command. This guide shows the built-in commands worth knowing and gives you copy-paste templates for your own.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#custom" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Build a Custom Command
+              </a>
+              <a href="#built-in" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                See Built-In Commands
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* What they are */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              What Are Slash Commands in Claude Code?
+            </h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-6">
+                A slash command is a shortcut you type at the start of a message in Claude Code. Type <code className="bg-gray-100 px-2 py-1 rounded text-sm">/</code> on its own to see every command available in your session, or type <code className="bg-gray-100 px-2 py-1 rounded text-sm">/</code> followed by letters to filter. A command is only recognized at the start of your message; anything you type after the command name is handed to it as an argument.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                There are two kinds. <strong>Built-in commands</strong> like <code className="bg-gray-100 px-2 py-1 rounded text-sm">/clear</code> and <code className="bg-gray-100 px-2 py-1 rounded text-sm">/compact</code> have their behavior coded into the CLI. <strong>Custom commands</strong> are reusable prompt templates you write yourself, so a prompt you keep retyping becomes a single word.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                One change matters in 2026: custom commands have been merged into skills. A file at <code className="bg-gray-100 px-2 py-1 rounded text-sm">.claude/commands/deploy.md</code> and a skill at <code className="bg-gray-100 px-2 py-1 rounded text-sm">.claude/skills/deploy/SKILL.md</code> both create <code className="bg-gray-100 px-2 py-1 rounded text-sm">/deploy</code> and work the same way. Your existing command files keep working, so there is nothing to migrate. The skill form just adds extras: a folder for supporting files, richer frontmatter, and the option for Claude to run the command automatically when your request matches it.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Built-in commands */}
+        <section id="built-in" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              The Built-In Slash Commands Worth Knowing
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Claude Code ships with dozens of built-in commands. You do not need to memorize them all. These are the ones that earn their place in a daily workflow. Type <code className="bg-gray-100 px-2 py-1 rounded text-sm">/help</code> to see the full list in your session.
+            </p>
+
+            <div className="space-y-3">
+              {builtInCommands.map((c) => (
+                <div key={c.command} className="bg-white p-4 rounded-lg border border-gray-200 md:flex md:items-start">
+                  <code className="text-sm font-mono text-[#1A1A1A] font-bold bg-gray-100 px-3 py-1 rounded inline-block mb-2 md:mb-0 md:mr-4 md:w-44 flex-shrink-0">{c.command}</code>
+                  <p className="text-[#333333] flex-1">{c.purpose}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>The two you will reach for most:</strong> <code>/clear</code> when you move to an unrelated task so old context stops confusing Claude, and <code>/compact</code> when a long session is eating your context window but you still need the thread.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Custom commands — the core */}
+        <section id="custom" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              How to Create a Custom Slash Command
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              A custom command is just a markdown file. The file name becomes the command, and the file body becomes the prompt Claude runs. Here is the whole process in three steps.
+            </p>
+
+            <div className="space-y-6">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">1</span>
+                  <div className="flex-1">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Create the commands folder</h3>
+                    <p className="text-[#333333] mb-3">
+                      Use <code className="bg-gray-100 px-2 py-1 rounded text-sm">.claude/commands/</code> inside your project for team-shared commands, or <code className="bg-gray-100 px-2 py-1 rounded text-sm">~/.claude/commands/</code> in your home directory for personal commands that follow you everywhere.
+                    </p>
+                    <div className="bg-[#1A1A1A] text-green-400 p-4 rounded-lg font-mono text-sm relative">
+                      <code>mkdir -p .claude/commands</code>
+                      <button onClick={() => copyToClipboard('mkdir -p .claude/commands', 'mk')} className="absolute top-2 right-2 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded">
+                        {copied === 'mk' ? 'Copied' : 'Copy'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">2</span>
+                  <div className="flex-1">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Write a markdown file named after the command</h3>
+                    <p className="text-[#333333]">
+                      A file at <code className="bg-gray-100 px-2 py-1 rounded text-sm">.claude/commands/review.md</code> becomes the command <code className="bg-gray-100 px-2 py-1 rounded text-sm">/review</code>. Put the prompt you want Claude to run inside the file. That is the minimum: a file with a name and a prompt is a working command.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">3</span>
+                  <div className="flex-1">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Invoke it by typing the slash</h3>
+                    <p className="text-[#333333]">
+                      Type <code className="bg-gray-100 px-2 py-1 rounded text-sm">/review</code> and Claude runs the file as a prompt. New files are picked up at the start of a session, or you can run <code className="bg-gray-100 px-2 py-1 rounded text-sm">/reload-skills</code> to pick up a command you just added without restarting.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>The before/after that makes this worth it:</strong> the weak version is opening every session and pasting "review my uncommitted changes, flag bugs first, then missing tests, then style, and quote the file and line for each issue." The strong version is typing <code>/review</code>. Same prompt, zero retyping, identical every time, shared with your whole team through git.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Templates */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+                Copy-Paste Custom Command Templates
+              </h2>
+              <p className="text-xl text-[#333333] max-w-3xl mx-auto">
+                Four commands that pull their weight. Copy one, drop it in your <code>.claude/commands/</code> or <code>.claude/skills/</code> folder, and adapt the prompt to your project.
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              {exampleCommandFiles.map((ex) => (
+                <div key={ex.id} className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="flex justify-between items-center px-6 py-3 bg-gray-100 border-b border-gray-200">
+                    <span className="font-semibold text-[#1A1A1A] text-sm">{ex.label}</span>
+                    <button onClick={() => copyToClipboard(ex.command, ex.id)} className="text-sm font-medium px-3 py-1 rounded bg-[#FFDE59] text-[#1A1A1A] hover:bg-[#E5C84F] transition-colors duration-200 flex-shrink-0 ml-3">
+                      {copied === ex.id ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <div className="px-6 py-4 bg-[#1A1A1A] overflow-x-auto">
+                    <pre className="text-green-400 font-mono text-sm whitespace-pre">{ex.command}</pre>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Common failure mode:</strong> putting a destructive workflow like deploy or commit in a normal command and letting Claude run it on its own. Add <code>disable-model-invocation: true</code> to the frontmatter (as in the commit template above) so only you can trigger it by typing the command. You never want Claude deciding to deploy because the code "looks ready."
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Arguments */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              How Arguments Work
+            </h2>
+            <p className="text-lg text-[#333333] mb-6">
+              Arguments turn a static command into a flexible one. Anything you type after the command name is passed in, and you control where it lands using placeholders.
+            </p>
+
+            <div className="space-y-4 mb-8">
+              <div className="bg-[#F9F9F9] p-5 rounded-lg border border-gray-200">
+                <code className="text-sm font-mono text-[#1A1A1A] font-bold">$ARGUMENTS</code>
+                <p className="text-[#333333] mt-1">The full string of everything you typed after the command. Running <code>/fix-issue 123</code> on a file containing "Fix issue $ARGUMENTS" sends "Fix issue 123."</p>
+              </div>
+              <div className="bg-[#F9F9F9] p-5 rounded-lg border border-gray-200">
+                <code className="text-sm font-mono text-[#1A1A1A] font-bold">$1, $2 (or $ARGUMENTS[0], $ARGUMENTS[1])</code>
+                <p className="text-[#333333] mt-1">Individual positional arguments. Running <code>/migrate SearchBar React Vue</code> maps to $1 = SearchBar, $2 = React, $3 = Vue. Wrap multi-word values in quotes to keep them as one argument.</p>
+              </div>
+              <div className="bg-[#F9F9F9] p-5 rounded-lg border border-gray-200">
+                <code className="text-sm font-mono text-[#1A1A1A] font-bold">Named arguments</code>
+                <p className="text-[#333333] mt-1">Declare an <code>arguments</code> list in the frontmatter, then reference them by name like <code>$issue</code> and <code>$branch</code> instead of by position.</p>
+              </div>
+            </div>
+
+            <p className="text-lg text-[#333333]">
+              If you invoke a command with arguments but the file has no placeholder, Claude Code appends <code className="bg-gray-100 px-2 py-1 rounded text-sm">ARGUMENTS: your input</code> to the end so your text is still seen.
+            </p>
+          </div>
+        </section>
+
+        {/* Frontmatter */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              Frontmatter Fields That Control a Command
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              The YAML block at the top of a command file (between <code>---</code> markers) configures how the command behaves. All fields are optional, but <code>description</code> is the one to always include so Claude knows what the command is for.
+            </p>
+
+            <div className="space-y-3">
+              {frontmatterFields.map((f) => (
+                <div key={f.field} className="bg-white p-4 rounded-lg border border-gray-200 md:flex md:items-start">
+                  <code className="text-sm font-mono text-[#1A1A1A] font-bold bg-gray-100 px-3 py-1 rounded inline-block mb-2 md:mb-0 md:mr-4 md:w-56 flex-shrink-0">{f.field}</code>
+                  <p className="text-[#333333] flex-1">{f.use}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* When to use */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              When to Use a Slash Command (and When Not To)
+            </h2>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">Make it a command when</h3>
+                <ul className="space-y-2 text-[#333333]">
+                  <li>You keep pasting the same prompt or checklist.</li>
+                  <li>A workflow has fixed, ordered steps (review, commit, scaffold a file).</li>
+                  <li>You want your team to do the same thing the same way every time.</li>
+                  <li>The prompt should pull in live data, like the current git diff.</li>
+                </ul>
+              </div>
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">Skip the command when</h3>
+                <ul className="space-y-2 text-[#333333]">
+                  <li>It is a one-off request you will not repeat.</li>
+                  <li>The task is exploratory and changes shape every time.</li>
+                  <li>A built-in command already does it (do not rebuild <code>/compact</code>).</li>
+                  <li>It is standing project context — that belongs in CLAUDE.md, not a command.</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Rule of thumb:</strong> if you have typed roughly the same instruction three times, turn it into a command. The whole point of a custom slash command is repeatability, so the payoff scales with how often you run it.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Course CTA */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl text-center">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+              Write Commands That Actually Work
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              A slash command is only as good as the prompt inside it. Vague instructions produce vague results no matter how you trigger them. PromptWritingStudio teaches the prompt-writing fundamentals — specificity, context, and structure — that make every command, skill, and AI workflow you build pull its weight.
+            </p>
+            <a href={COURSE_URL} target="_blank" rel="noopener noreferrer" className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+              Join Now
+            </a>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">
+              Frequently Asked Questions
+            </h2>
+            <p className="text-xl text-[#333333] text-center mb-12">
+              Common questions about Claude Code slash commands
+            </p>
+
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Authority links */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-2xl font-bold text-[#1A1A1A] mb-6 text-center">
+              Official Resources
+            </h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              <a href="https://code.claude.com/docs/en/commands" target="_blank" rel="noopener noreferrer" className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-[#FFDE59] hover:bg-white transition-all duration-200 bg-white">
+                <span className="text-[#FFDE59] mr-3 text-xl">&#8599;</span>
+                <span className="font-semibold text-gray-900">Built-In Commands Reference</span>
+              </a>
+              <a href="https://code.claude.com/docs/en/skills" target="_blank" rel="noopener noreferrer" className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-[#FFDE59] hover:bg-white transition-all duration-200 bg-white">
+                <span className="text-[#FFDE59] mr-3 text-xl">&#8599;</span>
+                <span className="font-semibold text-gray-900">Skills and Custom Commands</span>
+              </a>
+              <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener noreferrer" className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-[#FFDE59] hover:bg-white transition-all duration-200 bg-white">
+                <span className="text-[#FFDE59] mr-3 text-xl">&#8599;</span>
+                <span className="font-semibold text-gray-900">Claude Code Documentation</span>
+              </a>
+              <a href="https://github.com/anthropics/claude-code" target="_blank" rel="noopener noreferrer" className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-[#FFDE59] hover:bg-white transition-all duration-200 bg-white">
+                <span className="text-[#FFDE59] mr-3 text-xl">&#8599;</span>
+                <span className="font-semibold text-gray-900">Claude Code on GitHub</span>
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* Claude Code hub */}
+        <section className="py-16 bg-white border-t border-gray-100">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+                More Claude Code Resources
+              </h2>
+              <p className="text-lg text-[#333333] max-w-2xl mx-auto">
+                Slash commands are one piece. Here is the rest of the toolkit for working with Claude Code day to day.
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Link href="/claude-code-guide" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Guide</h3>
+                <p className="text-sm text-[#666666]">The full hub — install, features, workflows, pricing, and daily-use tips.</p>
+              </Link>
+              <Link href="/claude-code-sub-agents" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Sub-Agents</h3>
+                <p className="text-sm text-[#666666]">The isolated agents your custom commands can hand work off to.</p>
+              </Link>
+              <Link href="/skills-vs-mcp-vs-hooks" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Skills vs MCP vs Hooks</h3>
+                <p className="text-sm text-[#666666]">When a command should be a skill, an MCP server, or a hook instead.</p>
+              </Link>
+              <Link href="/claude-code-hooks-recipes" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Hooks Recipes</h3>
+                <p className="text-sm text-[#666666]">Working hooks for the rules you never want Claude to "decide" about.</p>
+              </Link>
+              <Link href="/claude-md-playbook" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">CLAUDE.md Playbook</h3>
+                <p className="text-sm text-[#666666]">Where standing project context belongs, instead of in a command.</p>
+              </Link>
+              <Link href="/claude-code-mcp-stack" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Minimum Viable MCP Stack</h3>
+                <p className="text-sm text-[#666666]">Five MCP servers worth wiring into Claude Code, with copy-paste config.</p>
+              </Link>
+              <Link href="/calculators/claude-plan-picker" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Plan Picker</h3>
+                <p className="text-sm text-[#666666]">Find the cheapest Claude plan that fits how much you actually use.</p>
+              </Link>
+            </div>
+
+            <div className="mt-10 text-center">
+              <Link href="/chatgpt-prompt-templates" className="inline-flex items-center text-[#1A1A1A] font-semibold underline hover:no-underline">
+                Browse all prompt templates →
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-sub-agents.js
+++ b/pages/claude-code-sub-agents.js
@@ -1,0 +1,469 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const faqs = [
+  {
+    question: "What is a sub-agent in Claude Code?",
+    answer: "A sub-agent is a specialized AI assistant that Claude Code spawns to handle a specific task in its own context window. It has its own system prompt, its own tool access, and independent permissions. When Claude encounters a task that matches a sub-agent's description, it delegates the work, the sub-agent runs on its own, and only the summary returns to your main conversation. This keeps verbose output (search results, logs, test runs) out of your main context."
+  },
+  {
+    question: "Where do Claude Code sub-agent files live?",
+    answer: "Project sub-agents go in .claude/agents/ in your repo root (check them into version control so your team shares them). Personal sub-agents go in ~/.claude/agents/ and are available across all your projects. Both directories are scanned recursively, so you can organize files into subfolders like agents/review/ or agents/research/. Identity comes from the name field in the frontmatter, not the filename or folder path."
+  },
+  {
+    question: "How do I create a Claude Code sub-agent?",
+    answer: "Run the /agents command inside Claude Code, choose Library then Create new agent, pick Personal or Project scope, and let Claude generate the config from a plain-English description. Or create the file by hand: a Markdown file with YAML frontmatter (name and description are required) followed by the system prompt in the body. Sub-agents created through /agents take effect immediately; files added on disk require a session restart."
+  },
+  {
+    question: "Can Claude Code run sub-agents in parallel?",
+    answer: "Yes. Background sub-agents run concurrently while you keep working, and you can ask Claude to research several independent areas at once (for example: 'Research the auth, database, and API modules in parallel using separate sub-agents'). Each sub-agent explores its area in its own context, then Claude synthesizes the findings. Parallel fan-out works best when the tasks do not depend on each other. Foreground sub-agents, by contrast, block the main conversation until they finish."
+  },
+  {
+    question: "What is the difference between a sub-agent and a slash command or skill?",
+    answer: "A sub-agent runs in an isolated context window and returns only a summary, which is ideal for verbose, self-contained work. A skill is a reusable prompt or workflow that runs in your main conversation context, so it shares your existing history. A slash command is a saved prompt you trigger manually. Use a sub-agent when you want isolation and tool restrictions; use a skill when the work needs your current context."
+  },
+  {
+    question: "How does Claude decide which sub-agent to use?",
+    answer: "Claude reads the description field of each registered sub-agent and matches it against your request and the current context. A vague description means Claude rarely delegates; a specific one (with phrases like 'use proactively after code changes') makes delegation reliable. You can also force a choice: name the sub-agent in your prompt, @-mention it to guarantee it runs, or launch a whole session as one sub-agent with the --agent flag."
+  },
+  {
+    question: "Can a sub-agent use fewer tools than the main session?",
+    answer: "Yes, and you should usually restrict them. Use the tools field as an allowlist (for example 'tools: Read, Grep, Glob, Bash' for a read-only reviewer) or disallowedTools as a denylist (for example 'disallowedTools: Write, Edit' to inherit everything except file writes). A reviewer that cannot edit files cannot accidentally break your codebase. Sub-agents inherit all tools by default if you omit both fields."
+  },
+  {
+    question: "Can a Claude Code sub-agent spawn its own sub-agents?",
+    answer: "Yes, as of Claude Code v2.1.172, a sub-agent can spawn nested sub-agents when its delegated task itself splits into parallel subtasks (for example, a reviewer that dispatches a verifier per finding). The intermediate output never reaches your main conversation; only the top-level sub-agent's summary returns. Background sub-agents stop spawning at depth five to prevent runaway concurrent trees."
+  }
+]
+
+const frontmatterFields = [
+  { field: 'name', required: 'Yes', desc: 'Unique identifier, lowercase letters and hyphens. This is how the sub-agent is invoked.' },
+  { field: 'description', required: 'Yes', desc: 'Tells Claude when to delegate to this sub-agent. Be specific. Add "use proactively" to encourage automatic delegation.' },
+  { field: 'tools', required: 'No', desc: 'Allowlist of tools the sub-agent can use. Inherits all tools if omitted.' },
+  { field: 'disallowedTools', required: 'No', desc: 'Denylist. Removes tools from the inherited or specified set.' },
+  { field: 'model', required: 'No', desc: 'sonnet, opus, haiku, a full model ID, or inherit. Defaults to inherit. Route cheap tasks to haiku to control cost.' },
+  { field: 'permissionMode', required: 'No', desc: 'default, acceptEdits, plan, dontAsk, or bypassPermissions. Controls how permission prompts are handled.' },
+  { field: 'skills', required: 'No', desc: 'Skills to preload into the sub-agent context at startup. The full skill content is injected.' },
+  { field: 'memory', required: 'No', desc: 'user, project, or local. Gives the sub-agent a persistent memory directory that survives across sessions.' },
+  { field: 'background', required: 'No', desc: 'Set to true to always run this sub-agent as a concurrent background task.' },
+  { field: 'isolation', required: 'No', desc: 'Set to worktree to run the sub-agent in an isolated git worktree, so its edits do not touch your checkout.' }
+]
+
+export default function ClaudeCodeSubAgents() {
+  const [copied, setCopied] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopied(id)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  const reviewerAgent = `---
+name: code-reviewer
+description: Expert code review specialist. Use proactively after writing or modifying code.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You are a senior code reviewer. When invoked:
+1. Run git diff to see recent changes
+2. Focus on modified files
+3. Begin review immediately
+
+Report issues by priority: Critical (must fix), Warnings
+(should fix), Suggestions (consider). Include a specific fix for each.`
+
+  const researcherAgent = `---
+name: doc-researcher
+description: Fetches and summarizes external documentation. Use for any task that would flood the main context with web pages or long files.
+tools: Read, Grep, Glob, WebFetch, WebSearch
+model: haiku
+---
+
+You research documentation in your own context and return only
+a tight summary with the exact facts, code snippets, and source
+URLs the main conversation needs. Never return raw page dumps.`
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Code Sub-Agents: How to Configure and Use Them (2026)',
+    description: 'A practical guide to Claude Code sub-agents: what they are, how to configure them with YAML frontmatter, where the files live, and how to run parallel fan-out workflows with real examples.',
+    url: 'https://promptwritingstudio.com/claude-code-sub-agents',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude code sub agents', 'claude code subagents', 'claude code agents', 'claude code parallel agents', 'claude code agents directory', 'claude code agent configuration']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Sub-Agents: How to Configure and Use Them (2026) | PromptWritingStudio</title>
+        <meta name="description" content="Claude Code sub-agents explained: what they are, how to configure them with YAML frontmatter, where the .claude/agents/ files live, and how to run parallel fan-out workflows. With copy-paste examples." />
+        <meta name="keywords" content="claude code sub agents, claude code subagents, claude code agents, claude code parallel agents, claude code agents directory, claude code agent configuration" />
+        <meta property="og:title" content="Claude Code Sub-Agents: How to Configure and Use Them (2026)" />
+        <meta property="og:description" content="What Claude Code sub-agents are, how to configure them, and how to run parallel fan-out workflows. With copy-paste examples." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-code-sub-agents" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-code-sub-agents" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        {/* Hero */}
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Code Sub-Agents
+              <span className="block text-[#FFDE59]">Configure, Use, and Fan Out in Parallel</span>
+            </h1>
+
+            {/* Answer Block - AEO */}
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                Claude Code sub-agents are specialized AI assistants that run in their own context window with their own system prompt, tool access, and permissions. You define them as Markdown files with YAML frontmatter in <code className="bg-black/30 px-1 rounded">.claude/agents/</code> (project) or <code className="bg-black/30 px-1 rounded">~/.claude/agents/</code> (personal). Claude delegates a matching task to the sub-agent, which works independently and returns only a summary, keeping verbose output out of your main conversation. You can run several in parallel for independent work.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              This is the part of Claude Code that turns it from a single assistant into a team. Here is exactly how to configure sub-agents and use them well.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#create" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Create One Now
+              </a>
+              <Link href="/claude-code-guide" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Full Claude Code Guide
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* What they are */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">What Are Sub-Agents in Claude Code?</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-6">
+                A sub-agent is a specialized assistant that Claude Code spawns to handle one type of task. It runs in its own context window with a custom system prompt, its own tool access, and independent permissions. When your request matches a sub-agent's <strong>description</strong>, Claude hands the work over. The sub-agent does the work in isolation and returns only a summary to your main conversation.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                The reason this matters is context. A side task like running the full test suite, fetching three pages of API docs, or grepping a large codebase produces output you will never read again. If that lands in your main conversation, it crowds out the work you actually care about. A sub-agent absorbs that output in its own window and returns the one paragraph you need.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                Claude Code ships with built-in sub-agents you will see working automatically: <strong>Explore</strong> (a fast, read-only Haiku agent for searching code), <strong>Plan</strong> (read-only research during plan mode), and <strong>general-purpose</strong> (full tools for multi-step work). On top of those, you define your own.
+              </p>
+
+              <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-6 rounded-r-lg my-6">
+                <p className="text-[#333333] mb-2"><strong>Sub-agent vs skill vs slash command, in one line each:</strong></p>
+                <ul className="space-y-2 text-[#333333]">
+                  <li><strong>Sub-agent:</strong> isolated context, returns a summary. Best for verbose, self-contained work.</li>
+                  <li><strong>Skill:</strong> reusable workflow that runs in your <em>current</em> context. See <Link href="/claude-code-skills" className="text-[#1A1A1A] underline hover:no-underline">Claude Code Skills</Link>.</li>
+                  <li><strong>Slash command:</strong> a saved prompt you trigger by hand.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* When to use */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">When Should You Use a Sub-Agent?</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Reach for a sub-agent when a task is self-contained and would otherwise flood your main context. Use the main conversation when the work needs frequent back-and-forth.
+            </p>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">Use a sub-agent when</h3>
+                <ul className="space-y-2 text-[#333333]">
+                  <li>The task produces verbose output you do not need (test logs, doc dumps, search results).</li>
+                  <li>You want to enforce tool restrictions, for example a reviewer that cannot write files.</li>
+                  <li>The work is self-contained and can return a clean summary.</li>
+                  <li>You want to run several independent investigations at once.</li>
+                </ul>
+              </div>
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">Stay in the main conversation when</h3>
+                <ul className="space-y-2 text-[#333333]">
+                  <li>The task needs frequent iterative refinement.</li>
+                  <li>Multiple phases share significant context (plan, build, test).</li>
+                  <li>You are making a quick, targeted change.</li>
+                  <li>Latency matters. A sub-agent starts fresh and needs time to gather context.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Create / configure */}
+        <section id="create" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">How to Create a Claude Code Sub-Agent</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              There are two routes. Use the <code className="bg-gray-100 px-2 py-1 rounded text-sm">/agents</code> command for guided setup, or write the file by hand for full control.
+            </p>
+
+            <div className="space-y-6">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Option 1: the /agents command (recommended)</h3>
+                <p className="text-[#333333] mb-3">
+                  Run <code className="bg-gray-100 px-2 py-1 rounded text-sm">/agents</code> inside Claude Code, switch to the <strong>Library</strong> tab, choose <strong>Create new agent</strong>, and pick <strong>Personal</strong> or <strong>Project</strong> scope. Select <strong>Generate with Claude</strong>, describe the agent in plain English, then pick its tools and model. Agents created this way are available immediately, no restart needed.
+                </p>
+              </div>
+
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Option 2: write the file by hand</h3>
+                <p className="text-[#333333] mb-3">
+                  A sub-agent is a Markdown file with YAML frontmatter, followed by the system prompt in the body. Only <code className="bg-gray-100 px-2 py-1 rounded text-sm">name</code> and <code className="bg-gray-100 px-2 py-1 rounded text-sm">description</code> are required. Drop it in your project's <code className="bg-gray-100 px-2 py-1 rounded text-sm">.claude/agents/</code> directory, then restart your session to load it.
+                </p>
+                <div className="bg-[#1A1A1A] text-green-400 p-4 rounded-lg font-mono text-sm overflow-x-auto relative">
+                  <pre>{reviewerAgent}</pre>
+                  <button
+                    onClick={() => copyToClipboard(reviewerAgent, 'reviewer')}
+                    className="absolute top-2 right-2 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded"
+                  >
+                    {copied === 'reviewer' ? 'Copied' : 'Copy'}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Where the files live:</strong> <code className="bg-gray-100 px-1 rounded">.claude/agents/</code> in your repo root for project sub-agents (commit these so your team shares them), or <code className="bg-gray-100 px-1 rounded">~/.claude/agents/</code> for personal ones available across every project. Identity comes from the <code className="bg-gray-100 px-1 rounded">name</code> field, not the filename. Keep names unique across the whole tree.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Frontmatter fields */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Sub-Agent Frontmatter Fields</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              These are the fields you will actually reach for. <code className="bg-gray-100 px-2 py-1 rounded text-sm">name</code> and <code className="bg-gray-100 px-2 py-1 rounded text-sm">description</code> are the only required ones; everything else tightens behavior.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Field</th>
+                    <th className="p-4 text-left font-semibold">Required</th>
+                    <th className="p-4 text-left font-semibold">What it does</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {frontmatterFields.map((row, i) => (
+                    <tr key={i} className={i % 2 === 0 ? 'bg-gray-50' : 'bg-white'}>
+                      <td className="p-4 border-b border-gray-200 font-mono text-sm font-bold text-[#1A1A1A]">{row.field}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333]">{row.required}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333]">{row.desc}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-sm text-[#666666] mt-4">
+              Field reference per Anthropic's official sub-agents documentation. The full list also includes <code className="bg-gray-100 px-1 rounded">mcpServers</code>, <code className="bg-gray-100 px-1 rounded">hooks</code>, <code className="bg-gray-100 px-1 rounded">maxTurns</code>, <code className="bg-gray-100 px-1 rounded">effort</code>, and <code className="bg-gray-100 px-1 rounded">color</code>.
+            </p>
+          </div>
+        </section>
+
+        {/* Restrict tools */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Restrict Tools So Sub-Agents Cannot Break Things</h2>
+            <p className="text-lg text-[#333333] mb-6">
+              The single most useful pattern is limiting a sub-agent's tools. A reviewer that has no <code className="bg-gray-100 px-2 py-1 rounded text-sm">Write</code> or <code className="bg-gray-100 px-2 py-1 rounded text-sm">Edit</code> tool cannot accidentally rewrite your code while it is supposed to be reading it. You have two ways to do this:
+            </p>
+            <div className="space-y-4 mb-6">
+              <div className="bg-[#F9F9F9] p-5 rounded-lg border border-gray-200">
+                <p className="text-[#333333] mb-2"><strong>Allowlist with <code className="bg-gray-100 px-1 rounded">tools</code>:</strong> the sub-agent gets only what you list.</p>
+                <code className="block bg-[#1A1A1A] text-green-400 p-3 rounded font-mono text-sm">tools: Read, Grep, Glob, Bash</code>
+              </div>
+              <div className="bg-[#F9F9F9] p-5 rounded-lg border border-gray-200">
+                <p className="text-[#333333] mb-2"><strong>Denylist with <code className="bg-gray-100 px-1 rounded">disallowedTools</code>:</strong> inherit everything except what you block.</p>
+                <code className="block bg-[#1A1A1A] text-green-400 p-3 rounded font-mono text-sm">disallowedTools: Write, Edit</code>
+              </div>
+            </div>
+            <p className="text-[#333333]">
+              If you set both, <code className="bg-gray-100 px-2 py-1 rounded text-sm">disallowedTools</code> is applied first, then <code className="bg-gray-100 px-2 py-1 rounded text-sm">tools</code> is resolved against what remains. A second lever is <code className="bg-gray-100 px-2 py-1 rounded text-sm">model</code>: route cheap, high-volume tasks to <code className="bg-gray-100 px-2 py-1 rounded text-sm">haiku</code> and save <code className="bg-gray-100 px-2 py-1 rounded text-sm">opus</code> for genuinely hard reasoning. Wondering whether your plan covers heavy sub-agent use? Check the <Link href="/claude-pro-vs-max-vs-api" className="text-[#1A1A1A] underline hover:no-underline">Claude Pro vs Max vs API comparison</Link> or run the <Link href="/calculators/claude-plan-picker" className="text-[#1A1A1A] underline hover:no-underline">Claude plan picker</Link>.
+            </p>
+          </div>
+        </section>
+
+        {/* Parallel fan-out */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Parallel Fan-Out: Running Sub-Agents at the Same Time</h2>
+            <p className="text-lg text-[#333333] mb-6">
+              Sub-agents run in the foreground (blocking) or background (concurrent). Background sub-agents are where the speed comes from: they run while you keep working, using the permissions already granted in the session. For independent work, you can fan several out at once.
+            </p>
+
+            <div className="bg-white p-6 rounded-lg border border-gray-200 mb-6">
+              <p className="text-sm font-semibold text-[#666666] mb-2">PARALLEL RESEARCH</p>
+              <div className="bg-[#1A1A1A] text-green-400 p-4 rounded-lg font-mono text-sm relative">
+                <span>Research the authentication, database, and API modules in parallel using separate sub-agents</span>
+                <button
+                  onClick={() => copyToClipboard('Research the authentication, database, and API modules in parallel using separate sub-agents', 'parallel')}
+                  className="absolute top-2 right-2 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded"
+                >
+                  {copied === 'parallel' ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <p className="text-[#333333] mt-3 text-sm">Each sub-agent explores its area independently, then Claude synthesizes the findings into one answer.</p>
+            </div>
+
+            <p className="text-lg text-[#333333] mb-4">Three patterns cover most fan-out work:</p>
+            <div className="space-y-4">
+              <div className="bg-white p-5 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-1">1. Isolate high-volume output</h3>
+                <p className="text-[#333333] text-sm">"Use a sub-agent to run the test suite and report only the failing tests with their error messages." The verbose run stays in the sub-agent; you get the failures.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-1">2. Parallel research</h3>
+                <p className="text-[#333333] text-sm">Spawn one sub-agent per independent area. Works best when the paths do not depend on each other.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-1">3. Chain sub-agents in sequence</h3>
+                <p className="text-[#333333] text-sm">"Use the code-reviewer sub-agent to find performance issues, then use the optimizer sub-agent to fix them." Each returns results that feed the next.</p>
+              </div>
+            </div>
+
+            <div className="mt-6 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Failure mode to avoid:</strong> fanning out many sub-agents that each return long, detailed results. Every summary lands back in your main conversation, so a wide fan-out of verbose agents can consume as much context as it saved. Keep each sub-agent's return tight, and for sustained parallelism reach for git <code className="bg-gray-100 px-1 rounded">isolation: worktree</code> so concurrent agents do not fight over the same checkout.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Real example */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">A Real Example: a Cheap, Read-Only Doc Researcher</h2>
+            <p className="text-lg text-[#333333] mb-6">
+              Here is a sub-agent worth keeping in <code className="bg-gray-100 px-2 py-1 rounded text-sm">~/.claude/agents/</code>. It fetches and summarizes documentation in its own context, runs on Haiku to keep costs down, and is read-only so it can never touch your files.
+            </p>
+            <div className="bg-[#1A1A1A] text-green-400 p-4 rounded-lg font-mono text-sm overflow-x-auto relative mb-6">
+              <pre>{researcherAgent}</pre>
+              <button
+                onClick={() => copyToClipboard(researcherAgent, 'researcher')}
+                className="absolute top-2 right-2 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded"
+              >
+                {copied === 'researcher' ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <p className="text-[#333333] mb-4">
+              Three things make this work, and they are the same three things that make any sub-agent work:
+            </p>
+            <ul className="space-y-2 text-[#333333] mb-6">
+              <li><strong>A specific description.</strong> "Use for any task that would flood the main context" tells Claude exactly when to delegate.</li>
+              <li><strong>A tight tool list.</strong> Read, Grep, Glob, WebFetch, WebSearch. No Write or Edit, so it is safe to run unattended.</li>
+              <li><strong>A model that fits the job.</strong> Summarizing docs is not hard reasoning, so Haiku is plenty and far cheaper.</li>
+            </ul>
+            <p className="text-[#333333]">
+              To invoke it explicitly rather than waiting for Claude to delegate, name it in your prompt ("Use the doc-researcher sub-agent to summarize the Stripe webhooks docs") or @-mention it to guarantee it runs.
+            </p>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">Common questions about Claude Code sub-agents</p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Authority */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-2xl font-bold text-[#1A1A1A] mb-6 text-center">Official Resources</h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              <a href="https://code.claude.com/docs/en/sub-agents" target="_blank" rel="noopener noreferrer" className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-[#FFDE59] hover:bg-[#F9F9F9] transition-all duration-200">
+                <span className="text-[#FFDE59] mr-3 text-xl">&#8599;</span>
+                <span className="font-semibold text-gray-900">Claude Code Sub-Agents Docs</span>
+              </a>
+              <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener noreferrer" className="flex items-center p-4 border border-gray-200 rounded-lg hover:border-[#FFDE59] hover:bg-[#F9F9F9] transition-all duration-200">
+                <span className="text-[#FFDE59] mr-3 text-xl">&#8599;</span>
+                <span className="font-semibold text-gray-900">Claude Code Documentation</span>
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* Hub links */}
+        <section className="py-16 bg-[#F9F9F9] border-t border-gray-100">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Keep Going With Claude Code</h2>
+              <p className="text-lg text-[#333333] max-w-2xl mx-auto">
+                Sub-agents are one piece of the extension stack. Start with the hub guide, then go deep on each part.
+              </p>
+            </div>
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Link href="/claude-code-guide" className="block p-6 bg-white rounded-lg border border-gray-200 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Guide (start here)</h3>
+                <p className="text-sm text-[#666666]">The full hub: install, features, workflows, pricing.</p>
+              </Link>
+              <Link href="/claude-code-skills" className="block p-6 bg-white rounded-lg border border-gray-200 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Skills</h3>
+                <p className="text-sm text-[#666666]">Reusable workflows that run in your main context, not isolated.</p>
+              </Link>
+              <Link href="/claude-code-slash-commands" className="block p-6 bg-white rounded-lg border border-gray-200 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Slash Commands</h3>
+                <p className="text-sm text-[#666666]">Custom commands that often invoke a sub-agent.</p>
+              </Link>
+              <Link href="/claude-code-mcp-stack" className="block p-6 bg-white rounded-lg border border-gray-200 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Minimum Viable MCP Stack</h3>
+                <p className="text-sm text-[#666666]">Five MCP servers worth wiring into your agents.</p>
+              </Link>
+              <Link href="/claude-code-hooks-recipes" className="block p-6 bg-white rounded-lg border border-gray-200 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Hooks Recipes</h3>
+                <p className="text-sm text-[#666666]">Guardrails and validation you can scope to a sub-agent.</p>
+              </Link>
+              <Link href="/claude-md-playbook" className="block p-6 bg-white rounded-lg border border-gray-200 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">CLAUDE.md Playbook</h3>
+                <p className="text-sm text-[#666666]">The context every sub-agent loads at startup.</p>
+              </Link>
+              <Link href="/calculators/claude-plan-picker" className="block p-6 bg-white rounded-lg border border-gray-200 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Plan Picker</h3>
+                <p className="text-sm text-[#666666]">Find the cheapest plan that covers your usage.</p>
+              </Link>
+            </div>
+            <div className="mt-10 text-center">
+              <a
+                href="https://courses.becomeawritertoday.com/purchase?product_id=6640678"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200"
+              >
+                Join the Prompt Writing Course
+              </a>
+              <p className="text-sm text-[#666666] mt-3">Learn to write the precise descriptions and prompts that make sub-agents delegate reliably.</p>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-code-tutorial.js
+++ b/pages/claude-code-tutorial.js
@@ -1,0 +1,439 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema, generateHowToSchema } from '../lib/schemaGenerator'
+
+const PAGE_URL = 'https://promptwritingstudio.com/claude-code-tutorial'
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+// Steps used for both the visible walkthrough and the HowTo schema.
+const howToSteps = [
+  { name: 'Install Claude Code', text: 'Confirm Node.js 18+ is installed, then run npm install -g @anthropic-ai/claude-code to add the claude command globally.' },
+  { name: 'Launch your first session', text: 'Move into a project folder and run claude. Authenticate with your Claude Pro/Max login or an Anthropic API key when prompted.' },
+  { name: 'Send your first prompt', text: 'Ask Claude Code to explain the project. This is a read-only prompt that teaches you how the read-then-act loop works with zero risk.' },
+  { name: 'Complete your first real task', text: 'Give it one small, specific job — a copy fix, a tiny feature, a renamed variable — and watch it read, edit, and report back.' },
+  { name: 'Review the diff', text: 'Read every change before accepting it. Treat Claude Code like a fast junior developer: trust the work, but verify it.' },
+  { name: 'Commit the change', text: 'Ask Claude Code to commit. It writes the message, stages the right files, and creates the commit so your first session ends in clean git history.' }
+]
+
+const faqs = [
+  {
+    question: "What is the fastest way to start a Claude Code tutorial as a beginner?",
+    answer: "Install Claude Code with npm install -g @anthropic-ai/claude-code, open a terminal inside any project folder, and run claude. Your very first prompt should be a read-only request like 'Explain what this project does.' That lets you watch how Claude Code reads files before it acts, with no risk of breaking anything. Once you understand that read-then-act loop, you give it a small real task, review the change, and commit. The whole first session takes about 15 minutes."
+  },
+  {
+    question: "Do I need to know how to code to follow a Claude Code tutorial?",
+    answer: "You need to be comfortable opening a terminal, navigating into a folder, and reading a code change before you approve it. You do not need to write code yourself. Claude Code writes it. But you do need enough judgement to tell whether a change looks reasonable, which is why this tutorial has you start with read-only prompts and small, low-risk tasks before anything serious. If you have never used a terminal, spend ten minutes on the cd and ls commands first."
+  },
+  {
+    question: "What should my first prompt to Claude Code be?",
+    answer: "Make your first prompt read-only so it cannot change anything. Good examples: 'Explain what this project does and how it is structured,' or 'Walk me through how the login flow works.' Claude Code will read the relevant files and summarise them. This teaches you its core behaviour (it reads before it acts) and builds your confidence before you ask it to edit code. Save editing prompts for your second or third request."
+  },
+  {
+    question: "How do I give Claude Code a good first task?",
+    answer: "Pick one small, specific, reversible change. Bad: 'improve the homepage.' Good: 'In components/Hero.js, change the headline text to \"Build faster with AI\" and nothing else.' Specific instructions with a file path and a clear expected outcome produce clean results. Keep the first task to a single file so the diff is easy to review. You can scale up to multi-file tasks once you trust the workflow."
+  },
+  {
+    question: "What does Claude Code cost for a beginner just learning it?",
+    answer: "Claude Code is free to install. The AI behind it costs money. A Claude Pro subscription at $20/month gives predictable flat-rate access and is the simplest option for someone learning. If you prefer pay-as-you-go, an Anthropic API key bills per token, and a light learning session typically costs well under a dollar. For exact plan guidance, use the Claude Plan Picker calculator on this site."
+  },
+  {
+    question: "How is this tutorial different from the Claude Code guide?",
+    answer: "This page is a linear first-session walkthrough: it takes one beginner from a fresh terminal to a committed change in roughly fifteen minutes, in order. The Claude Code guide is the reference hub. It covers every feature, the full pricing breakdown, comparison tables against Cursor and Copilot, and advanced workflows. Start here to get your hands dirty, then move to the guide once you want depth."
+  }
+]
+
+// Real worked examples — absorbs "claude code examples" intent.
+const workedExamples = [
+  {
+    label: 'Read-only: understand the project',
+    safe: true,
+    prompt: 'Explain what this project does, the main folders, and where the homepage lives.'
+  },
+  {
+    label: 'First real task: a one-file text change',
+    safe: true,
+    prompt: 'In the homepage file, change the main headline to "Ship features in minutes" and change nothing else.'
+  },
+  {
+    label: 'Fix a small, specific bug',
+    safe: true,
+    prompt: 'The contact form submit button does nothing on mobile. Find why and fix only that, then tell me what was wrong.'
+  },
+  {
+    label: 'Add a tiny feature',
+    safe: false,
+    prompt: 'Add a "back to top" button that appears after the user scrolls 600px down the page. Plan it first, then wait for my go-ahead.'
+  },
+  {
+    label: 'Commit your work',
+    safe: true,
+    prompt: 'Commit these changes with a clear message describing what changed and why.'
+  }
+]
+
+export default function ClaudeCodeTutorial() {
+  const [copied, setCopied] = useState(null)
+
+  const copy = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopied(id)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const howToSchema = generateHowToSchema('Claude Code (First Session Walkthrough)', howToSteps, PAGE_URL)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Code Tutorial: Your First Session, Step by Step (2026)',
+    description: 'A beginner Claude Code tutorial that walks you through one full first session — install, first prompt, first real task, and your first commit — in about 15 minutes.',
+    url: PAGE_URL,
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude code tutorial', 'claude code for beginners', 'claude code examples', 'how to use claude code', 'claude code first session', 'claude code walkthrough']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Code Tutorial: Your First Session, Step by Step (2026) | PromptWritingStudio</title>
+        <meta name="description" content="A beginner Claude Code tutorial that walks you through one full first session: install, your first prompt, your first real task, and your first commit — in about 15 minutes." />
+        <meta name="keywords" content="claude code tutorial, claude code for beginners, claude code examples, how to use claude code, claude code first session, claude code walkthrough 2026" />
+        <meta property="og:title" content="Claude Code Tutorial: Your First Session, Step by Step (2026)" />
+        <meta property="og:description" content="Go from a fresh terminal to your first committed change with Claude Code in about 15 minutes. A linear, beginner-friendly walkthrough with copy-paste prompts." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={PAGE_URL} />
+        <link rel="canonical" href={PAGE_URL} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howToSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        {/* Hero */}
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Beginner tutorial · Updated June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Code Tutorial:
+              <span className="block text-[#FFDE59]">Your First Session, Step by Step</span>
+            </h1>
+
+            {/* Direct-answer block — AEO */}
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                This Claude Code tutorial walks one beginner through a single first session, in order: install the tool, launch it inside a project, send a safe read-only prompt, complete one small real task, review the change, and make your first commit. It takes about 15 minutes. Every step has a copy-paste prompt you can run as you read.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-3xl mx-auto">
+              No theory dump. You will type real commands and finish with a committed change in your own project.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#step-1" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Start the Walkthrough
+              </a>
+              <Link href="/claude-code-guide" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                See the Full Reference Guide
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Who this is for + what differs */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Who this tutorial is for</h2>
+            <p className="text-lg text-[#333333] mb-4">
+              You have heard about Claude Code, maybe installed it, and then stared at a blinking cursor with no idea what to type. This page fixes that. It is a linear, do-it-with-me walkthrough of one complete first session.
+            </p>
+            <p className="text-lg text-[#333333] mb-4">
+              You need three things: a terminal you can open, a code project you do not mind experimenting in, and the willingness to read a change before you approve it. That is the whole prerequisite list.
+            </p>
+            <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Tutorial vs reference:</strong> this page gets your hands dirty in one sitting. When you want the deep version — every feature, pricing tables, and how it compares to Cursor and GitHub Copilot — read the <Link href="/claude-code-guide" className="text-[#1A1A1A] underline font-semibold">Claude Code guide</Link>. Bookmark both.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Step 1 — Install (kept brief, linked out) */}
+        <section id="step-1" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="flex items-center mb-6">
+              <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 mr-4">1</span>
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A]">Install Claude Code</h2>
+            </div>
+            <p className="text-lg text-[#333333] mb-4">
+              Claude Code needs Node.js 18 or higher. Check it, then install the tool globally so the <code className="bg-gray-100 px-2 py-1 rounded text-sm">claude</code> command works from any folder.
+            </p>
+            <div className="bg-[#1A1A1A] text-green-400 p-4 rounded-lg font-mono text-sm relative mb-4">
+              <code>node --version<br/>npm install -g @anthropic-ai/claude-code</code>
+              <button onClick={() => copy('node --version\nnpm install -g @anthropic-ai/claude-code', 'install')} className="absolute top-2 right-2 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded">
+                {copied === 'install' ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <p className="text-[#333333]">
+              That is all the setup this tutorial covers on purpose. If the install errors out, or you want the full setup options (API key vs subscription, Windows notes, IDE extension), follow the dedicated <Link href="/claude-code-skills/install-guide" className="text-[#1A1A1A] underline font-semibold">install guide</Link>, then come back here.
+            </p>
+          </div>
+        </section>
+
+        {/* Step 2 — Launch */}
+        <section id="step-2" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="flex items-center mb-6">
+              <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 mr-4">2</span>
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A]">Launch your first session</h2>
+            </div>
+            <p className="text-lg text-[#333333] mb-4">
+              Open your terminal, move into a project you can safely experiment in, and run the command.
+            </p>
+            <div className="bg-[#1A1A1A] text-green-400 p-4 rounded-lg font-mono text-sm relative mb-4">
+              <code>cd path/to/your-project<br/>claude</code>
+              <button onClick={() => copy('cd path/to/your-project\nclaude', 'launch')} className="absolute top-2 right-2 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded">
+                {copied === 'launch' ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <p className="text-[#333333] mb-4">
+              The first time you run it, Claude Code asks you to sign in. Use your Claude Pro or Max login if you have one, or paste an Anthropic API key. It will then ask permission to read your project files. Say yes.
+            </p>
+            <p className="text-[#333333]">
+              You now have a prompt waiting for you. Do not rush to ask it to build something. The next step is the most important one for a beginner.
+            </p>
+          </div>
+        </section>
+
+        {/* Step 3 — First prompt (read-only) */}
+        <section id="step-3" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="flex items-center mb-6">
+              <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 mr-4">3</span>
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A]">Send your first prompt (make it read-only)</h2>
+            </div>
+            <p className="text-lg text-[#333333] mb-4">
+              Your first prompt should be impossible to get wrong. Ask Claude Code to <strong>explain</strong> the project, not change it. Reading cannot break anything, and it teaches you the single most important thing about how the tool works: it reads files before it acts.
+            </p>
+            <div className="bg-white rounded-lg border border-gray-200 overflow-hidden mb-6">
+              <div className="flex justify-between items-center px-6 py-3 bg-gray-100 border-b border-gray-200">
+                <span className="font-semibold text-[#1A1A1A] text-sm">Paste this first</span>
+                <button onClick={() => copy('Explain what this project does, the main folders, and where the homepage lives.', 'p3')} className="text-sm font-medium px-3 py-1 rounded bg-[#FFDE59] text-[#1A1A1A] hover:bg-[#E5C84F]">
+                  {copied === 'p3' ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <div className="px-6 py-4">
+                <p className="text-[#333333] font-mono text-sm">Explain what this project does, the main folders, and where the homepage lives.</p>
+              </div>
+            </div>
+            <p className="text-[#333333]">
+              Watch what happens. Claude Code opens a few files, then writes you a plain-English summary. That read-then-explain loop is the same loop it uses for every task, including ones that change code. Once you have seen it work safely, you will trust it on real edits.
+            </p>
+          </div>
+        </section>
+
+        {/* Step 4 — First real task */}
+        <section id="step-4" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="flex items-center mb-6">
+              <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 mr-4">4</span>
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A]">Complete your first real task</h2>
+            </div>
+            <p className="text-lg text-[#333333] mb-4">
+              Now give it one small job. The rule for a first task: <strong>one file, one specific change, easy to reverse.</strong> Vague prompts produce messy results, so name the file and the exact outcome.
+            </p>
+
+            {/* Before/after — moat requirement */}
+            <div className="grid md:grid-cols-2 gap-4 mb-6">
+              <div className="bg-red-50 border border-red-200 rounded-lg p-5">
+                <p className="text-sm font-bold text-red-700 mb-2">Weak prompt</p>
+                <p className="text-[#333333] font-mono text-sm">"Improve the homepage."</p>
+                <p className="text-sm text-[#666666] mt-3">Too open. Claude Code has to guess what "improve" means and may touch files you did not expect.</p>
+              </div>
+              <div className="bg-green-50 border border-green-200 rounded-lg p-5">
+                <p className="text-sm font-bold text-green-700 mb-2">Strong prompt</p>
+                <p className="text-[#333333] font-mono text-sm">"In the homepage file, change the main headline to 'Ship features in minutes' and change nothing else."</p>
+                <p className="text-sm text-[#666666] mt-3">Names the file, the exact text, and a hard boundary. The diff will be one line.</p>
+              </div>
+            </div>
+
+            <p className="text-[#333333] mb-4">
+              For anything bigger than a single file, add three words to your prompt: <strong>"plan it first."</strong> Claude Code will lay out what it intends to change before touching anything, and you approve the plan. This one habit prevents most beginner accidents.
+            </p>
+            <div className="bg-[#F9F9F9] border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Known failure mode:</strong> a brand-new beginner asks for a huge change ("rebuild the whole nav"), accepts everything without reading, and ends up with a broken project and no idea what changed. Avoid it by keeping task one tiny, and by reading the diff in the next step before you accept.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Step 5 — Review */}
+        <section id="step-5" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="flex items-center mb-6">
+              <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 mr-4">5</span>
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A]">Review the change before you accept it</h2>
+            </div>
+            <p className="text-lg text-[#333333] mb-4">
+              When Claude Code proposes an edit, it shows you a diff: the old lines and the new lines side by side. Read it. For your one-line headline change this takes five seconds, which is exactly why a small first task matters.
+            </p>
+            <p className="text-[#333333] mb-4">
+              You are not checking whether the code is perfect. You are checking whether it did what you asked and nothing more. If the diff touches a file you did not expect, stop and ask why before accepting.
+            </p>
+            <p className="text-[#333333]">
+              This is the same habit you would apply to a fast junior developer: trust the work, but verify it. The review step is not optional, and it is the single thing that separates people who use Claude Code safely from people who break their projects.
+            </p>
+          </div>
+        </section>
+
+        {/* Step 6 — Commit */}
+        <section id="step-6" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="flex items-center mb-6">
+              <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 mr-4">6</span>
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A]">Make your first commit</h2>
+            </div>
+            <p className="text-lg text-[#333333] mb-4">
+              End your first session by saving the change to git. You do not have to remember the commands — just ask.
+            </p>
+            <div className="bg-white rounded-lg border border-gray-200 overflow-hidden mb-6">
+              <div className="flex justify-between items-center px-6 py-3 bg-gray-100 border-b border-gray-200">
+                <span className="font-semibold text-[#1A1A1A] text-sm">Final prompt</span>
+                <button onClick={() => copy('Commit these changes with a clear message describing what changed and why.', 'p6')} className="text-sm font-medium px-3 py-1 rounded bg-[#FFDE59] text-[#1A1A1A] hover:bg-[#E5C84F]">
+                  {copied === 'p6' ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <div className="px-6 py-4">
+                <p className="text-[#333333] font-mono text-sm">Commit these changes with a clear message describing what changed and why.</p>
+              </div>
+            </div>
+            <p className="text-[#333333]">
+              Claude Code writes the commit message, stages the right files, and creates the commit. That is the full loop: prompt, edit, review, commit. You just shipped your first change with an AI pair programmer. Everything else you will ever do with Claude Code is a bigger version of these six steps.
+            </p>
+          </div>
+        </section>
+
+        {/* Worked examples — absorbs "claude code examples" */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="text-center mb-10">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Claude Code examples to run next</h2>
+              <p className="text-lg text-[#333333] max-w-2xl mx-auto">
+                Once your first session works, try these in order. The green ones are safe for beginners; the last asks Claude Code to plan before acting.
+              </p>
+            </div>
+            <div className="space-y-4">
+              {workedExamples.map((ex, i) => (
+                <div key={i} className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="flex justify-between items-center px-6 py-3 bg-gray-100 border-b border-gray-200">
+                    <span className="font-semibold text-[#1A1A1A] text-sm">
+                      {ex.safe ? 'Safe: ' : 'Caution: '}{ex.label}
+                    </span>
+                    <button onClick={() => copy(ex.prompt, `ex${i}`)} className="text-sm font-medium px-3 py-1 rounded bg-[#FFDE59] text-[#1A1A1A] hover:bg-[#E5C84F]">
+                      {copied === `ex${i}` ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <div className="px-6 py-4">
+                    <p className="text-[#333333] font-mono text-sm">{ex.prompt}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>The prompt skill carries over:</strong> writing clear instructions for Claude Code is the same skill as writing clear prompts for ChatGPT or Claude chat — name the outcome, give context, set boundaries. If you want to get systematically better at that, the <a href={COURSE_URL} className="text-[#1A1A1A] underline font-semibold">Prompt Writing Studio course</a> teaches the prompting patterns that make every AI tool, including Claude Code, far more reliable.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* What to learn next — internal links */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <div className="text-center mb-10">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Where to go after your first session</h2>
+              <p className="text-lg text-[#333333] max-w-2xl mx-auto">
+                You have the loop. These are the next things worth learning, in roughly the order most beginners need them.
+              </p>
+            </div>
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Link href="/claude-code-guide" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Full Claude Code Guide</h3>
+                <p className="text-sm text-[#666666]">The complete reference: every feature, pricing, and tool comparisons.</p>
+              </Link>
+              <Link href="/claude-md-playbook" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">CLAUDE.md Playbook</h3>
+                <p className="text-sm text-[#666666]">Give Claude Code persistent project context so you stop repeating yourself.</p>
+              </Link>
+              <Link href="/calculators/claude-plan-picker" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Plan Picker</h3>
+                <p className="text-sm text-[#666666]">Find the cheapest plan that covers how much you actually use it.</p>
+              </Link>
+              <Link href="/claude-code-mcp-stack" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Minimum Viable MCP Stack</h3>
+                <p className="text-sm text-[#666666]">The five MCP servers worth adding once the basics feel easy.</p>
+              </Link>
+              <Link href="/claude-code-vs-cursor" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code vs Cursor</h3>
+                <p className="text-sm text-[#666666]">How the terminal workflow compares to a visual AI editor.</p>
+              </Link>
+              <Link href="/claude-code-review" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Review</h3>
+                <p className="text-sm text-[#666666]">Our hands-on verdict once you have run it for real work.</p>
+              </Link>
+              <Link href="/claude-code-pricing" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Pricing</h3>
+                <p className="text-sm text-[#666666]">What it costs on each plan, and where the API beats a subscription.</p>
+              </Link>
+              <Link href="/claude-code-skills/install-guide" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Skills Install Guide</h3>
+                <p className="text-sm text-[#666666]">Add slash commands and subagents to automate your repeated workflows.</p>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">
+              Claude Code Tutorial FAQ
+            </h2>
+            <p className="text-xl text-[#333333] text-center mb-12">
+              The questions beginners ask on their first day
+            </p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-50 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Course CTA */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl text-center">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+              Get better at the part that actually matters
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Claude Code is only as good as the instructions you give it. The prompts in this tutorial are simple on purpose — but real work needs real prompting skill. The Prompt Writing Studio course teaches the patterns that make Claude Code, ChatGPT, and every other AI tool produce work you can trust.
+            </p>
+            <a href={COURSE_URL} className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-10 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+              Join Now
+            </a>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-context-window.js
+++ b/pages/claude-context-window.js
@@ -1,0 +1,301 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import LastVerified from '../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import { CURRENT_MODELS, LEGACY_MODELS, MODELS_META } from '../lib/claude-data'
+
+// Approximate word equivalent for a token count. Anthropic's rough guide is
+// ~0.75 words per token for English prose. Used only for human-readable scale.
+const WORDS_PER_TOKEN = 0.75
+
+function tokensToWords(tokens) {
+  return Math.round((tokens * WORDS_PER_TOKEN) / 1000) * 1000
+}
+
+function formatTokens(tokens) {
+  if (tokens >= 1000000) return `${tokens / 1000000}M`
+  if (tokens >= 1000) return `${tokens / 1000}K`
+  return String(tokens)
+}
+
+function formatWords(words) {
+  if (words >= 1000000) return `~${(words / 1000000).toFixed(1)}M words`
+  if (words >= 1000) return `~${Math.round(words / 1000)}K words`
+  return `~${words} words`
+}
+
+const faqs = [
+  {
+    question: "What is the Claude context window?",
+    answer: "The context window is the total amount of text Claude can hold in working memory for a single request — your prompt, any files or pasted text, the conversation history, and Claude's own reply all count against it. It is measured in tokens, not words. One token is roughly 0.75 of an English word, so a 200,000-token window holds about 150,000 words. When a conversation exceeds the window, the oldest content drops out and Claude can no longer 'see' it."
+  },
+  {
+    question: "How big is Claude's context window?",
+    answer: `It depends on the model. ${CURRENT_MODELS.map(m => `${m.name} has a ${formatTokens(m.contextTokens)}-token window`).join(', ')}. The flagship and workhorse models reach 1,000,000 tokens — roughly 750,000 words, or several full-length books — while the fastest model holds 200,000 tokens. Limits change as new models ship, so always check the live figure rather than memorising a number.`
+  },
+  {
+    question: "How many words fit in a 1M token context window?",
+    answer: "About 750,000 words, using Anthropic's rough guide of 0.75 words per token. That is the length of roughly seven to nine full novels, or a mid-sized codebase. In practice you rarely want to fill it — large contexts cost more, run slower, and can dilute Claude's focus on the part that matters."
+  },
+  {
+    question: "Does a bigger context window make Claude smarter?",
+    answer: "No. The context window controls how much Claude can read at once, not how well it reasons. Reasoning quality is a function of the model tier. A larger window lets you feed in more source material, but stuffing it with irrelevant text usually hurts answer quality — a focused 5,000-token prompt beats a bloated 500,000-token one. Use the window for relevant material, not as a dumping ground."
+  },
+  {
+    question: "What happens when I exceed Claude's context window?",
+    answer: "In the API you get an error if a single request is too large. In the Claude.ai chat, long conversations are truncated — the earliest messages silently fall out of scope, so Claude appears to 'forget' things you said earlier. The fix is to start a fresh conversation, summarise the important points into a new prompt, or use Projects to keep reference material attached."
+  },
+  {
+    question: "Does the context window affect cost?",
+    answer: "On the API, yes — you pay per input token, so a request that fills a 1M-token window costs far more than a tight prompt. On consumer Pro and Max subscriptions there is no per-token charge, but very large contexts count more heavily against your usage limits. Either way, the cheapest and fastest prompt is the one that includes only what Claude needs."
+  }
+]
+
+const tips = [
+  {
+    title: 'Send only what matters',
+    body: 'Paste the relevant section, not the entire document. A focused 3,000-token prompt almost always outperforms a 300,000-token data dump — and it is cheaper and faster.'
+  },
+  {
+    title: 'Start fresh conversations often',
+    body: 'In a long chat, old turns quietly drop out of scope. When a thread drifts, open a new conversation and paste a two-line summary of what Claude needs to remember.'
+  },
+  {
+    title: 'Summarise instead of re-pasting',
+    body: 'Rather than re-attaching a long file every turn, ask Claude to summarise it once, then carry the summary forward. You preserve the signal and reclaim the tokens.'
+  },
+  {
+    title: 'Put the question last',
+    body: 'When you do load a large context, place your actual instruction at the end of the prompt. Models attend strongly to the most recent text, so the ask should be the last thing Claude reads.'
+  },
+  {
+    title: 'Match the model to the job',
+    body: 'You do not need a 1M-token window to rewrite an email. Reserve the large-context models for whole-codebase or whole-book tasks; use the fast model for short, high-volume work.'
+  }
+]
+
+const longContextModels = CURRENT_MODELS.filter(m => m.contextTokens >= 1000000)
+
+const article = generateArticleSchema({
+  title: 'Claude Context Window: Token Limits by Model and How to Manage It (2026)',
+  description: 'A plain-English guide to the Claude context window — what it is, the token limit for every current model, the 1M-token window, and practical ways to manage it.',
+  slug: 'claude-context-window',
+  datePublished: '2026-06-16'
+})
+
+export default function ClaudeContextWindow() {
+  const faqSchema = generateFAQSchema(faqs)
+  const flagship = CURRENT_MODELS[0]
+
+  return (
+    <>
+      <Head>
+        <title>Claude Context Window: Token Limits by Model (2026) | PromptWritingStudio</title>
+        <meta name="description" content="What the Claude context window is, the token limit for every current Claude model, the 1M-token window explained, and practical tips to manage it without wasting tokens." />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-context-window" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-4xl">
+            <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">Claude · Reference</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
+              Claude Context Window: Token Limits by Model and How to Manage It
+            </h1>
+            <p className="text-xl text-gray-200 max-w-3xl mx-auto">
+              What the context window actually is, the exact token limit for every current Claude model, and how to work inside it without wasting tokens or losing your thread.
+            </p>
+            <LastVerified date={MODELS_META.lastVerified} source={MODELS_META.source} label="Model limits verified" className="mt-4 text-gray-300" />
+          </div>
+        </section>
+
+        <section className="py-10 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
+              <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                The <strong>Claude context window</strong> is the total text Claude can hold in working memory for one request — your prompt, attached files, the conversation so far, and Claude's reply all count. It is measured in <strong>tokens</strong> (≈0.75 of a word each). Claude's top models reach <strong>{formatTokens(flagship.contextTokens)} tokens</strong> ({formatWords(tokensToWords(flagship.contextTokens))}); the fastest model holds 200K. A bigger window lets you feed in more, but it does not make Claude smarter — focused prompts still win.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">What is a context window?</h2>
+            <p className="text-[#333333] mb-4 leading-relaxed">
+              Think of the context window as Claude's short-term memory for a single request. Everything you put in front of it — the instruction you type, any documents or code you paste, the back-and-forth of the conversation, and the answer it writes — has to fit inside one budget.
+            </p>
+            <p className="text-[#333333] mb-4 leading-relaxed">
+              That budget is counted in <strong>tokens</strong>, not words or characters. A token is a chunk of text — often a short word or part of a longer one. Anthropic's rough rule of thumb is that one token is about <strong>0.75 of an English word</strong>, so 1,000 tokens is roughly 750 words.
+            </p>
+            <p className="text-[#333333] mb-4 leading-relaxed">
+              The single most useful thing to understand: <strong>input and output share the same window.</strong> If a model has a 200,000-token window and your prompt uses 180,000 of them, Claude has only 20,000 tokens left to write its answer. Long inputs squeeze the room available for the reply.
+            </p>
+            <div className="bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 mt-6">
+              <p className="text-[#1A1A1A]"><strong>One-line definition:</strong> the context window is the maximum amount of text — prompt plus reply — that Claude can process in a single request, measured in tokens.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2 text-center">Context window by Claude model</h2>
+            <p className="text-[#333333] mb-8 text-center max-w-2xl mx-auto">Current models, with the token limit and the rough word equivalent. Figures pulled live from our model data, verified {MODELS_META.lastVerified}.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full bg-white rounded-lg border border-gray-200 text-sm">
+                <thead className="bg-[#1A1A1A] text-white">
+                  <tr>
+                    <th className="p-3 text-left">Model</th>
+                    <th className="p-3 text-left">Tier</th>
+                    <th className="p-3 text-left">Context window</th>
+                    <th className="p-3 text-left">≈ Words</th>
+                    <th className="p-3 text-left">Max output</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {CURRENT_MODELS.map(m => (
+                    <tr key={m.id}>
+                      <td className="p-3 font-semibold text-[#1A1A1A]">{m.name}</td>
+                      <td className="p-3 text-[#333333] capitalize">{m.tier}</td>
+                      <td className="p-3 text-[#333333]">{m.contextTokens.toLocaleString()} tokens</td>
+                      <td className="p-3 text-[#333333]">{formatWords(tokensToWords(m.contextTokens))}</td>
+                      <td className="p-3 text-[#333333]">{m.maxOutputTokens.toLocaleString()} tokens</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-gray-500 mt-3 text-center">
+              Word counts are approximate (0.75 words/token). Older models —{' '}
+              {LEGACY_MODELS.filter(m => m.status === 'legacy').slice(0, 3).map(m => m.name).join(', ')} — mostly held 200K tokens. Limits change with each release; verified against{' '}
+              <a href={MODELS_META.source} target="_blank" rel="noopener noreferrer" className="underline">Anthropic's model docs</a> on {MODELS_META.lastVerified}.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">The 1M-token context window, explained</h2>
+            <p className="text-[#333333] mb-4 leading-relaxed">
+              Claude's flagship and workhorse models — {longContextModels.map(m => m.name).join(' and ')} — carry a <strong>1,000,000-token</strong> context window. That is about <strong>750,000 words</strong>: seven to nine full-length novels, or a substantial software codebase, in a single request.
+            </p>
+            <p className="text-[#333333] mb-4 leading-relaxed">
+              It unlocks genuinely new workflows. You can drop an entire repository in and ask for an architecture review, paste a 300-page contract and ask for the risky clauses, or feed a year of meeting notes and ask for the decisions that were never followed up.
+            </p>
+            <p className="text-[#333333] mb-4 leading-relaxed">
+              Two caveats keep it honest. First, <strong>more context is not free</strong>: on the API you pay per input token, so filling a 1M window is expensive, and even on subscriptions it counts harder against your limits. Second, <strong>large contexts can dilute focus</strong> — burying your real question inside 800,000 tokens of background often produces a worse answer than a tight, relevant prompt.
+            </p>
+            <div className="bg-[#FFDE59]/10 border-l-4 border-[#FFDE59] p-5 rounded-r mt-6">
+              <p className="text-[#1A1A1A]"><strong>Rule of thumb:</strong> use the big window to include material Claude genuinely needs to read — not as an excuse to skip deciding what is relevant.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2">How to manage the context window</h2>
+            <p className="text-[#333333] mb-8">Five habits that keep your prompts sharp, cheap, and inside the limit.</p>
+            <div className="space-y-4">
+              {tips.map((tip, i) => (
+                <div key={i} className="bg-white p-5 rounded-lg border border-[#E5E5E5]">
+                  <h3 className="font-bold text-[#1A1A1A] mb-1">{i + 1}. {tip.title}</h3>
+                  <p className="text-[#333333] leading-relaxed">{tip.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">A prompt template for large-context tasks</h2>
+            <p className="text-[#333333] mb-5 leading-relaxed">
+              When you do need to load a long document, structure the prompt so Claude knows what to ignore and what to act on. Fill in the slots:
+            </p>
+            <div className="bg-[#1A1A1A] text-gray-100 rounded-lg p-5 text-sm leading-relaxed font-mono whitespace-pre-wrap">
+{`You are reviewing the material below. Do not summarise all of it.
+
+GOAL: [the one thing you want — e.g. "find every clause that limits liability"]
+SCOPE: [which part to focus on — e.g. "sections 4 to 9 only"]
+FORMAT: [how to answer — e.g. "a bullet list, clause number then plain-English risk"]
+
+--- MATERIAL START ---
+[paste your document, code, or notes here]
+--- MATERIAL END ---
+
+Now do the GOAL. Quote the exact text you are referring to.`}
+            </div>
+            <p className="text-[#333333] mt-5 leading-relaxed">
+              <strong>Why it works:</strong> the goal and format sit at the top and bottom — the two positions models attend to most — and the explicit "do not summarise all of it" stops Claude from spending its output budget restating what you pasted.
+            </p>
+            <p className="text-[#333333] mt-4 leading-relaxed">
+              Want hundreds more fill-in-the-blank prompts like this, organised by job to be done? That is the core of the{' '}
+              <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="text-[#1A1A1A] font-semibold underline">Prompt Writing Studio course</a> — the prompt engineering system, not a list of one-off tricks.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6 text-center">Frequently asked questions</h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-4 cursor-pointer hover:bg-gray-50 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-4 pb-4"><p className="text-gray-600 leading-relaxed">{faq.answer}</p></div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6 text-center">Keep going</h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              <Link href="/claude-sonnet-vs-opus" className="block bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Claude Sonnet vs Opus</h3>
+                <p className="text-[#333333] text-sm">Which tier to pick — and why the bigger window does not always mean the better model.</p>
+              </Link>
+              <Link href="/claude-code-guide" className="block bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Claude Code guide</h3>
+                <p className="text-[#333333] text-sm">How context management plays out in agentic coding sessions.</p>
+              </Link>
+              <Link href="/claude-pro-vs-max-vs-api" className="block bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Claude Pro vs Max vs API</h3>
+                <p className="text-[#333333] text-sm">How large contexts affect cost and usage limits across plans.</p>
+              </Link>
+              <Link href="/calculators/claude-prompt-cost" className="block bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Claude prompt cost calculator</h3>
+                <p className="text-[#333333] text-sm">See what a large-context request actually costs in input tokens.</p>
+              </Link>
+              <Link href="/anthropic-api-pricing" className="block bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Anthropic API pricing</h3>
+                <p className="text-[#333333] text-sm">Per-token input and output rates by model, where context size hits the bill.</p>
+              </Link>
+              <Link href="/claude-vs-gemini" className="block bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5 hover:border-[#FFDE59] transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">Claude vs Gemini</h3>
+                <p className="text-[#333333] text-sm">How the two stack up on context window and long-document handling.</p>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A] text-center">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-white mb-4">Stop wasting tokens on weak prompts</h2>
+            <p className="text-gray-300 mb-6">Knowing the context window is the easy part. Writing prompts that get a great answer in the fewest tokens is the skill. The Prompt Writing Studio course is the full system — templates, frameworks, and the engineering behind prompts that work the first time.</p>
+            <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Join Now</a>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-for-business.js
+++ b/pages/claude-for-business.js
@@ -1,0 +1,271 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import LastVerified from '../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import { TEAM_PLANS, PLANS_META } from '../lib/claude-data'
+
+const teamStandard = TEAM_PLANS.find(p => p.id === 'team-standard')
+const teamPremium = TEAM_PLANS.find(p => p.id === 'team-premium')
+const enterprise = TEAM_PLANS.find(p => p.id === 'enterprise')
+
+const faqs = [
+  {
+    question: "What is Claude for business?",
+    answer: "Claude for business means using Anthropic's Claude models inside a company through the Team plan or Enterprise plan, rather than individual Pro or Max subscriptions. The Team plan starts at $25 per seat per month (minimum 5 seats) and adds SSO, central billing, admin controls, and a guarantee that your conversations aren't used to train models. Enterprise adds compliance features like audit logs, SCIM, and IP allowlisting for regulated industries."
+  },
+  {
+    question: "How much does Claude Team cost?",
+    answer: `Claude Team has two seat types. A Standard seat is $${teamStandard.pricePerSeatPerMonth} per seat per month ($${teamStandard.pricePerSeatPerMonthAnnual} billed annually), with a ${teamStandard.minSeats}-seat minimum. A Premium seat is $${teamPremium.pricePerSeatPerMonth} per seat per month ($${teamPremium.pricePerSeatPerMonthAnnual} annually) and carries roughly 5x the usage ceiling — built for people running Claude Code or heavy analysis all day. You can mix seat types, so most teams put Standard seats on everyone and Premium seats on their power users.`
+  },
+  {
+    question: "How do businesses actually use Claude day to day?",
+    answer: "The highest-ROI uses are repetitive writing and analysis tasks: drafting customer support replies, turning meeting notes into action items, summarising long documents, writing first-draft proposals and SOPs, cleaning and analysing spreadsheets, and reviewing code. The pattern that works is a saved, fill-in-the-blank prompt for each recurring task so the whole team gets the same quality output instead of starting from scratch each time."
+  },
+  {
+    question: "Is Claude Team better than five individual Pro subscriptions?",
+    answer: `Five Pro subscriptions cost $100 per month and give you no shared admin, no SSO, and no central billing. Five Claude Team Standard seats cost $${teamStandard.pricePerSeatPerMonth * teamStandard.minSeats} per month and add all of those plus a contractual no-training-on-your-data default. The $25 difference buys back IT admin time and removes the data-training question that legal teams ask first. For any company past a handful of users, Team is the cleaner answer.`
+  },
+  {
+    question: "Does Claude train on my company's data?",
+    answer: "On Team and Enterprise plans, Anthropic's default is not to train models on your conversations or uploaded content. This is the single feature that moves Claude from a personal tool to a sanctioned business tool — verify the current data-handling terms on Anthropic's pricing and trust pages before rolling out, since policies are updated over time."
+  },
+  {
+    question: "When should a business move from Team to Enterprise?",
+    answer: `Move to Enterprise when compliance requirements outgrow the Team plan: when you need audit logs, SCIM provisioning, role-based access, custom data retention, IP allowlisting, or a HIPAA-ready configuration. Enterprise is billed per seat plus usage at API rates rather than a flat seat price, so it suits regulated industries and larger orgs more than a 10-person team.`
+  },
+  {
+    question: "How do I roll Claude out to a team without it becoming shelfware?",
+    answer: "Pick three recurring tasks the team already does manually — support replies, meeting summaries, proposal drafts are common — and write one saved prompt template for each. Share those templates on day one. Adoption fails when people are handed a blank chat box and told to 'be creative'; it succeeds when they get a fill-in-the-blank prompt that produces a usable draft on the first try."
+  }
+]
+
+const useCases = [
+  {
+    title: 'Customer support',
+    task: 'Draft consistent, on-brand replies to common tickets',
+    roi: 'Cuts first-response drafting from minutes to seconds; new agents sound like senior ones',
+    template: `You are a support agent for [COMPANY], which sells [PRODUCT].
+Tone: [friendly / formal / concise].
+Customer message: """[PASTE TICKET]"""
+Write a reply that: acknowledges the issue, gives the fix in numbered steps,
+and ends with one clear next action. Do not promise anything not in our policy: [PASTE POLICY].`
+  },
+  {
+    title: 'Meetings & operations',
+    task: 'Turn raw notes or a transcript into decisions and owners',
+    roi: 'Removes the post-meeting write-up tax; nothing falls through the cracks',
+    template: `Here are my raw meeting notes: """[PASTE NOTES]"""
+Produce three sections: (1) Decisions made, (2) Action items as a table with
+Owner and Due date, (3) Open questions. Flag anything ambiguous instead of guessing.`
+  },
+  {
+    title: 'Sales & proposals',
+    task: 'Generate a tailored first-draft proposal from a brief',
+    roi: 'Compresses a half-day proposal into a 20-minute edit',
+    template: `Draft a proposal for [PROSPECT], a [INDUSTRY] company with [N] employees.
+Their stated problem: [PROBLEM]. Our solution: [SOLUTION].
+Structure: situation, recommended approach, scope, timeline, and pricing placeholder.
+Keep it under one page. Match this tone: [PASTE A PAST WINNING PROPOSAL].`
+  },
+  {
+    title: 'Data & spreadsheets',
+    task: 'Clean, summarise, and pull insight from messy data',
+    roi: 'No formula expertise required; analysts spend time on judgment, not wrangling',
+    template: `Here is a CSV export: """[PASTE DATA]"""
+Tell me: the three most important trends, any rows that look like data-entry errors,
+and one chart I should build. Then give me the exact spreadsheet formula for each metric.`
+  }
+]
+
+const article = generateArticleSchema({
+  title: 'Claude for Business: Use Cases, Team Pricing, and How to Get Started (2026)',
+  description: 'How businesses use Claude day to day — support, meetings, proposals, and data — plus what the Claude Team plan costs, the ROI math, and copy-paste prompt templates to roll it out.',
+  slug: 'claude-for-business',
+  datePublished: '2026-06-16'
+})
+
+export default function ClaudeForBusiness() {
+  const faqSchema = generateFAQSchema(faqs)
+
+  return (
+    <>
+      <Head>
+        <title>Claude for Business: Use Cases, Team Pricing & Getting Started (2026) | PromptWritingStudio</title>
+        <meta name="description" content="How businesses use Claude for business — support, meetings, proposals, and data analysis — with Claude Team plan pricing, the ROI math, and copy-paste prompt templates." />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-for-business" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-4xl">
+            <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">Claude · For Business</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
+              Claude for Business: Use Cases, Pricing, and How to Get Started
+            </h1>
+            <p className="text-xl text-gray-200 max-w-3xl mx-auto">
+              What businesses actually use Claude for, what the Team plan costs, and the prompt templates that get a team productive on day one.
+            </p>
+            <LastVerified date={PLANS_META.lastVerified} source={PLANS_META.source} className="mt-4 text-gray-300" />
+          </div>
+        </section>
+
+        <section className="py-10 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
+              <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                <strong>Claude for business</strong> means running Claude across a company on the <strong>Team plan</strong> — from <strong>${teamStandard.pricePerSeatPerMonth}/seat/mo</strong> with a {teamStandard.minSeats}-seat minimum — instead of scattered personal subscriptions. The Team plan adds SSO, central billing, admin controls, and a no-training-on-your-data default. The ROI comes from saved prompt templates for recurring work: support replies, meeting notes, proposals, and data analysis.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">What businesses actually use Claude for</h2>
+            <p className="text-[#333333] mb-4">
+              Most generic guides stop at the pricing table. The value is in the work itself. The four use cases below cover the bulk of business ROI — each comes with a fill-in-the-blank template you can paste in and use today.
+            </p>
+            <p className="text-[#333333] mb-8">
+              The rule that separates teams who get value from teams whose seats go cold: <strong>turn every recurring task into a saved prompt</strong>. A blank chat box produces inconsistent output. A template produces a usable draft on the first try.
+            </p>
+            <div className="space-y-6">
+              {useCases.map((u, i) => (
+                <div key={i} className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="bg-[#1A1A1A] text-white px-6 py-4 flex flex-wrap items-baseline gap-3">
+                    <h3 className="text-xl font-bold">{u.title}</h3>
+                    <span className="text-sm text-gray-400 ml-auto">{u.task}</span>
+                  </div>
+                  <div className="p-6">
+                    <p className="text-sm text-[#333333] mb-3"><strong>Why it pays off:</strong> {u.roi}</p>
+                    <p className="text-sm font-semibold text-[#1A1A1A] mb-2">Copy-paste template:</p>
+                    <pre className="bg-[#F9F9F9] border border-gray-200 rounded p-4 text-sm text-[#1A1A1A] whitespace-pre-wrap overflow-x-auto">{u.template}</pre>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="bg-[#FFDE59]/10 border-l-4 border-[#FFDE59] p-4 rounded-r mt-8">
+              <p className="text-sm text-[#1A1A1A]"><strong>Failure mode to avoid:</strong> rolling Claude out with a "go be creative" memo. Adoption dies when people face a blank box. Ship three saved templates on day one — support, meetings, proposals — and let usage grow from there.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2 text-center">What does Claude for business cost?</h2>
+            <p className="text-[#333333] mb-8 text-center max-w-2xl mx-auto">The Team plan has two seat types plus an Enterprise tier. Mix Standard seats for most staff with Premium seats for power users.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full bg-white rounded-lg border border-gray-200 text-sm">
+                <thead className="bg-[#1A1A1A] text-white">
+                  <tr>
+                    <th className="p-3 text-left">Plan / seat</th>
+                    <th className="p-3 text-left">Price</th>
+                    <th className="p-3 text-left">Min seats</th>
+                    <th className="p-3 text-left">Usage</th>
+                    <th className="p-3 text-left">Best for</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {TEAM_PLANS.map(p => (
+                    <tr key={p.id}>
+                      <td className="p-3 font-semibold text-[#1A1A1A]">{p.name}</td>
+                      <td className="p-3 text-[#333333]">
+                        ${p.pricePerSeatPerMonth}/seat/mo
+                        {p.pricePerSeatPerMonthAnnual && p.pricePerSeatPerMonthAnnual < p.pricePerSeatPerMonth && (
+                          <span className="block text-xs text-gray-500">${p.pricePerSeatPerMonthAnnual} annual</span>
+                        )}
+                        {p.billing === 'per-seat-plus-api-usage' && (
+                          <span className="block text-xs text-gray-500">+ usage at API rates</span>
+                        )}
+                      </td>
+                      <td className="p-3 text-[#333333]">{p.minSeats || '—'}</td>
+                      <td className="p-3 text-[#333333]">{p.usageLimit}</td>
+                      <td className="p-3 text-[#333333]">{p.bestFor}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-gray-500 mt-3 text-center">Team and Enterprise pricing verified against claude.com/pricing on {PLANS_META.lastVerified}. AI pricing changes often — confirm current rates before purchasing.</p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">The ROI math: Team vs five personal Pro plans</h2>
+            <p className="text-[#333333] mb-4">
+              The most common mistake is letting employees expense individual Pro subscriptions. Here is the comparison at the {teamStandard.minSeats}-seat minimum:
+            </p>
+            <ul className="space-y-2 mb-6">
+              <li className="flex items-start gap-2 text-[#333333]"><span className="text-[#FFDE59] font-bold mt-0.5">•</span><span><strong>Five personal Pro plans:</strong> $100/mo. No SSO, no central billing, no admin visibility, and the default consumer data terms.</span></li>
+              <li className="flex items-start gap-2 text-[#333333]"><span className="text-[#FFDE59] font-bold mt-0.5">•</span><span><strong>Five Team Standard seats:</strong> ${teamStandard.pricePerSeatPerMonth * teamStandard.minSeats}/mo. Adds SSO, central billing, admin controls, and the no-training-on-your-data default.</span></li>
+            </ul>
+            <p className="text-[#333333] mb-4">
+              For ${teamStandard.pricePerSeatPerMonth * teamStandard.minSeats - 100} more per month you remove the data-training question legal asks first and the IT admin overhead of managing five separate accounts. If those five people each save even 30 minutes a day on drafting, the plan pays for itself many times over before you count anything else.
+            </p>
+            <p className="text-[#333333]">
+              Want the per-task numbers for your own team? The calculators below run the math on content speed, support savings, and overall AI readiness.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">How to get started with Claude for business</h2>
+            <ol className="space-y-4">
+              <li className="bg-white p-5 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">1. Confirm the right plan</h3>
+                <p className="text-[#333333]">Under 5 people or piloting solo? Start on Pro or Max and decide later. Five or more people who need shared admin? Go straight to Team. Run the numbers with the <Link href="/claude-pro-vs-max-vs-api" className="text-blue-600 underline">Pro vs Max vs API guide</Link> and the plan picker.</p>
+              </li>
+              <li className="bg-white p-5 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">2. Pick three recurring tasks</h3>
+                <p className="text-[#333333]">Choose the highest-volume manual writing work your team already does. Support replies, meeting summaries, and proposals are the usual three. Write one fill-in-the-blank template for each — use the templates above as a starting point.</p>
+              </li>
+              <li className="bg-white p-5 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">3. Ship templates, not a blank box</h3>
+                <p className="text-[#333333]">Share the templates in a shared doc or Projects on day one. Measure adoption by whether people reuse them, not by seat count. Add new templates as people request them.</p>
+              </li>
+              <li className="bg-white p-5 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-1">4. Upgrade seats and tiers as needed</h3>
+                <p className="text-[#333333]">Move heavy daily users to Premium seats. Move to {enterprise.name} only when compliance needs (audit logs, SCIM, HIPAA-ready) outgrow the Team plan.</p>
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6 text-center">Frequently asked questions</h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-4 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-4 pb-4"><p className="text-gray-600 leading-relaxed">{faq.answer}</p></div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A] text-center">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-white mb-4">Make the templates pay for the plan</h2>
+            <p className="text-gray-300 mb-6">A team only gets ROI from Claude when everyone uses prompts that work. Prompt Writing Studio teaches the exact frameworks for building reusable, fill-in-the-blank templates like the ones above — so your whole team produces senior-level output instead of guessing at the prompt. Start with the calculators, then build the skill.</p>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-4 justify-center mb-6">
+              <Link href="/calculators/claude-plan-picker" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Open the plan picker</Link>
+              <Link href="/calculators/business-ai-readiness" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">AI readiness calculator</Link>
+              <Link href="/calculators/customer-service-ai-savings" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Support savings calculator</Link>
+            </div>
+            <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition">Join Now</a>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-for-coding.js
+++ b/pages/claude-for-coding.js
@@ -1,0 +1,425 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { getCurrentModelByTier } from '../lib/claude-data'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const opus = getCurrentModelByTier('flagship')
+const sonnet = getCurrentModelByTier('workhorse')
+const haiku = getCurrentModelByTier('fast')
+
+const faqs = [
+  {
+    question: "Is Claude good for coding?",
+    answer: `Yes. Claude is one of the strongest coding models available. ${opus.name} handles hard reasoning, large refactors, and multi-file changes; ${sonnet.name} is the everyday workhorse for writing functions, tests, and small features; ${haiku.name} is the fast, cheap option for boilerplate and quick lookups. You can use any of them three ways: chatting at claude.ai, calling the API from your own code, or running Claude Code in your terminal.`
+  },
+  {
+    question: "Which Claude model is best for coding?",
+    answer: `For most day-to-day coding, ${sonnet.name} is the right default — it is fast, cheap enough to run all day, and capable enough for the large majority of tasks. Reach for ${opus.name} when a problem needs deep reasoning: a gnarly bug, a large refactor, or planning a feature that touches many files. Use ${haiku.name} for high-volume, low-stakes work like generating test fixtures or classifying code. The cost climbs with capability, so start on Sonnet and only escalate when the output is not good enough.`
+  },
+  {
+    question: "What is the difference between using Claude in chat and using Claude Code?",
+    answer: "Claude in chat (claude.ai) is copy-paste: you paste code in, read the answer, paste it back into your editor. It is perfect for learning, one-off questions, and explaining unfamiliar code. Claude Code is an agent that runs in your terminal, reads your real files, runs commands, and edits code directly across your whole project. Chat is the lowest-friction way to start; Claude Code is what you graduate to once you are doing this every day."
+  },
+  {
+    question: "Do I need to be a developer to use Claude for coding?",
+    answer: "No. Claude in chat is genuinely usable by non-developers for small scripts, spreadsheet formulas, and automating repetitive tasks — you describe what you want in plain English and paste the result where it runs. The catch is that Claude only knows what you tell it. The better your prompt (what the code should do, what tools you have, what the input and output look like), the better the result. That is the whole skill, and it is closer to clear writing than to engineering."
+  },
+  {
+    question: "How much does it cost to use Claude for coding?",
+    answer: `Claude in chat is free with daily limits, or ${'$'}20/month for Claude Pro, which also unlocks Claude Code. Heavy daily Claude Code users move to Max plans for higher limits. The API is pay-per-token (${sonnet.name} and ${opus.name} are priced separately) and only works out cheaper for apps and automations you ship, not for your own hands-on-keyboard coding. Start on Pro, prove the workflow, then scale the plan to your real usage.`
+  },
+  {
+    question: "Can Claude write code in any programming language?",
+    answer: "Claude is strong across mainstream languages — Python, JavaScript and TypeScript, Java, Go, Rust, SQL, shell, HTML and CSS — and competent in most others. It is best where there is a lot of public code to learn from, so popular languages and frameworks get better results than niche or proprietary ones. For obscure stacks, give Claude more context: paste an example file, name the exact version, and describe the conventions you follow."
+  },
+  {
+    question: "Why does Claude sometimes write code that does not run?",
+    answer: "Almost always because it is guessing at something you did not tell it: a library version, a function signature, a file path, or how your data is actually shaped. Claude will confidently invent a plausible-looking API rather than admit it does not know. The fix is context, not a better model — paste the real error, the relevant file, and the exact versions you are on, and ask it to fix that specific failure rather than rewrite from scratch."
+  }
+]
+
+const promptTemplates = [
+  {
+    id: 'feature',
+    label: 'Write a new function or feature',
+    when: 'Best in chat or Claude Code when you know exactly what you want built.',
+    content: `You are writing [LANGUAGE] for a [TYPE OF PROJECT].
+
+Write a function that [WHAT IT SHOULD DO].
+
+Inputs: [DESCRIBE INPUTS + TYPES]
+Output: [DESCRIBE EXPECTED OUTPUT + TYPE]
+Constraints: [e.g. no external libraries, must handle empty input, must be O(n)]
+
+Conventions to follow:
+- [e.g. type hints on every argument]
+- [e.g. early returns, no nested conditionals deeper than 2]
+
+Return only the function plus a one-line comment on anything non-obvious. Do not explain unless I ask.`
+  },
+  {
+    id: 'debug',
+    label: 'Debug an error',
+    when: 'Paste the real error and the real file. The most common newcomer mistake is describing the bug instead of showing it.',
+    content: `I'm getting this error in [LANGUAGE]:
+
+[PASTE THE FULL ERROR MESSAGE AND STACK TRACE]
+
+Here is the relevant code:
+
+[PASTE THE CODE THAT THROWS — include enough context, not just the one line]
+
+Versions: [LANGUAGE/RUNTIME VERSION], [KEY LIBRARY VERSIONS]
+
+Tell me the root cause in one sentence, then give me the minimal fix. Do not refactor anything I didn't ask about.`
+  },
+  {
+    id: 'explain',
+    label: 'Understand unfamiliar code',
+    when: 'The fastest way into a new codebase. Works great in chat.',
+    content: `Explain this [LANGUAGE] code to me as if I'm an experienced developer who has never seen this codebase.
+
+[PASTE THE CODE]
+
+Cover, in this order:
+1. What it does in one sentence.
+2. The flow, step by step.
+3. Anything surprising, risky, or non-idiomatic.
+4. What I'd need to know before changing it.
+
+Be concise. No line-by-line narration.`
+  },
+  {
+    id: 'tests',
+    label: 'Write tests for existing code',
+    when: 'Hand Claude the function and your test framework. It is reliably good at this.',
+    content: `Write tests for this [LANGUAGE] function using [TEST FRAMEWORK, e.g. pytest, Jest, Go testing].
+
+[PASTE THE FUNCTION]
+
+Cover:
+- The happy path
+- Edge cases: [empty input, nulls, boundary values — name the ones that matter here]
+- Any error conditions the function is supposed to raise
+
+Use the same assertion style as this existing test: [PASTE ONE EXISTING TEST, or say "use idiomatic [FRAMEWORK] style"]. Return only the test file.`
+  },
+  {
+    id: 'refactor',
+    label: 'Refactor without breaking behaviour',
+    when: 'A job for the flagship model. Always tell it what must NOT change.',
+    content: `Refactor this [LANGUAGE] code for [GOAL: readability / performance / fewer dependencies].
+
+[PASTE THE CODE]
+
+Hard rules:
+- The public behaviour must not change. Same inputs, same outputs.
+- Do not add new dependencies.
+- [Any other constraint that matters]
+
+Show me the refactored version, then a short bullet list of exactly what changed and why. Flag anything I should test before trusting it.`
+  }
+]
+
+export default function ClaudeForCoding() {
+  const [copiedId, setCopiedId] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopiedId(id)
+    setTimeout(() => setCopiedId(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude for Coding: The Practical Guide (Models, Workflows, Prompts)',
+    description: 'How to use Claude for coding — the three ways to use it, which model to pick, copy-paste prompt templates, and the workflows that actually work. A plain-English starting point.',
+    url: 'https://promptwritingstudio.com/claude-for-coding',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude for coding', 'claude coding', 'is claude good for coding', 'best claude model for coding', 'claude code prompts', 'claude vs chatgpt coding']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude for Coding: The Practical Guide (Models, Workflows, Prompts) | PromptWritingStudio</title>
+        <meta name="description" content="How to use Claude for coding: the three ways to run it, which Claude model to pick, copy-paste prompt templates, and the workflows that actually work. A plain-English starting point." />
+        <meta name="keywords" content="claude for coding, claude coding, is claude good for coding, best claude model for coding, claude code prompts, claude vs chatgpt for coding" />
+        <meta property="og:title" content="Claude for Coding: The Practical Guide" />
+        <meta property="og:description" content="The three ways to use Claude for coding, which model to pick, and copy-paste prompt templates that actually work." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-for-coding" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-for-coding" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude for Coding
+              <span className="block text-[#FFDE59]">Which model, which workflow, which prompt</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                <strong>Using Claude for coding</strong> means one of three things: chatting at claude.ai, calling the API from your own code, or running Claude Code in your terminal. Pick {sonnet.name} as your default model and {opus.name} for hard problems. The quality of what you get back is mostly decided by your prompt — which is the part this guide actually helps with.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              A no-hype starting point: the three ways to use it, how to choose a model, and five copy-paste prompt templates you can use today.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#prompts" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Jump to the prompt templates
+              </a>
+              <a href="#models" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Which model should I use?
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The three ways to use Claude for coding</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              People say "Claude for coding" to mean very different things. They map to three levels of friction. Start at the top and move down as your usage grows.
+            </p>
+
+            <div className="space-y-4">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">1. Claude in chat (claude.ai)</h3>
+                <p className="text-[#333333] mb-3">Copy-paste. You paste code in, read the answer, paste it back into your editor. Zero setup. Best for learning, one-off questions, explaining unfamiliar code, and small scripts. This is where everyone should start.</p>
+                <p className="text-[#333333]"><strong>Good for:</strong> beginners, quick fixes, understanding code, anything you can describe in a paragraph.</p>
+              </div>
+
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">2. The Claude API</h3>
+                <p className="text-[#333333] mb-3">Calling Claude from your own code, paying per token. This is not for writing your code — it is for building apps and automations that use Claude as a feature. If you are asking "how do I use Claude to help me code", this is not the answer; chat or Claude Code is.</p>
+                <p className="text-[#333333]"><strong>Good for:</strong> shipping a product that calls Claude, scripted or high-volume jobs.</p>
+              </div>
+
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">3. Claude Code (terminal agent)</h3>
+                <p className="text-[#333333] mb-3">An agent that runs in your terminal, reads your real files, runs commands, and edits code across your whole project — no copy-paste. This is what you graduate to once you are coding with Claude every day. It is a step up in power and a step up in setup.</p>
+                <p className="text-[#333333]"><strong>Good for:</strong> daily development, multi-file changes, real projects. See the <Link href="/claude-code-guide" className="text-blue-600 underline font-semibold">full Claude Code guide</Link> when you are ready.</p>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Rule of thumb:</strong> if you are reading this, start in chat. Move to <Link href="/claude-code-guide" className="text-blue-600 underline">Claude Code</Link> when copy-pasting between the browser and your editor starts to feel slow. Reach for the API only when you are building software that calls Claude, not when you are coding for yourself.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="models" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Which Claude model is best for coding?</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Anthropic ships three current models. They trade capability against speed and cost. The mistake newcomers make is reaching for the biggest model by default — most coding does not need it, and you pay for the privilege.
+            </p>
+
+            <div className="space-y-4">
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start gap-4">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold px-3 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-sm">Default</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{sonnet.name} — your everyday workhorse</h3>
+                    <p className="text-[#333333]">Fast, cheap enough to run all day, and capable enough for the large majority of coding tasks: writing functions, tests, small features, and routine debugging. Make this your default and only escalate when the output is not good enough.</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start gap-4">
+                  <span className="bg-[#1A1A1A] text-white font-bold px-3 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-sm">Hard</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{opus.name} — for the hard problems</h3>
+                    <p className="text-[#333333]">Anthropic's most capable model, with a 1M-token context window. Reach for it on gnarly bugs, large refactors, and planning features that touch many files. It costs more, so use it deliberately — not as a reflex.</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start gap-4">
+                  <span className="bg-gray-200 text-[#1A1A1A] font-bold px-3 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-sm">Volume</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{haiku.name} — fast and cheap</h3>
+                    <p className="text-[#333333]">The small, fast model for high-volume, low-stakes work: generating test fixtures, classifying code, quick lookups. Rarely your main coding model, but useful for scripted jobs where speed and cost matter more than depth.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                In claude.ai and Claude Code, you often do not pick manually — the product routes your request to a sensible model. Model names and pricing shift over time; for the current lineup and full pricing, see <Link href="/ai-models" className="text-blue-600 underline">the model comparison</Link> and <Link href="/claude-code-pricing" className="text-blue-600 underline">Claude Code pricing</Link>. Weighing Claude against ChatGPT? Read <Link href="/claude-vs-chatgpt" className="text-blue-600 underline">Claude vs ChatGPT</Link>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="prompts" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Five copy-paste prompt templates for coding</h2>
+              <p className="text-xl text-[#333333] max-w-3xl mx-auto">
+                The single biggest lever on Claude's coding output is the prompt, not the model. These work in chat or Claude Code. Fill in the brackets, paste the real code, and be specific about what must <em>not</em> change.
+              </p>
+            </div>
+
+            <div className="space-y-8">
+              {promptTemplates.map(template => (
+                <div key={template.id} className="bg-[#F9F9F9] rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="p-6 border-b border-gray-200">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{template.label}</h3>
+                    <p className="text-[#333333]">{template.when}</p>
+                  </div>
+                  <div className="relative">
+                    <pre className="bg-[#1A1A1A] text-green-400 p-6 overflow-x-auto font-mono text-sm leading-relaxed whitespace-pre-wrap">{template.content}</pre>
+                    <button
+                      onClick={() => copyToClipboard(template.content, template.id)}
+                      className="absolute top-4 right-4 bg-[#FFDE59] text-[#1A1A1A] text-xs font-semibold px-3 py-1.5 rounded hover:bg-[#E5C84F] transition"
+                    >
+                      {copiedId === template.id ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-10 text-center">
+              <p className="text-lg text-[#333333] mb-4">Want more coding prompts in this fill-in-the-blank style?</p>
+              <Link href="/chatgpt-prompts-for/coding" className="inline-block bg-white border-2 border-[#1A1A1A] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#F9F9F9] transition">
+                Browse the coding prompt templates
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">A before-and-after that shows why prompts matter</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Same model, same task, two prompts. The difference is entirely in what context you hand over.
+            </p>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white p-6 rounded-lg border-l-4 border-red-300">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-3">Weak prompt</h3>
+                <p className="font-mono text-sm text-[#333333] bg-[#F9F9F9] p-4 rounded mb-4">"Fix my login function, it's broken."</p>
+                <p className="text-[#333333]">Claude has to guess the language, the framework, what "broken" means, and what the code looks like. It will invent a plausible login function that almost certainly does not match yours — and may use a library you do not have.</p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border-l-4 border-green-400">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-3">Strong prompt</h3>
+                <p className="font-mono text-sm text-[#333333] bg-[#F9F9F9] p-4 rounded mb-4">"Here's my Node/Express login handler [paste]. It returns 500 on valid credentials. Error: [paste stack trace]. Using bcrypt 5.x. Find the root cause and give the minimal fix."</p>
+                <p className="text-[#333333]">Now Claude has the real code, the real error, and the versions. It can pinpoint the actual bug instead of rewriting your auth from scratch.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The failure mode to watch for: confident guessing</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-5">
+                The most common way Claude lets you down is not writing bad code — it is writing <em>plausible</em> code for a situation you did not fully describe. Asked about a library it is unsure of, Claude will invent a clean-looking function name and signature rather than say it does not know. The result compiles in your head and fails in your terminal.
+              </p>
+              <p className="text-lg text-[#333333] mb-5">Three habits keep you out of that trap:</p>
+              <ul className="space-y-4 text-lg text-[#333333]">
+                <li><strong>Paste the real thing.</strong> Real code, real error, real version numbers. Never describe what the code does when you can show it.</li>
+                <li><strong>Constrain the change.</strong> Tell Claude what must not change ("same inputs and outputs", "no new dependencies"). Open-ended requests invite rewrites you did not want.</li>
+                <li><strong>Run it before you trust it.</strong> Treat every snippet as a draft until your tests or your terminal say otherwise. Then feed the actual error back in rather than starting over.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">A simple workflow once you are past copy-paste</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              When chat starts feeling slow, this is the loop most people settle into with Claude Code. It keeps you in control while letting the agent do the typing.
+            </p>
+
+            <div className="space-y-4">
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">1. Ask for a plan first, not code</h3>
+                <p className="text-[#333333]">Have Claude lay out how it would tackle the task before it writes anything. Read the plan, correct what it got wrong, then let it execute. This catches wrong assumptions before they become wrong code.</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">2. Work in small steps</h3>
+                <p className="text-[#333333]">One function, one bug, one file at a time. Small changes are easy to review and easy to roll back. Sprawling "do everything" requests are where things quietly go off the rails.</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">3. Give it persistent context</h3>
+                <p className="text-[#333333]">In Claude Code, a <Link href="/claude-md-playbook" className="text-blue-600 underline">CLAUDE.md file</Link> tells the agent your conventions, commands, and gotchas every session, so you stop repeating yourself and it stops guessing.</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">4. Review every change</h3>
+                <p className="text-[#333333]">You are still the engineer. Read the diff, run the tests, and feed real errors back in. Claude is a fast pair, not a replacement for judgement.</p>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                Ready to set this up properly? Start with the <Link href="/claude-code-guide" className="text-blue-600 underline">Claude Code guide</Link>, follow the <Link href="/claude-code-skills/install-guide" className="text-blue-600 underline">install walkthrough</Link>, and if you are weighing tools, read <Link href="/claude-code-vs-cursor" className="text-blue-600 underline">Claude Code vs Cursor</Link> or the wider field of <Link href="/claude-code-alternatives" className="text-blue-600 underline">Claude Code alternatives</Link>. Want our hands-on take first? See the <Link href="/claude-code-review" className="text-blue-600 underline">Claude Code review</Link>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions people ask before they get started with Claude for coding.</p>
+
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              The model is the easy part. The prompt is the skill.
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              You have seen it on this page: same model, wildly different output depending on how you ask. Prompt Writing Studio teaches the prompting frameworks behind these templates — so you get production-ready results from Claude on the first try, not the fifth.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+              <Link href="/chatgpt-prompt-templates" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Browse free prompt templates
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-for-writing.js
+++ b/pages/claude-for-writing.js
@@ -1,0 +1,401 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import { getAIModelById } from '../lib/ai-models'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+// Pull live model facts from the central JSON so names/prices update in one place.
+const opus = getAIModelById('claude-opus-4-7')
+const sonnet = getAIModelById('claude-sonnet-4-6')
+const haiku = getAIModelById('claude-haiku-4-5-20251001')
+
+const modelPicker = [
+  {
+    model: opus.display_name,
+    use: 'Hard, high-stakes writing',
+    detail: `Book chapters, long essays, dense technical docs, anything where you want the model to hold a 30-page argument in its head. ${opus.context_window_label} context. Slowest and priciest of the three, worth it when quality matters more than speed.`
+  },
+  {
+    model: sonnet.display_name,
+    use: 'Daily writing workhorse',
+    detail: `The right default for most writing tasks: blog drafts, newsletters, rewrites, outlines, email. Fast, ${sonnet.context_window_label} context, and good enough that most writers never need to reach for Opus. This is the one to live in.`
+  },
+  {
+    model: haiku.display_name,
+    use: 'Bulk, low-stakes text',
+    detail: `Headlines, subject-line variations, tagging, quick reformatting, first-pass summaries of short pieces. ${haiku.context_window_label} context. Use it when you need volume and speed and the output gets a human edit anyway.`
+  }
+]
+
+const beforeAfter = {
+  weak: 'Write a blog post about email marketing.',
+  weakResult: 'A generic 600-word listicle: "In today\'s digital landscape, email marketing remains a powerful tool..." Bland intro, five obvious tips, no point of view.',
+  strong: `You are writing for solo consultants who already send a monthly newsletter but get almost no replies.
+
+Write a 900-word blog post on why their emails get ignored and three specific fixes.
+
+Constraints:
+- Open with a concrete failure scenario, not a definition.
+- Plain, direct sentences. No "in today's digital landscape" openers.
+- One example per fix, drawn from a one-person consulting business.
+- End with a single action the reader can take this week.
+- Voice: dry, practical, slightly contrarian. Short paragraphs.`,
+  strongResult: 'A post that opens on a consultant staring at a 0.4% reply rate, names the real cause (writing to a list like it\'s a billboard), and gives three fixes with concrete examples. On-voice, useful, publishable with a light edit.'
+}
+
+const voiceSteps = [
+  {
+    title: '1. Give it a sample, not an adjective',
+    body: '"Write in a friendly tone" means almost nothing. Paste 300-500 words you have already written and say: "Match the voice in this sample — sentence length, rhythm, vocabulary." Claude is unusually good at mimicking a concrete sample. Adjectives produce generic prose; samples produce yours.'
+  },
+  {
+    title: '2. Name what to avoid',
+    body: 'Tell it the patterns you hate. "No em dashes. No rhetorical questions as openers. Never start a sentence with \'In today\'s.\' Avoid the words leverage, robust, seamless." A short ban-list removes most of the AI-tells in one move.'
+  },
+  {
+    title: '3. Set the reader, not just the topic',
+    body: 'Voice is partly a function of audience. "Writing for a skeptical CFO" and "writing for a first-time founder" produce different prose from the same instruction. Define the reader and the register follows.'
+  },
+  {
+    title: '4. Build a reusable style block',
+    body: 'Once you find a voice that works, save the instructions as a block you paste at the top of every chat — or pin it in a Claude Project so it applies automatically. This is the difference between re-explaining your voice daily and having it on tap.'
+  }
+]
+
+const editSteps = [
+  {
+    title: 'Line edit without rewriting',
+    body: 'Paste your draft and say: "Line-edit for clarity and rhythm. Keep my voice and my structure. Do not add ideas, do not reorder paragraphs. Return the edited text, then a short bullet list of the changes and why." The constraints stop Claude from quietly turning your piece into its piece.'
+  },
+  {
+    title: 'Critique before it touches a word',
+    body: 'Sometimes you want diagnosis, not surgery. "Read this draft as a tough editor. List the three weakest paragraphs and why. Do not rewrite anything yet." Then you fix the real problems instead of accepting a smooth rewrite that buries them.'
+  },
+  {
+    title: 'Tighten to a word count',
+    body: '"Cut this from 1,100 words to 800 without losing any of the three main arguments. Show me what you cut." The "show me what you cut" clause keeps you in control of the edit instead of trusting it blind.'
+  },
+  {
+    title: 'Catch your tics',
+    body: '"List every word or phrase I use more than twice, and every sentence longer than 30 words." Claude is a fast, honest mirror for the habits you stop noticing in your own writing.'
+  }
+]
+
+const longFormSteps = [
+  {
+    title: 'Outline first, in a separate turn',
+    body: 'Do not ask for a 3,000-word piece in one shot. Get the outline first: "Give me a section-by-section outline with a one-line purpose for each section." Approve or fix the structure, then write section by section. The result holds together; the one-shot version drifts.'
+  },
+  {
+    title: 'Use the long context, but anchor it',
+    body: `Opus and Sonnet both ship with ${opus.context_window_label} context, so you can paste an entire transcript, research dump, or prior draft. But say what to do with it: "Use the attached interview only as source material. Do not invent quotes. Cite the speaker by name." Long context plus a tight instruction is where Claude earns its keep for long-form.`
+  },
+  {
+    title: 'Write in passes, not one giant prompt',
+    body: 'Pass one: get the argument down, ugly but complete. Pass two: "Now improve flow and transitions, keep the content." Pass three: line edit. Separating drafting from polishing produces better writing than asking for "a great finished post" in a single turn.'
+  },
+  {
+    title: 'Keep a running brief in a Project',
+    body: 'For a book or a long series, a Claude Project holds your style guide, character notes, or argument spine across chats. You stop re-establishing context every session, and consistency across chapters improves noticeably.'
+  }
+]
+
+const failures = [
+  {
+    title: 'Asking for "engaging" or "compelling" copy',
+    fix: 'These words push the model toward hype and filler. Ask for specific qualities instead: "short sentences," "one concrete example per point," "no adjectives in the first paragraph." Specific beats flattering every time.'
+  },
+  {
+    title: 'Letting it rewrite when you wanted an edit',
+    fix: 'If you paste a draft and say "improve this," Claude will often rebuild it in its own voice. Add "keep my voice and structure; line-edit only" whenever you want a polish, not a replacement.'
+  },
+  {
+    title: 'Accepting invented facts in non-fiction',
+    fix: 'Claude can produce confident, plausible, wrong details — fake stats, fake quotes. For anything factual, instruct "only use facts from the source I gave you; flag anything you are unsure about," and verify names, numbers, and dates yourself.'
+  },
+  {
+    title: 'Starting from a blank prompt every time',
+    fix: 'Re-typing your voice and rules in each chat is slow and inconsistent. Save a reusable style block or a Project. The single biggest quality-of-life upgrade in writing with Claude is not re-explaining yourself.'
+  }
+]
+
+const faqs = [
+  {
+    question: 'Which Claude model is best for writing?',
+    answer: `For most writing, ${sonnet.display_name} is the right default — fast, cheap enough for daily use, and capable enough for blog posts, newsletters, rewrites, and outlines, with a ${sonnet.context_window_label} context window. Reach for ${opus.display_name} when the task is genuinely hard: long-form essays, book chapters, or dense documents where you want the model holding a long argument together. ${haiku.display_name} is for high-volume, low-stakes text like headline variations and quick summaries. In claude.ai, the app often routes you to the right model automatically, but you can pick manually when it matters.`
+  },
+  {
+    question: 'How do I get Claude to write in my voice?',
+    answer: 'Give it a concrete sample of your writing rather than adjectives. Paste 300-500 words and say "match the voice in this sample." Then add a short ban-list of patterns you dislike (em dashes, rhetorical-question openers, words like "leverage" or "seamless"), and define the reader you are writing for. Adjectives like "friendly" produce generic prose; a real sample plus a ban-list produces something close to your actual voice.'
+  },
+  {
+    question: 'Is Claude good for editing my own writing?',
+    answer: 'Yes, and it is often more useful as an editor than as a first-drafter. The key is constraint: tell it "line-edit for clarity, keep my voice and structure, do not add ideas," and ask it to list the changes it made. You can also use it for critique without rewriting ("name the three weakest paragraphs and why"), for cutting to a word count, and for catching repeated words and overlong sentences you have stopped noticing.'
+  },
+  {
+    question: 'Can Claude write long-form content like a full article or book chapter?',
+    answer: `Yes. Claude is one of the stronger tools for long-form because ${opus.display_name} and ${sonnet.display_name} ship with ${opus.context_window_label} context windows. The trick is not to ask for the whole thing in one prompt. Get an outline first, approve the structure, then write section by section. For a book or long series, keep your style guide and notes in a Claude Project so consistency holds across chats.`
+  },
+  {
+    question: 'Will Claude make my writing sound like AI?',
+    answer: 'It can, if you let it. Out of the box, Claude reaches for words like "leverage," "robust," and "seamless," and openers like "In today\'s fast-paced world." You remove most of this with a ban-list in your prompt and by giving it a sample of your real voice to match. The default output is the AI-sounding version; the steered output is much closer to human writing.'
+  },
+  {
+    question: 'Is the free version of Claude good enough for writing?',
+    answer: 'For occasional writing, yes. Claude Free runs on Sonnet with a daily message cap, which is fine for the odd blog post or rewrite. If you write daily or work on long pieces, Claude Pro at $20/month gives you higher limits, access to Opus, Projects, and Artifacts. For most working writers the Pro tier pays for itself quickly in volume alone.'
+  },
+  {
+    question: 'How is writing with Claude different from writing with ChatGPT?',
+    answer: 'Most professional writers find Claude produces more natural prose out of the box and follows tone instructions more faithfully, which makes it the stronger choice for long-form and nuanced rewrites. ChatGPT is faster for short-form marketing copy and pairs with DALL-E for images. The honest test is to draft the same piece in both and keep the voice you prefer. Good prompting transfers between them either way.'
+  },
+  {
+    question: 'What is the best prompt structure for writing tasks in Claude?',
+    answer: 'A reliable structure has four parts: role and reader ("you are writing for skeptical CFOs"), the task and length ("a 900-word post on X"), constraints ("short sentences, one example per point, no em dashes"), and a voice anchor (a pasted sample to match). Vague prompts like "write a blog post about email marketing" produce generic filler; a structured prompt produces something publishable with a light edit.'
+  }
+]
+
+export default function ClaudeForWriting() {
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude for Writing (2026): The Practical Guide to Drafting, Voice, and Editing',
+    description: 'How to use Claude for writing: which model to pick, prompting for your voice and tone, editing your own drafts, and handling long-form. Copy-ready prompt templates and a before/after example.',
+    url: 'https://promptwritingstudio.com/claude-for-writing',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['Claude for writing', 'using Claude for writing', 'Claude writing prompts', 'best Claude model for writing', 'Claude editing', 'write in my voice with Claude']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude for Writing (2026): The Practical Guide to Drafting, Voice & Editing | PromptWritingStudio</title>
+        <meta name="description" content="Claude for writing, the practical way: which model to pick, how to prompt for your tone and voice, editing your own drafts, and long-form. With copy-ready templates and a before/after example." />
+        <meta name="keywords" content="Claude for writing, using Claude for writing, Claude writing prompts, best Claude model for writing, Claude editing, write in my voice with Claude, Claude long-form writing" />
+        <meta property="og:title" content="Claude for Writing (2026): The Practical Guide to Drafting, Voice & Editing" />
+        <meta property="og:description" content="How to actually use Claude for writing — model choice, voice prompting, editing, and long-form, with copy-ready templates." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-for-writing" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-for-writing" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude for Writing
+              <span className="block text-[#FFDE59]">Model choice, voice, editing, and long-form — the practical version</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                <strong>Short answer:</strong> Claude is the AI most professional writers prefer for serious work because it produces more natural prose and follows tone instructions faithfully. To use Claude for writing well, default to {sonnet.display_name} for daily drafting, give it a sample of your real voice instead of adjectives, and treat it as an editor with tight constraints rather than a one-shot author. The model matters less than the prompt.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              This is the guide I wish I had the first week I used Claude to draft — what to pick, how to prompt, and the mistakes that make output sound like a robot.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#model" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Which model to use
+              </a>
+              <a href="#voice" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Prompting for your voice
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* Which model */}
+        <section id="model" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Which Claude model should you use for writing?</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Claude comes in three tiers. For writing, the honest answer is that you will live in the middle one and rarely need the top. Here is the mental model.
+            </p>
+            <div className="space-y-5">
+              {modelPicker.map((m, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                  <div className="flex flex-wrap items-start justify-between gap-4 mb-3">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] flex-1 min-w-0">{m.model}</h3>
+                    <span className="bg-[#FFDE59] text-[#1A1A1A] text-sm font-bold px-3 py-1 rounded-full whitespace-nowrap">{m.use}</span>
+                  </div>
+                  <p className="text-[#333333]">{m.detail}</p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-6 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>The shortcut:</strong> in claude.ai the app usually routes you to the right model automatically. Default to {sonnet.display_name} for everyday writing and only switch up to {opus.display_name} when a piece is genuinely hard. If you want help deciding by task and budget, the <Link href="/calculators/claude-model-selector" className="text-[#1A1A1A] font-semibold underline">Claude model selector</Link> walks you through it.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Before / after */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Before and after: the same task, two prompts</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              The single biggest lever on writing quality is the prompt, not the model. Here is the same blog-post request, lazy versus scoped.
+            </p>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white p-6 rounded-lg border-2 border-gray-200">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-3">Weak prompt</h3>
+                <pre className="whitespace-pre-wrap text-sm text-[#333333] bg-[#F9F9F9] p-4 rounded mb-4 font-mono">{beforeAfter.weak}</pre>
+                <p className="text-[#666666] text-sm"><strong>What you get:</strong> {beforeAfter.weakResult}</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border-2 border-[#FFDE59]">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-3">Strong prompt</h3>
+                <pre className="whitespace-pre-wrap text-sm text-[#333333] bg-[#F9F9F9] p-4 rounded mb-4 font-mono">{beforeAfter.strong}</pre>
+                <p className="text-[#666666] text-sm"><strong>What you get:</strong> {beforeAfter.strongResult}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Voice */}
+        <section id="voice" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">How do you get Claude to write in your voice?</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Voice is where most people give up on AI writing — the output is competent but generic. Four moves fix that.
+            </p>
+            <div className="space-y-5">
+              {voiceSteps.map((s, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 rounded-lg border-l-4 border-[#FFDE59]">
+                  <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">{s.title}</h3>
+                  <p className="text-[#333333]">{s.body}</p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 bg-[#1A1A1A] p-6 rounded-lg">
+              <p className="text-sm font-semibold text-[#FFDE59] mb-2">Copy-ready voice block</p>
+              <pre className="whitespace-pre-wrap text-sm text-gray-100 font-mono">{`Voice rules for everything I ask you to write:
+- Match the voice in this sample: [paste 300-500 of your words].
+- Short, plain sentences. One idea per sentence where possible.
+- No em dashes. No rhetorical questions as openers.
+- Never start a sentence with "In today's".
+- Ban-list: leverage, robust, seamless, unlock, delve, navigate.
+- Write for: [describe the exact reader].`}</pre>
+            </div>
+          </div>
+        </section>
+
+        {/* Editing */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Using Claude to edit your own writing</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Claude is often more valuable as an editor than as a first-drafter — but only if you constrain it. Tell it to edit, and it will edit. Say "improve this," and it will quietly rewrite your piece in its own voice.
+            </p>
+            <div className="grid md:grid-cols-2 gap-6">
+              {editSteps.map((s, i) => (
+                <div key={i} className="bg-white p-6 rounded-lg border border-gray-200">
+                  <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">{s.title}</h3>
+                  <p className="text-[#333333] text-sm">{s.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Long-form */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Long-form: articles, essays, and book chapters</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Long-form is where Claude pulls ahead, thanks to {opus.context_window_label} context windows on {opus.display_name} and {sonnet.display_name}. But the one-shot "write me a 3,000-word article" prompt always disappoints. Work in passes instead.
+            </p>
+            <div className="space-y-5">
+              {longFormSteps.map((s, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 rounded-lg border-l-4 border-[#FFDE59]">
+                  <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">{s.title}</h3>
+                  <p className="text-[#333333]">{s.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Failure modes */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Four mistakes that make Claude's writing worse</h2>
+            <div className="space-y-5">
+              {failures.map((f, i) => (
+                <div key={i} className="bg-white p-6 rounded-lg border border-gray-200">
+                  <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">{f.title}</h3>
+                  <p className="text-[#333333]"><strong className="text-[#1A1A1A]">Fix:</strong> {f.fix}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Course CTA */}
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              The model is the easy part. The prompting is the skill.
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              Everything on this page is one piece of a larger system: writing prompts that get your voice, your structure, and your standards out of the model every time — without re-explaining yourself. That system is what <a href={COURSE_URL} className="text-[#FFDE59] font-semibold underline">PromptWritingStudio</a> teaches. Not a list of one-off tricks — the repeatable method for writing with AI.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href={COURSE_URL} className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+              <Link href="/model-prompting-guide/claude" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Claude prompting guide
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions writers ask most when they start using Claude.</p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Related */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl text-center">
+            <h2 className="text-2xl md:text-3xl font-bold text-[#1A1A1A] mb-8">Keep going</h2>
+            <div className="flex flex-wrap gap-4 justify-center">
+              <Link href="/claude-vs-chatgpt" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">Claude vs ChatGPT</Link>
+              <Link href="/claude-prompts" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">Claude prompts library</Link>
+              <Link href="/how-to-use-claude" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">How to use Claude</Link>
+              <Link href="/claude-system-prompt" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">Claude system prompts</Link>
+              <Link href="/model-prompting-guide" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">Model prompting guides</Link>
+              <Link href="/ai-prompt-examples" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">AI prompt examples</Link>
+              <Link href="/chatgpt-prompt-templates" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">Prompt templates</Link>
+              <Link href="/ai-prompt-generator" className="bg-white border border-gray-200 px-6 py-3 rounded-lg font-semibold text-[#1A1A1A] hover:border-[#FFDE59] transition">Free prompt generator</Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-projects.js
+++ b/pages/claude-projects.js
@@ -1,0 +1,535 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+const faqs = [
+  {
+    question: "What is a Claude Project?",
+    answer: "A Claude Project is a self-contained workspace inside Claude.ai that bundles three things together: a knowledge base of files you upload, a set of custom instructions Claude follows in every chat, and the chat history for that workspace. Instead of re-explaining your style guide, audience, and context in every conversation, you set it once and every chat in the project inherits it. Anthropic describes Projects as having \"their own chat histories and knowledge bases.\""
+  },
+  {
+    question: "Are Claude Projects free?",
+    answer: "Yes, partly. Per Anthropic's documentation, Projects are available to all users, including free accounts, and free users can create a maximum of five projects. However, enhanced project knowledge with RAG (the retrieval system that lets Claude search across large uploaded knowledge bases) is only available on paid plans: Claude Pro, Max, Team, or Enterprise. So a free user can build a project, but the document-search capacity is more limited."
+  },
+  {
+    question: "How big can a Claude Project knowledge base be?",
+    answer: "Claude's context window is 200K tokens, which is roughly 150,000 words or about 500 pages of text. On paid plans, Anthropic says RAG mode can \"expand capacity by up to 10x\" so Claude retrieves only the relevant chunks of your uploaded files rather than loading everything at once. For writers, that means you can upload a full back catalogue of past articles, a brand style guide, and reference material without blowing the limit."
+  },
+  {
+    question: "What is the difference between Claude Projects and custom instructions?",
+    answer: "Profile custom instructions apply to every chat across your whole account and have roughly a 1,500-character limit. Project instructions apply only to chats inside that one project and support far more (around 8,000 characters). The practical split: put your identity and default tone in your profile, and put domain-specific rules (this client's voice, this newsletter's format, this series' constraints) in each project."
+  },
+  {
+    question: "Can I use Claude Projects for writing instead of coding?",
+    answer: "Yes. While developers use Projects for codebases, the feature is just as useful for writers. Upload your style guide, three of your best past articles, and your audience notes; set custom instructions describing your voice and structure rules; then every draft, outline, and edit you request inside that project comes back already aligned to your standards. You stop re-teaching Claude your style on every single chat."
+  },
+  {
+    question: "Do Claude Projects remember previous chats?",
+    answer: "Each project keeps its own chat history, so you can return to past conversations within that workspace. However, a brand-new chat does not automatically read the content of your other chats. What every new chat does inherit is the project's knowledge base and custom instructions. If you want continuity of decisions across chats, record those decisions in a file and add it to the knowledge base."
+  },
+  {
+    question: "Can I share a Claude Project with my team?",
+    answer: "Sharing and collaboration features are limited to Team and Enterprise plans, where you can grant permission-based access and let multiple people contribute to the same project. On Pro and free plans, a project is private to your account. A common workaround for solo writers and small teams is to document the project's instructions and knowledge files so they can be recreated by a collaborator."
+  }
+]
+
+const setupSteps = [
+  {
+    title: 'Create the project and name it for the job',
+    body: 'In the Claude.ai sidebar, click Projects, then Create project. Name it after the recurring job it serves, not the topic. "Weekly Newsletter" or "Acme Corp blog" beats "Writing" because you will reuse the workspace for every instance of that job.'
+  },
+  {
+    title: 'Add custom instructions (the voice and the rules)',
+    body: 'Open the project, find the instructions panel, and write the rules Claude should follow in every chat here: who the audience is, the tone, the structure, the words to avoid, and how you want drafts delivered. This field holds far more than profile instructions, so be specific. Treat it like onboarding a new ghostwriter.'
+  },
+  {
+    title: 'Upload your knowledge base',
+    body: 'Add the documents that define good output: your style guide, two or three of your strongest published pieces, your audience research, product fact sheets, and any glossary of terms. Claude reads these to ground its writing in your actual standards rather than generic best practice.'
+  },
+  {
+    title: 'Start a chat and request work',
+    body: 'Open a new chat inside the project and give it a normal request: "Draft a 700-word post on X for our audience." The draft arrives already shaped by your instructions and knowledge. Iterate in that chat, and start a fresh chat for the next piece. All of them inherit the same setup.'
+  }
+]
+
+const writerWorkflows = [
+  {
+    name: 'The newsletter project',
+    setup: 'Knowledge base: last 5 issues, subscriber persona, your section structure. Instructions: word count, voice, banned phrases, sign-off format.',
+    payoff: 'Every issue starts from your established format and voice. You spend your time on the idea, not re-teaching Claude your house style.'
+  },
+  {
+    name: 'The client voice project',
+    setup: 'One project per client. Knowledge base: their brand guidelines, three approved past pieces, their product list. Instructions: their tone, their audience, their no-go words.',
+    payoff: 'You switch clients by switching projects, and the voice switches with you. No more cross-contaminating one client\'s tone into another\'s draft.'
+  },
+  {
+    name: 'The book or long-form project',
+    setup: 'Knowledge base: your outline, character or argument notes, completed chapters. Instructions: POV, tense, style constraints, what is canon.',
+    payoff: 'Claude keeps continuity with what you have already written instead of contradicting earlier chapters or drifting in tone.'
+  },
+  {
+    name: 'The repurposing project',
+    setup: 'Knowledge base: a long-form source piece plus your platform rules. Instructions: how a LinkedIn post, a thread, and a newsletter blurb should each be shaped.',
+    payoff: 'Drop in one article and pull out five platform-native variants that already match how each channel should sound.'
+  }
+]
+
+const beforeAfter = {
+  before: 'Write me a blog post about email marketing for small businesses. Make it sound professional but friendly. Around 800 words. Don\'t be too salesy. Our audience is non-technical owners. Use short paragraphs and a clear takeaway at the end. Avoid jargon like "leverage" and "synergy"...',
+  after: 'Draft an 800-word post on email marketing for our audience.'
+}
+
+export default function ClaudeProjects() {
+  const [copied, setCopied] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopied(id)
+    setTimeout(() => setCopied(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Projects: How to Set Up a Custom Workspace for Writing (2026)',
+    description: 'A practical guide to Claude Projects for writers. What they are, how to set one up, how to use project knowledge and custom instructions, and four workflows that save hours of re-explaining your style.',
+    url: 'https://promptwritingstudio.com/claude-projects',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude projects', 'claude projects guide', 'how to use claude projects', 'claude project knowledge', 'claude custom instructions', 'claude projects for writers']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Projects: How to Set Up a Custom Writing Workspace (2026) | PromptWritingStudio</title>
+        <meta name="description" content="What Claude Projects are and how to set one up for writing. Use project knowledge and custom instructions so every chat matches your voice. Step-by-step guide with writer workflows." />
+        <meta name="keywords" content="claude projects, claude projects guide, how to use claude projects, claude project knowledge, claude custom instructions, claude projects for writers, claude workspace" />
+        <meta property="og:title" content="Claude Projects: How to Set Up a Custom Writing Workspace (2026)" />
+        <meta property="og:description" content="A practical guide to Claude Projects for writers: knowledge base, custom instructions, setup steps, and four workflows that stop you re-teaching Claude your style." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-projects" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-projects" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+        />
+      </Head>
+
+      <Layout>
+        {/* Hero */}
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Projects:
+              <span className="block text-[#FFDE59]">Set Up a Workspace That Knows Your Style</span>
+            </h1>
+
+            {/* Answer Block - AEO */}
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                Claude Projects are self-contained workspaces inside Claude.ai that combine a knowledge base of uploaded files, a set of custom instructions, and their own chat history. You set your audience, voice, and rules once, and every chat in the project follows them automatically. For writers, that means you stop re-explaining your style in every conversation. Projects are available on free and paid plans; free accounts can create up to five.
+              </p>
+            </div>
+
+            <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
+              Most guides to Claude Projects are written for developers managing code. This one is written for writers managing voice, clients, and deadlines.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a
+                href="#setup"
+                className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200"
+              >
+                Jump to Setup
+              </a>
+              <a
+                href="#workflows"
+                className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200"
+              >
+                See Writer Workflows
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* What is a Claude Project */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              What is a Claude Project?
+            </h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-6">
+                A Claude Project is a workspace inside <a href="https://claude.ai" target="_blank" rel="noopener noreferrer" className="text-[#1A1A1A] underline hover:no-underline">Claude.ai</a> that holds three things together: a knowledge base of files you upload, custom instructions Claude follows in every chat, and the chat history for that workspace. Anthropic describes Projects as &quot;self-contained workspaces with their own chat histories and knowledge bases.&quot;
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                The problem a project solves is repetition. Without one, you open a fresh Claude chat and re-explain who your audience is, what tone you want, how long the piece should be, and which words to avoid. You do that every single time. A project lets you define all of that once. Every new chat inside the project inherits it.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                Think of it as the difference between briefing a new freelancer on every job and having one writer who already knows the brand. The knowledge base is their reference shelf. The custom instructions are their standing brief. The chat history is their record of past work for you.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                Projects are available to all Claude users, including free accounts, though some capabilities differ by plan. We cover the plan differences below so you know what you actually get.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* The two building blocks */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+                The Two Building Blocks: Knowledge and Instructions
+              </h2>
+              <p className="text-xl text-[#333333] max-w-3xl mx-auto">
+                Everything a project does well comes from these two parts. Get them right and the rest follows.
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-8">
+              <div className="bg-white p-8 rounded-lg border border-gray-200">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">Project Knowledge (the reference shelf)</h3>
+                <p className="text-[#333333] mb-4">
+                  The knowledge base is where you upload documents that define good output: your style guide, your best past articles, audience research, product facts, a glossary. Claude reads these to ground its writing in your real standards instead of generic advice.
+                </p>
+                <p className="text-[#333333] mb-4">
+                  Claude&apos;s context window is 200K tokens, roughly 150,000 words or about 500 pages. On paid plans, Anthropic says RAG mode can &quot;expand capacity by up to 10x,&quot; so Claude retrieves only the relevant parts of large knowledge bases rather than loading everything at once.
+                </p>
+                <p className="text-sm text-[#666666]">
+                  <strong>Writer move:</strong> upload three of your strongest pieces, not thirty mediocre ones. Claude imitates what it sees. Feed it your best.
+                </p>
+              </div>
+
+              <div className="bg-white p-8 rounded-lg border border-gray-200">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">Custom Instructions (the standing brief)</h3>
+                <p className="text-[#333333] mb-4">
+                  Project instructions are the rules Claude follows in every chat inside the project. Anthropic notes you can &quot;define project instructions for each project to further tailor Claude&apos;s responses,&quot; from tone to perspective.
+                </p>
+                <p className="text-[#333333] mb-4">
+                  These hold far more than profile-level instructions (project instructions support roughly 8,000 characters versus about 1,500 for your account profile), so you can be genuinely specific about voice, structure, and constraints.
+                </p>
+                <p className="text-sm text-[#666666]">
+                  <strong>Writer move:</strong> profile for identity and default tone; project instructions for the domain-specific rules of this client, newsletter, or series.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Before / after */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+              Why It Matters: One Prompt, Before and After
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              The same request, written for a blank Claude chat versus a properly configured project. The project absorbs everything you would otherwise have to type every time.
+            </p>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <p className="text-sm font-bold text-[#666666] uppercase tracking-wide mb-3">Weak: blank chat, every detail crammed in</p>
+                <p className="text-[#333333] font-mono text-sm leading-relaxed">{beforeAfter.before}</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border-2 border-[#FFDE59]">
+                <p className="text-sm font-bold text-[#1A1A1A] uppercase tracking-wide mb-3">Strong: inside a configured project</p>
+                <p className="text-[#333333] font-mono text-sm leading-relaxed mb-4">{beforeAfter.after}</p>
+                <p className="text-sm text-[#666666]">
+                  The audience, tone, length, paragraph style, banned words, and takeaway format all live in the project. You only type what is unique to this piece.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Setup */}
+        <section id="setup" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              How to Set Up a Claude Project (Step by Step)
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Setup takes about ten minutes and you do it once per recurring job. Here is the order that works.
+            </p>
+
+            <div className="space-y-6">
+              {setupSteps.map((step, index) => (
+                <div key={index} className="bg-white p-6 rounded-lg border border-gray-200">
+                  <div className="flex items-start">
+                    <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mr-4 mt-1">{index + 1}</span>
+                    <div className="flex-1">
+                      <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{step.title}</h3>
+                      <p className="text-[#333333]">{step.body}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Tip:</strong> once a project produces work you are happy with, duplicate it as the template for the next client or series. You inherit the structure and only swap the specifics, which is far faster than building from scratch each time.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Custom instructions template */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              A Fill-in-the-Blank Custom Instructions Template
+            </h2>
+            <p className="text-lg text-[#333333] mb-6">
+              Paste this into your project instructions and replace the bracketed parts. It covers the things Claude most often gets wrong when it does not know your context.
+            </p>
+
+            <div className="bg-[#1A1A1A] text-green-400 p-6 rounded-lg font-mono text-sm overflow-x-auto relative">
+              <button
+                onClick={() => copyToClipboard(
+`You are writing for [PUBLICATION / CLIENT].
+
+AUDIENCE: [who reads this, their level of expertise, what they care about].
+
+VOICE: [e.g. direct, warm, plain-spoken. First person or second person. Contractions allowed?].
+
+STRUCTURE: [opening style, paragraph length, use of subheads, how every piece should end].
+
+WORD COUNT: default to [N] words unless I say otherwise.
+
+ALWAYS: [non-negotiables, e.g. one clear takeaway, concrete examples, short paragraphs].
+
+NEVER: [banned words and habits, e.g. no "leverage", "unlock", "game-changer", no fluffy intros].
+
+DELIVERY: give me the draft only, no preamble, unless I ask for options.`,
+                  'template'
+                )}
+                className="absolute top-3 right-3 text-gray-400 hover:text-white text-xs bg-gray-700 px-2 py-1 rounded"
+              >
+                {copied === 'template' ? 'Copied' : 'Copy'}
+              </button>
+              <pre className="whitespace-pre-wrap">{`You are writing for [PUBLICATION / CLIENT].
+
+AUDIENCE: [who reads this, their level of expertise, what they care about].
+
+VOICE: [e.g. direct, warm, plain-spoken. First person or second person. Contractions allowed?].
+
+STRUCTURE: [opening style, paragraph length, use of subheads, how every piece should end].
+
+WORD COUNT: default to [N] words unless I say otherwise.
+
+ALWAYS: [non-negotiables, e.g. one clear takeaway, concrete examples, short paragraphs].
+
+NEVER: [banned words and habits, e.g. no "leverage", "unlock", "game-changer", no fluffy intros].
+
+DELIVERY: give me the draft only, no preamble, unless I ask for options.`}</pre>
+            </div>
+
+            <p className="text-[#333333] mt-6">
+              For more reusable starting points you can drop straight into a project, see our <Link href="/how-to-use-claude" className="text-[#1A1A1A] underline hover:no-underline">guide to using Claude</Link> and the broader <Link href="/chatgpt-prompt-templates" className="text-[#1A1A1A] underline hover:no-underline">prompt template library</Link>.
+            </p>
+          </div>
+        </section>
+
+        {/* Writer workflows */}
+        <section id="workflows" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+                Four Claude Project Workflows for Writers
+              </h2>
+              <p className="text-xl text-[#333333] max-w-3xl mx-auto">
+                Each is one project you set up once and reuse for every instance of that job.
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-8">
+              {writerWorkflows.map((flow, index) => (
+                <div key={index} className="bg-white p-8 rounded-lg border border-gray-200">
+                  <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">{flow.name}</h3>
+                  <p className="text-[#333333] mb-4"><strong className="text-[#1A1A1A]">Set up:</strong> {flow.setup}</p>
+                  <p className="text-[#333333]"><strong className="text-[#1A1A1A]">Payoff:</strong> {flow.payoff}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Known failure mode */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              The Mistake Most People Make With Claude Projects
+            </h2>
+            <p className="text-lg text-[#333333] mb-6">
+              The common failure is treating the knowledge base like a junk drawer. People upload every document they own, assume more context is better, and then wonder why drafts feel muddled.
+            </p>
+            <p className="text-lg text-[#333333] mb-6">
+              Claude imitates what you give it. Upload thirty average articles and you get average writing back. Upload your three best pieces and a tight style guide, and the output sharpens. Curate the knowledge base the way you would curate a portfolio.
+            </p>
+            <p className="text-lg text-[#333333] mb-6">
+              The second mistake is expecting a new chat to remember decisions made in another chat. Within a project, each chat is separate; what carries across is the knowledge base and instructions, not the conversation. If a decision matters long-term (a naming convention, a positioning call), write it into a file and add it to the knowledge base so it persists.
+            </p>
+            <p className="text-lg text-[#333333]">
+              A related point: Claude Projects are about persistent context, not the in-chat interactive previews. If you want those rich previews of drafts, documents, or code, that is a separate feature covered in our guide to <Link href="/claude-artifacts" className="text-[#1A1A1A] underline hover:no-underline">Claude Artifacts</Link>.
+            </p>
+          </div>
+        </section>
+
+        {/* Plan differences */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">
+              What You Get on Each Plan
+            </h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Projects exist on every plan, but the capacity and collaboration features differ. Here is the breakdown based on Anthropic&apos;s documentation.
+            </p>
+
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Capability</th>
+                    <th className="p-4 text-left font-semibold">Free</th>
+                    <th className="p-4 text-left font-semibold">Pro / Max</th>
+                    <th className="p-4 text-left font-semibold">Team / Enterprise</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="bg-gray-50">
+                    <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A]">Create projects</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Up to 5</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes</td>
+                  </tr>
+                  <tr className="bg-white">
+                    <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A]">Custom instructions</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes</td>
+                  </tr>
+                  <tr className="bg-gray-50">
+                    <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A]">Enhanced knowledge (RAG)</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">No</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes (up to 10x capacity)</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes</td>
+                  </tr>
+                  <tr className="bg-white">
+                    <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A]">Share / collaborate</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">No</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">No</td>
+                    <td className="p-4 border-b border-gray-200 text-[#333333]">Yes</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <p className="text-sm text-[#666666] mt-4">
+              Plan capabilities and limits change. Confirm current details against Anthropic&apos;s support documentation before relying on them. For help choosing between Claude plans, see our <Link href="/claude-pro-vs-max-vs-api" className="text-[#1A1A1A] underline hover:no-underline">Claude Pro vs Max vs API comparison</Link>.
+            </p>
+          </div>
+        </section>
+
+        {/* Course CTA */}
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="bg-[#1A1A1A] rounded-2xl p-8 md:p-12 text-center">
+              <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+                A Project Is Only as Good as Its Instructions
+              </h2>
+              <p className="text-xl text-gray-300 mb-8 max-w-2xl mx-auto">
+                The custom instructions field is where most writers lose the gains. If your prompts are vague, your project produces vague work. PromptWritingStudio teaches you to write the precise, repeatable prompts that make a workspace like this genuinely save you hours.
+              </p>
+              <a
+                href={COURSE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200"
+              >
+                Join Now
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">
+              Frequently Asked Questions
+            </h2>
+            <p className="text-xl text-[#333333] text-center mb-12">
+              Common questions about Claude Projects, answered for writers
+            </p>
+
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Related resources */}
+        <section className="py-16 bg-white border-t border-gray-100">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">
+                More Claude Guides for Writers
+              </h2>
+              <p className="text-lg text-[#333333] max-w-2xl mx-auto">
+                Keep building your Claude setup with these companion guides and tools.
+              </p>
+            </div>
+
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <Link href="/claude-artifacts" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Artifacts Guide</h3>
+                <p className="text-sm text-[#666666]">The in-chat preview feature for drafts, docs, and code, explained for writers.</p>
+              </Link>
+              <Link href="/how-to-use-claude" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">How to Use Claude</h3>
+                <p className="text-sm text-[#666666]">A practical walkthrough of Claude for everyday writing work.</p>
+              </Link>
+              <Link href="/claude-pro-vs-max-vs-api" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Pro vs Max vs API</h3>
+                <p className="text-sm text-[#666666]">Which Claude plan fits how you actually use it.</p>
+              </Link>
+              <Link href="/claude-vs-chatgpt" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude vs ChatGPT</h3>
+                <p className="text-sm text-[#666666]">How the two assistants compare for writing work.</p>
+              </Link>
+              <Link href="/calculators/claude-plan-picker" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Plan Picker</h3>
+                <p className="text-sm text-[#666666]">Interactive calculator that recommends the cheapest plan for your usage.</p>
+              </Link>
+              <Link href="/chatgpt-prompt-templates" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Prompt Template Library</h3>
+                <p className="text-sm text-[#666666]">Hundreds of prompts organised by role and task.</p>
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-prompts.js
+++ b/pages/claude-prompts.js
@@ -1,0 +1,431 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
+
+const faqs = [
+  {
+    question: "What makes a good Claude prompt?",
+    answer: "A good Claude prompt gives Claude a role, one clear action, specific context, and an output format. Claude follows long, structured instructions faithfully, so being explicit pays off: 'Act as a senior copywriter. Rewrite the paragraph below to cut its word count by 30% while keeping the key claim. Return only the rewritten paragraph.' beats 'make this better' almost every time. Vague prompts get competent but generic answers; specific prompts make the quality jump visibly."
+  },
+  {
+    question: "What is the best prompt structure for Claude?",
+    answer: "Role, then task, then context, then format, then the input. Put the long reference material (a document, a transcript, data) near the bottom of the prompt and your instruction near the top or the very end. Anthropic recommends wrapping distinct pieces in XML tags so Claude knows where the instructions stop and the data begins, for example <document>...</document> followed by your question."
+  },
+  {
+    question: "Should I use XML tags in Claude prompts?",
+    answer: "Yes, when a prompt has multiple parts. Anthropic lists XML structuring as a core prompting technique. Tags like <context>, <example>, and <document> stop Claude from confusing your instructions with the material it is supposed to act on. For a one-line request you do not need them; for anything that pastes in a document, transcript, or dataset, they noticeably improve reliability."
+  },
+  {
+    question: "How is prompting Claude different from prompting ChatGPT?",
+    answer: "Claude tends to follow long, detailed, structured instructions more literally, so verbose well-organised prompts that might overwhelm another model often produce its best work. It also responds strongly to XML tags and to a clear system prompt that sets a persistent role. In practice that means you can hand Claude a 200-word brief with sections and it will honour each part, where a terser model might ignore the back half."
+  },
+  {
+    question: "What is a Claude system prompt and when should I use one?",
+    answer: "A system prompt is a persistent instruction that sets Claude's role and rules for the whole conversation, separate from each individual message. Use one when you want a consistent persona or constraint across many turns, such as 'You are a technical editor. You never change the meaning of a sentence, only its clarity.' For one-off requests, putting the role in the message itself is enough."
+  },
+  {
+    question: "Why does Claude give vague or generic answers?",
+    answer: "Almost always because the prompt was vague. The most common failure is asking for an outcome ('write a good email') without specifying audience, goal, length, and tone. Add those four things and the output changes immediately. The second most common failure is burying the actual instruction in the middle of a long block of pasted text, where it competes with the data for Claude's attention; move the instruction to the end and wrap the data in tags."
+  }
+]
+
+const promptTemplates = [
+  {
+    id: 'rewrite',
+    label: 'Rewrite / edit (writing)',
+    description: 'Editing is where vague prompts fail hardest. This template forces a role, a single edit goal, a constraint, and a clean output.',
+    content: `Act as a [senior copy editor / technical writer / plain-English specialist].
+
+Rewrite the text inside <draft> to [goal: cut length by 30% / raise reading ease / make it more direct].
+
+Rules:
+- Keep the key claim and the facts unchanged.
+- Do not add new information.
+- Match a [confident, plain] tone.
+
+Return only the rewritten version, no commentary.
+
+<draft>
+[paste your text here]
+</draft>`
+  },
+  {
+    id: 'analyse',
+    label: 'Analyse a document (business)',
+    description: 'The XML tags keep Claude from treating the document as instructions. The question goes last, after the material, where Claude weights it most.',
+    content: `You are a [strategy analyst]. Read the document below and answer the question.
+
+<document>
+[paste report, contract, or transcript here]
+</document>
+
+Question: [What are the three biggest risks, and which one would you act on first and why?]
+
+Format your answer as:
+1. A one-sentence summary.
+2. The three risks, ranked, one line each.
+3. Your recommended first action.`
+  },
+  {
+    id: 'firstdraft',
+    label: 'First draft with examples (writing)',
+    description: 'Few-shot examples are an official Anthropic technique. Two short samples teach Claude your style faster than three paragraphs describing it.',
+    content: `Write a [LinkedIn post] about [topic] for [audience].
+
+Match the style of these examples:
+
+<example>
+[paste one short post you like]
+</example>
+
+<example>
+[paste a second short post you like]
+</example>
+
+Constraints: [under 120 words, no hashtags, end on a question].
+Write three different versions so I can pick.`
+  },
+  {
+    id: 'debug',
+    label: 'Debug code (coding)',
+    description: 'State the language, paste the error, paste the code in tags, and ask Claude to reason before fixing. Asking for the cause first prevents confident wrong patches.',
+    content: `You are a senior [Python] engineer.
+
+I am getting this error:
+<error>
+[paste the full error and stack trace]
+</error>
+
+Here is the relevant code:
+<code>
+[paste the function or file]
+</code>
+
+First, explain the most likely cause in two sentences.
+Then give the corrected code.
+Then list one test that would catch this regression.`
+  },
+  {
+    id: 'think',
+    label: 'Reason it through (extended thinking)',
+    description: 'For problems with steps, asking Claude to think before answering measurably improves accuracy. Keep the final-answer format explicit so the thinking does not bleed into your deliverable.',
+    content: `Solve the problem below. Think step by step before you answer.
+
+<problem>
+[paste the problem, calculation, or decision]
+</problem>
+
+Show your reasoning, then put the final answer on its own line prefixed with "Answer:".`
+  }
+]
+
+const beforeAfter = [
+  {
+    weak: 'Write a product description.',
+    strong: 'Act as an e-commerce copywriter. Write a 60-word product description for a stainless-steel insulated water bottle aimed at gym-goers. Lead with the benefit, name two features, end with a one-line call to action. No exclamation marks.',
+    why: 'The weak version gives Claude no audience, length, structure, or tone, so it returns a generic paragraph you have to rewrite. The strong version fixes all four and the output is usable on the first try.'
+  },
+  {
+    weak: 'Summarise this meeting.',
+    strong: 'Summarise the transcript in <transcript> into: (1) decisions made, (2) action items with owners, (3) open questions. Keep each item to one line. If an owner is not stated, write "unassigned".',
+    why: 'A bare "summarise" produces a wall of prose. Naming the exact sections and the fallback for missing data turns it into a structured artefact you can paste straight into your notes.'
+  },
+  {
+    weak: 'Make this email more professional.',
+    strong: 'Rewrite the email in <draft> to sound calm and professional without being stiff. Keep it under 90 words, keep the request and the deadline, and remove the apology in the opening line. Return only the rewritten email.',
+    why: '"More professional" is subjective and unbounded. The strong version defines the tone, sets a length, and names the specific change to make, so Claude is not guessing what "professional" means to you.'
+  }
+]
+
+const techniques = [
+  {
+    title: 'Be clear and direct',
+    detail: 'State the role, the single action, and the output format. One action verb per prompt — write, analyse, rewrite, summarise, debug. If a colleague would need to ask a clarifying question, so will Claude.'
+  },
+  {
+    title: 'Give examples (multishot)',
+    detail: 'Two or three short examples of the output you want teach style faster than a paragraph describing it. This is Anthropic\'s "multishot" technique. Wrap each one in an <example> tag.'
+  },
+  {
+    title: 'Let Claude think first',
+    detail: 'For multi-step problems, add "think step by step before you answer". Reasoning before the final answer improves accuracy on analysis, maths, and decisions. Keep the final-answer format explicit so the working does not leak into your deliverable.'
+  },
+  {
+    title: 'Use XML tags',
+    detail: 'When a prompt mixes instructions with pasted material, wrap the material in tags like <document>, <draft>, or <transcript>. It tells Claude where your instruction ends and the data begins, which stops it acting on the wrong thing.'
+  },
+  {
+    title: 'Set a system prompt / role',
+    detail: 'For a persistent persona across many turns, put the role in a system prompt: "You are a technical editor who never changes meaning, only clarity." For a one-off, the role can live in the message itself.'
+  },
+  {
+    title: 'Chain prompts for big jobs',
+    detail: 'Break a large task into linked prompts — outline, then draft from the outline, then edit the draft — rather than asking for everything at once. Each step is easier to steer and easier to fix.'
+  }
+]
+
+export default function ClaudePrompts() {
+  const [copiedId, setCopiedId] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopiedId(id)
+    setTimeout(() => setCopiedId(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude Prompts: The Best Prompts and How to Write Good Ones',
+    description: 'The best Claude prompts plus the method behind them. Copy-pasteable templates with variable slots for writing, business, and coding, weak-vs-strong examples, and the official Anthropic techniques that make them work.',
+    url: 'https://promptwritingstudio.com/claude-prompts',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude prompts', 'best claude prompts', 'claude prompt examples', 'how to write claude prompts', 'claude ai prompts', 'good claude prompts']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude Prompts: The Best Prompts and How to Write Good Ones | PromptWritingStudio</title>
+        <meta name="description" content="The best Claude prompts and how to write your own. Copy-pasteable templates for writing, business, and coding, weak-vs-strong examples, and the official Anthropic techniques behind them." />
+        <meta name="keywords" content="claude prompts, best claude prompts, claude prompt examples, how to write claude prompts, claude ai prompts, good claude prompts" />
+        <meta property="og:title" content="Claude Prompts: The Best Prompts and How to Write Good Ones" />
+        <meta property="og:description" content="Copy-pasteable Claude prompt templates for writing, business, and coding, plus weak-vs-strong examples and the official techniques that make them work." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-prompts" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-prompts" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude Prompts
+              <span className="block text-[#FFDE59]">The best ones, and how to write your own</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                <strong>The short version:</strong> the best Claude prompts give Claude a role, one clear action, specific context, and an output format. Claude follows long, structured instructions faithfully, so being explicit beats being clever. Below are copy-pasteable templates for writing, business, and coding, each with variable slots — plus the official techniques that make them work and the weak-vs-strong examples that prove it.
+              </p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#templates" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Jump to the templates
+              </a>
+              <a href="#techniques" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Learn the method
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">What makes a Claude prompt good</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-6">
+                Most prompt lists hand you 50 prompts and never tell you why any of them work. That is a problem, because the moment your task differs from the example, you are stuck. The faster path is to learn the shape of a strong prompt once, then fill it in for anything.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                A strong Claude prompt has four parts: a <strong>role</strong> ("act as a senior editor"), one clear <strong>action</strong> ("rewrite", "analyse", "summarise"), specific <strong>context</strong> (audience, goal, constraints), and an <strong>output format</strong> (length, structure, what to return). Claude rewards this. It follows long, detailed instructions more literally than most models, so a structured 150-word brief that might overwhelm another tool tends to produce Claude's best work.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                The templates below are built on that shape. Replace anything in square brackets and paste your material into the tagged blocks.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="templates" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Five copy-pasteable Claude prompt templates</h2>
+              <p className="text-xl text-[#333333] max-w-3xl mx-auto">
+                One each for the jobs people actually hire Claude for: editing, document analysis, drafting, debugging, and reasoning. Fill the slots, paste your input, run it.
+              </p>
+            </div>
+
+            <div className="space-y-8">
+              {promptTemplates.map(template => (
+                <div key={template.id} className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="p-6 border-b border-gray-200">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{template.label}</h3>
+                    <p className="text-[#333333]">{template.description}</p>
+                  </div>
+                  <div className="relative">
+                    <pre className="bg-[#1A1A1A] text-green-400 p-6 overflow-x-auto font-mono text-sm leading-relaxed whitespace-pre-wrap">{template.content}</pre>
+                    <button
+                      onClick={() => copyToClipboard(template.content, template.id)}
+                      className="absolute top-4 right-4 bg-[#FFDE59] text-[#1A1A1A] text-xs font-semibold px-3 py-1.5 rounded hover:bg-[#E5C84F] transition"
+                    >
+                      {copiedId === template.id ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                Want more in this shape, including ChatGPT versions? See the{' '}
+                <Link href="/chatgpt-prompt-templates" className="text-[#1A1A1A] font-semibold underline">fill-in-the-blank prompt templates</Link>{' '}
+                and the{' '}
+                <Link href="/ai-prompt-examples" className="text-[#1A1A1A] font-semibold underline">prompt examples library</Link>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Weak prompt vs strong prompt</h2>
+            <p className="text-lg text-[#333333] mb-10">
+              The single biggest lever is specificity. Here is the same request written two ways, with what changed and why the second wins.
+            </p>
+
+            <div className="space-y-8">
+              {beforeAfter.map((pair, i) => (
+                <div key={i} className="bg-[#F9F9F9] rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="grid md:grid-cols-2">
+                    <div className="p-6 border-b md:border-b-0 md:border-r border-gray-200">
+                      <p className="text-xs font-bold uppercase tracking-wide text-red-500 mb-2">Weak</p>
+                      <p className="text-[#333333] font-mono text-sm">{pair.weak}</p>
+                    </div>
+                    <div className="p-6">
+                      <p className="text-xs font-bold uppercase tracking-wide text-green-600 mb-2">Strong</p>
+                      <p className="text-[#333333] font-mono text-sm">{pair.strong}</p>
+                    </div>
+                  </div>
+                  <div className="px-6 py-4 bg-white border-t border-gray-200">
+                    <p className="text-[#333333]"><strong>Why it wins:</strong> {pair.why}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="techniques" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The six techniques behind every good Claude prompt</h2>
+            <p className="text-lg text-[#333333] mb-10">
+              These map to Anthropic's own prompt-engineering guidance: clarity, examples, thinking, XML structuring, roles, and chaining. Learn the six and you can build a prompt for any task, not just the ones on a list.
+            </p>
+
+            <div className="space-y-6">
+              {techniques.map((t, i) => (
+                <div key={i} className="bg-white p-6 rounded-lg border border-gray-200">
+                  <div className="flex items-start gap-4">
+                    <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0">{i + 1}</span>
+                    <div>
+                      <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{t.title}</h3>
+                      <p className="text-[#333333]">{t.detail}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                Source: Anthropic's prompt-engineering documentation lists clarity, examples (multishot), letting Claude think, XML tags, role / system prompts, and prompt chaining as its core techniques. The templates above are these six, applied.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Why your Claude prompts return generic answers</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-5">
+                When Claude gives a bland, hedge-everything answer, the prompt is almost always the cause. Two failure modes account for most of it.
+              </p>
+              <ul className="space-y-4 text-lg text-[#333333]">
+                <li><strong>You asked for an outcome, not a spec.</strong> "Write a good email" has no audience, goal, length, or tone, so Claude fills the gaps with the safest generic version. Add those four and the output changes on the next run.</li>
+                <li><strong>You buried the instruction inside the data.</strong> When you paste a long document and drop your question in the middle, the question competes with the text for attention. Move the instruction to the end and wrap the document in an <code>&lt;document&gt;</code> tag so Claude knows what to act on.</li>
+              </ul>
+              <p className="text-lg text-[#333333] mt-6">
+                Fix those two and most "Claude is not very good" complaints disappear. The model was waiting for a clearer brief.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Claude prompts vs ChatGPT prompts</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-5">
+                The four-part shape works for both, but two things lean Claude-specific. Claude follows long, structured briefs more literally, so a detailed sectioned prompt that might overwhelm a terser model often produces its best work. And Claude responds strongly to XML tags and a persistent system prompt, which is why the templates above lean on both.
+              </p>
+              <p className="text-lg text-[#333333] mb-5">
+                If you are choosing between the two for a given task, the{' '}
+                <Link href="/claude-vs-chatgpt" className="text-[#1A1A1A] font-semibold underline">Claude vs ChatGPT comparison</Link>{' '}
+                breaks down where each one wins, and the{' '}
+                <Link href="/ai-models" className="text-[#1A1A1A] font-semibold underline">AI model comparison</Link>{' '}
+                covers the wider lineup. If you are deciding which Claude plan you need, see{' '}
+                <Link href="/claude-pro-vs-max-vs-api" className="text-[#1A1A1A] font-semibold underline">Claude Pro vs Max vs API</Link>.
+              </p>
+              <p className="text-lg text-[#333333]">
+                New to Claude entirely? Start with{' '}
+                <Link href="/how-to-use-claude" className="text-[#1A1A1A] font-semibold underline">how to use Claude</Link>. To set standing rules that apply to every prompt, see{' '}
+                <Link href="/claude-system-prompt" className="text-[#1A1A1A] font-semibold underline">Claude system prompts</Link>, and for longer-form work read{' '}
+                <Link href="/claude-for-writing" className="text-[#1A1A1A] font-semibold underline">Claude for writing</Link>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions people ask most about writing prompts for Claude.</p>
+
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              Templates get you started. The method makes you fast.
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              PromptWritingStudio is the full course on writing prompts that work — for Claude, ChatGPT, and Gemini. You get the frameworks, a template library, and the practice to stop guessing and start getting first-draft-usable output every time.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href={COURSE_URL} className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+              <Link href="/claude-code-guide" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Using Claude for code? Read the guide
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-sonnet-vs-opus.js
+++ b/pages/claude-sonnet-vs-opus.js
@@ -1,0 +1,236 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import LastVerified from '../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import { getCurrentModelByTier, MODELS_META } from '../lib/claude-data'
+
+// Pull live specs from the single source of truth (data/claude-models.json).
+// Do not hardcode names/prices — they decay fast and propagate from here.
+const opus = getCurrentModelByTier('flagship')
+const sonnet = getCurrentModelByTier('workhorse')
+const haiku = getCurrentModelByTier('fast')
+
+const fmtCtx = (tokens) => {
+  if (tokens >= 1000000) return `${tokens / 1000000}M`
+  return `${tokens / 1000}K`
+}
+
+const models = [opus, sonnet, haiku]
+
+const faqs = [
+  {
+    question: `What is the difference between ${sonnet.name} and ${opus.name}?`,
+    answer: `${opus.name} is Anthropic's flagship model — built for the hardest reasoning and agentic coding work — at $${opus.inputPricePerMTok}/$${opus.outputPricePerMTok} per million input/output tokens. ${sonnet.name} is the workhorse: nearly as smart for everyday tasks, faster, and cheaper at $${sonnet.inputPricePerMTok}/$${sonnet.outputPricePerMTok} per million tokens. For 80% of prompting and coding work, Sonnet is the right default. Reach for Opus only when a task genuinely stalls a smaller model.`
+  },
+  {
+    question: 'When should I use Opus instead of Sonnet?',
+    answer: 'Use Opus when the task needs multi-step reasoning that Sonnet gets wrong — large refactors across many files, dense legal or financial analysis, tricky debugging, or long agentic runs where a single wrong turn compounds. If Sonnet produces a correct answer on the first or second try, Opus is wasted money. A good rule: draft on Sonnet, escalate to Opus only on the specific prompts where Sonnet fails.'
+  },
+  {
+    question: `Is ${sonnet.name} good enough for most prompting?`,
+    answer: `Yes. ${sonnet.name} handles content writing, summarisation, data extraction, most coding, and structured-output prompts at near-flagship quality — faster and at ${Math.round((1 - sonnet.inputPricePerMTok / opus.inputPricePerMTok) * 100)}% lower input cost than ${opus.name}. Most people who think they need Opus are actually fighting a weak prompt, not a weak model. Tighten the prompt before you upgrade the model.`
+  },
+  {
+    question: `Where does ${haiku.name} fit in?`,
+    answer: `${haiku.name} is the fast, cheap tier at $${haiku.inputPricePerMTok}/$${haiku.outputPricePerMTok} per million tokens — the ${haiku.latency} of the three. Use it for high-volume, low-judgement work: classification, tagging, simple extraction, routing, first-pass drafts you will edit. It is not the model for nuanced reasoning, but for batch jobs where you run thousands of prompts, the cost difference versus Opus is dramatic.`
+  },
+  {
+    question: 'Do Sonnet and Opus have the same context window?',
+    answer: `${opus.name} and ${sonnet.name} both offer a ${fmtCtx(opus.contextTokens)}-token context window, so window size is not the deciding factor between them. ${haiku.name} is smaller at ${fmtCtx(haiku.contextTokens)} tokens. If you are feeding an entire codebase or a long document, either Sonnet or Opus will hold it — pick on reasoning need and cost, not context.`
+  },
+  {
+    question: 'How much cheaper is Sonnet than Opus in practice?',
+    answer: `${sonnet.name} input tokens cost $${sonnet.inputPricePerMTok}/M versus $${opus.inputPricePerMTok}/M for ${opus.name}, and output is $${sonnet.outputPricePerMTok}/M versus $${opus.outputPricePerMTok}/M. On a typical coding session that reads a lot of context and writes moderate output, Sonnet runs roughly ${Math.round((opus.outputPricePerMTok / sonnet.outputPricePerMTok) * 10) / 10}x cheaper on output alone. Over a month of daily use that is the difference between a small bill and a large one.`
+  }
+]
+
+const decisionRows = [
+  { task: 'Blog posts, marketing copy, email drafts', pick: sonnet.name, why: 'Quality is indistinguishable at this complexity; Sonnet is faster.' },
+  { task: 'Summarising or extracting from long documents', pick: sonnet.name, why: 'Full context window, low cost per run.' },
+  { task: 'Everyday coding, small-to-medium features', pick: sonnet.name, why: 'Handles most code correctly first try.' },
+  { task: 'Large multi-file refactors, architecture decisions', pick: opus.name, why: 'Reasoning depth prevents compounding errors.' },
+  { task: 'Hard debugging where Sonnet keeps missing', pick: opus.name, why: 'Escalate only on the prompts that actually stall.' },
+  { task: 'Dense analysis: legal, financial, research synthesis', pick: opus.name, why: 'Nuance and multi-step logic justify the premium.' },
+  { task: 'Long agentic runs with many tool calls', pick: opus.name, why: 'One wrong turn early compounds across the run.' },
+  { task: 'Classification, tagging, routing at scale', pick: haiku.name, why: 'Cheapest and fastest; judgement is light.' },
+  { task: 'High-volume batch jobs (thousands of prompts)', pick: haiku.name, why: 'Cost difference vs Opus is dramatic at volume.' }
+]
+
+const article = generateArticleSchema({
+  title: `Claude Sonnet vs Opus: When to Use Each Model (2026)`,
+  description: `A practical guide to choosing between Claude Sonnet, Opus, and Haiku — by cost, speed, capability, and context window. With a decision table and a known failure mode to avoid.`,
+  slug: 'claude-sonnet-vs-opus',
+  datePublished: '2026-06-16'
+})
+
+export default function ClaudeSonnetVsOpus() {
+  const faqSchema = generateFAQSchema(faqs)
+
+  return (
+    <>
+      <Head>
+        <title>Claude Sonnet vs Opus: When to Use Each Model (2026) | PromptWritingStudio</title>
+        <meta name="description" content={`Claude Sonnet vs Opus compared on cost, speed, capability, and context. When to pick ${sonnet.name}, ${opus.name}, or ${haiku.name} — with a decision table and the mistake most people make.`} />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-sonnet-vs-opus" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-4xl">
+            <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">Claude · Models</p>
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
+              Claude Sonnet vs Opus: When to Use Each Model
+            </h1>
+            <p className="text-xl text-gray-200 max-w-3xl mx-auto">
+              A practical guide to choosing between {sonnet.name}, {opus.name}, and {haiku.name} — by cost, speed, capability, and context window.
+            </p>
+            <LastVerified date={MODELS_META.lastVerified} source={MODELS_META.source} label="Model specs verified" className="mt-4 text-gray-300" />
+          </div>
+        </section>
+
+        <section className="py-10 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
+              <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                Use <strong>{sonnet.name}</strong> as your default — it handles roughly 80% of prompting and coding work at near-flagship quality, faster, and at a fraction of the cost. Escalate to <strong>{opus.name}</strong> only on the specific tasks where Sonnet actually fails: large refactors, dense analysis, hard debugging, long agentic runs. Drop to <strong>{haiku.name}</strong> for high-volume, low-judgement jobs. The model is rarely the bottleneck — a weak prompt usually is.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-8 text-center">Sonnet vs Opus vs Haiku at a glance</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full bg-white rounded-lg border border-gray-200 text-sm">
+                <thead className="bg-[#1A1A1A] text-white">
+                  <tr>
+                    <th className="p-3 text-left">Model</th>
+                    <th className="p-3 text-left">Tier</th>
+                    <th className="p-3 text-left">Input / Output ($/M tok)</th>
+                    <th className="p-3 text-left">Context</th>
+                    <th className="p-3 text-left">Speed</th>
+                    <th className="p-3 text-left">Best for</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {models.map((m, i) => (
+                    <tr key={m.id} className={i === 1 ? 'bg-yellow-50' : ''}>
+                      <td className="p-3 font-semibold text-[#1A1A1A]">{m.name}</td>
+                      <td className="p-3 text-[#333333] capitalize">{m.tier}</td>
+                      <td className="p-3 text-[#333333]">${m.inputPricePerMTok} / ${m.outputPricePerMTok}</td>
+                      <td className="p-3 text-[#333333]">{fmtCtx(m.contextTokens)}</td>
+                      <td className="p-3 text-[#333333] capitalize">{m.latency}</td>
+                      <td className="p-3 text-[#333333]">{m.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-gray-500 mt-3 text-center">Specs and prices verified against Anthropic's model docs on {MODELS_META.lastVerified}. {sonnet.name} highlighted as the recommended default.</p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-2">When should you use Sonnet vs Opus?</h2>
+            <p className="text-[#333333] mb-8">Match the task to the model. When in doubt, start on {sonnet.name} and only escalate the prompts that actually stall.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full bg-white rounded-lg border border-gray-200 text-sm">
+                <thead className="bg-[#1A1A1A] text-white">
+                  <tr>
+                    <th className="p-3 text-left">Task</th>
+                    <th className="p-3 text-left">Pick</th>
+                    <th className="p-3 text-left">Why</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {decisionRows.map((row, i) => (
+                    <tr key={i}>
+                      <td className="p-3 text-[#333333]">{row.task}</td>
+                      <td className="p-3 font-semibold text-[#1A1A1A] whitespace-nowrap">{row.pick}</td>
+                      <td className="p-3 text-[#333333]">{row.why}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">The cost difference, in plain numbers</h2>
+            <p className="text-[#333333] mb-4">
+              {sonnet.name} costs <strong>${sonnet.inputPricePerMTok}/M input</strong> and <strong>${sonnet.outputPricePerMTok}/M output</strong>. {opus.name} costs <strong>${opus.inputPricePerMTok}/M input</strong> and <strong>${opus.outputPricePerMTok}/M output</strong>. On output tokens — the expensive part of most generation work — Opus is {Math.round((opus.outputPricePerMTok / sonnet.outputPricePerMTok) * 10) / 10}x the price of Sonnet.
+            </p>
+            <p className="text-[#333333] mb-4">
+              That gap is invisible on a single prompt and brutal at scale. Run a hundred coding sessions a month on Opus when Sonnet would have produced the same result, and you have paid a multiple for no extra quality. The discipline is not "always use the cheapest" — it is "use the cheapest model that gets the task right."
+            </p>
+            <p className="text-[#333333]">
+              {haiku.name} sits below both at <strong>${haiku.inputPricePerMTok}/M input</strong> and <strong>${haiku.outputPricePerMTok}/M output</strong>. For batch classification or tagging across thousands of items, that is where the real savings live.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6">The mistake most people make</h2>
+            <div className="bg-white p-6 rounded-lg border-l-4 border-red-400 mb-6">
+              <h3 className="font-bold text-[#1A1A1A] mb-2">Reaching for Opus when the prompt is the problem</h3>
+              <p className="text-[#333333]">
+                The most common failure mode: a prompt returns a weak answer on {sonnet.name}, so the user upgrades to {opus.name} and pays the premium — when the real fix was a clearer prompt. Vague instructions, missing context, and no examples will hobble any model. Opus papers over a bad prompt at {Math.round((opus.outputPricePerMTok / sonnet.outputPricePerMTok) * 10) / 10}x the output cost.
+              </p>
+            </div>
+            <p className="text-sm font-semibold text-[#1A1A1A] mb-3">Before you upgrade the model, upgrade the prompt:</p>
+            <div className="bg-white rounded-lg border border-gray-200 p-5 font-mono text-sm text-[#333333] mb-4 whitespace-pre-wrap">{`Role: You are a [specific role].
+Task: [one clear objective].
+Context: [the inputs, constraints, audience].
+Format: [exact output shape — JSON, table, headings].
+Examples: [1-2 good outputs to anchor on].
+If unsure: [what to do instead of guessing].`}</div>
+            <p className="text-[#333333]">
+              Run that on {sonnet.name} first. If a fully-specified prompt still fails, you have a genuine reasoning task — and that is exactly when {opus.name} earns its price. Our <Link href="/" className="text-blue-700 underline">prompt-writing course</Link> drills this fill-in-the-blank structure across dozens of real tasks.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-6 text-center">Frequently asked questions</h2>
+            <div className="space-y-3">
+              {faqs.map((faq, i) => (
+                <details key={i} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-4 cursor-pointer hover:bg-gray-50 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-4 pb-4"><p className="text-gray-600 leading-relaxed">{faq.answer}</p></div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A] text-center">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <h2 className="text-3xl font-bold text-white mb-4">Stop guessing which model to use</h2>
+            <p className="text-gray-300 mb-6">The model selector takes your task type and runs the choice for you. Once you know the model, the next lever is the prompt — that is where most of the quality lives, and what the course teaches end to end.</p>
+            <div className="flex flex-col sm:flex-row flex-wrap gap-4 justify-center">
+              <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition">Join Now</a>
+              <Link href="/calculators/claude-model-selector" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Open the model selector</Link>
+              <Link href="/claude-context-window" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Claude context window</Link>
+              <Link href="/claude-vs-gemini" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Claude vs Gemini</Link>
+              <Link href="/calculators/claude-prompt-cost" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Prompt cost calculator</Link>
+              <Link href="/claude-pro-vs-max-vs-api" className="border-2 border-white text-white px-6 py-3 rounded-lg font-bold hover:bg-white hover:text-[#1A1A1A] transition">Pro vs Max vs API</Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-system-prompt.js
+++ b/pages/claude-system-prompt.js
@@ -1,0 +1,452 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const faqs = [
+  {
+    question: "What is a Claude system prompt?",
+    answer: "A Claude system prompt is a separate instruction block that sets Claude's role, rules, tone, and constraints before the conversation starts. In the Anthropic Messages API it is passed as a dedicated `system` parameter, not as a user message. It applies to every turn of the conversation, so you define behaviour once instead of repeating it in each request. Anthropic's own guidance puts it plainly: 'Setting a role in the system prompt focuses Claude's behavior and tone for your use case.'"
+  },
+  {
+    question: "What is the difference between a system prompt and a user prompt?",
+    answer: "The user prompt is the specific request for this turn — the question or task. The system prompt is the standing context that frames how Claude should answer every request in the session: who it is, what it knows, what format to use, and what to avoid. A useful frame: the system prompt is the job description, the user prompt is the individual ticket. Put durable rules in the system prompt and the one-off ask in the user prompt."
+  },
+  {
+    question: "How do I set a system prompt for Claude?",
+    answer: "In the Anthropic API you pass it as the `system` field on the messages.create call, alongside the `messages` array. In Claude.ai you set standing behaviour through a Project's custom instructions, which act as a persistent system prompt for every chat in that Project. In tools built on the API (chatbots, agents, internal apps) the developer sets the system prompt in code and the end user never sees it."
+  },
+  {
+    question: "How long should a Claude system prompt be?",
+    answer: "As long as it needs to be and no longer. A single role sentence already changes output. Most production system prompts run from a paragraph to a page: role, a few hard rules, output format, and any domain context Claude cannot infer. Every line competes with the user's actual request for attention, so cut anything that is not earning its place. If a rule has never changed an output, delete it."
+  },
+  {
+    question: "Can I use XML tags in a Claude system prompt?",
+    answer: "Yes, and Claude is specifically trained to parse them. Anthropic recommends wrapping different content types in their own tags — for example `<instructions>`, `<context>`, and `<examples>` — so Claude can tell rules apart from data. This matters most when the prompt mixes instructions, reference material, and examples. Use consistent, descriptive tag names across your prompts."
+  },
+  {
+    question: "Why is Claude ignoring my system prompt?",
+    answer: "Usually one of three things. First, you put the instruction in a user message instead of the `system` field, so it reads as a one-off rather than a standing rule. Second, the prompt is contradictory — it tells Claude to be brief and thorough at once — and Claude picks one. Third, you used negative phrasing ('do not use markdown') which is weaker than positive phrasing ('write in flowing prose paragraphs'). Fix the channel, remove the contradiction, and state what to do rather than what to avoid."
+  },
+  {
+    question: "Does the system prompt count toward token usage?",
+    answer: "Yes. The system prompt is sent with every request, so it is billed as input tokens on each turn of the conversation. A long system prompt that repeats on a high-traffic app adds up. This is another reason to keep it tight — and, for stable system prompts, to look at prompt caching so the repeated block is not reprocessed at full cost every call."
+  }
+]
+
+const templates = [
+  {
+    id: 'support',
+    label: 'Customer support assistant',
+    description: 'A role, a tone, hard limits, and an escape hatch. The escalation rule is what stops the bot from inventing policy.',
+    content: `You are a customer support assistant for [COMPANY], a [WHAT YOU SELL] company.
+
+Role and tone:
+- Friendly, concise, and practical. No corporate filler.
+- Answer in plain language. Assume the customer is busy.
+
+Rules:
+- Only answer using the information in <knowledge_base>. If the answer is not there, say so.
+- Never invent prices, policies, refund terms, or delivery dates.
+- For billing disputes, account deletion, or anything legal, do not resolve it yourself. Reply: "I'll pass this to a human agent" and stop.
+
+Output format:
+- A direct answer first, in 1-3 sentences.
+- Then any steps as a short numbered list, only if steps are needed.`
+  },
+  {
+    id: 'writer',
+    label: 'Brand-voice content writer',
+    description: 'The before/after value here is voice consistency. Without the voice rules Claude drifts to generic marketing copy by the third paragraph.',
+    content: `You are a content writer for [BRAND], writing for [TARGET READER].
+
+Voice:
+- Direct and concrete. Short sentences. No hype words ("revolutionary", "game-changing", "unlock").
+- Write at roughly an 8th-grade reading level.
+- Use the second person ("you") and active voice.
+
+Rules:
+- Lead with the reader's problem, not the product.
+- Every claim needs a concrete example, number, or step behind it.
+- Do not use em dashes or exclamation marks.
+
+Output format:
+- A one-sentence hook, then the body in short paragraphs of 2-3 sentences.
+- End with a single, specific call to action.`
+  },
+  {
+    id: 'analyst',
+    label: 'Document analyst (grounded answers)',
+    description: 'This pattern forces Claude to quote before it concludes, which is the most reliable way to cut hallucinated claims on long documents.',
+    content: `You are a research analyst. You answer questions strictly from the documents provided.
+
+Rules:
+- Before answering, find and quote the passages that support your answer.
+- If the documents do not contain the answer, reply: "Not stated in the source documents."
+- Never use outside knowledge to fill gaps. Never guess.
+
+Output format:
+<evidence>
+- Quote the relevant lines, with the source name for each.
+</evidence>
+<answer>
+- Your conclusion, in plain language, grounded only in the evidence above.
+</answer>`
+  },
+  {
+    id: 'coding',
+    label: 'Coding assistant (single role line)',
+    description: 'Proof that one sentence works. This is Anthropic’s own minimal example. Add rules only when you see a behaviour you want to change.',
+    content: `You are a helpful coding assistant specializing in Python.
+
+- Prefer the standard library before reaching for dependencies.
+- Show the working code first, then a one-line explanation of the tricky part.
+- If a request is ambiguous, ask one clarifying question before writing code.`
+  }
+]
+
+const mistakes = [
+  {
+    title: 'Putting standing rules in the user message',
+    detail: 'If a rule should apply to every turn — role, tone, format, hard limits — it belongs in the system prompt, not pasted at the top of each user message. Rules in the user turn read as a one-off and get diluted as the conversation grows. The system prompt is the only place that reliably persists across the whole session.'
+  },
+  {
+    title: 'Telling Claude what not to do',
+    detail: 'Negative instructions are weak. "Do not use markdown" is less reliable than "Write your response as flowing prose paragraphs." Anthropic’s guidance is explicit: tell Claude what to do instead of what not to do. Whenever you catch yourself writing "don’t", rewrite it as the positive behaviour you actually want.'
+  },
+  {
+    title: 'Contradicting yourself',
+    detail: 'A prompt that says "be thorough and detailed" in one line and "keep it short" in another forces Claude to pick a winner, and it may not pick yours. Read your system prompt as a single instruction set and resolve every conflict. If two rules genuinely apply in different situations, say which situation triggers which.'
+  },
+  {
+    title: 'Stuffing reference data into the role',
+    detail: 'A 2,000-word system prompt that pastes your entire price list and FAQ buries the actual rules. Keep the system prompt to role, rules, and format. Pass bulky reference material as structured context — wrapped in XML tags like <knowledge_base> — so Claude can tell instructions apart from data, and so you can swap the data without rewriting the role.'
+  },
+  {
+    title: 'No escape hatch',
+    detail: 'Without an explicit "if you do not know, say so" rule, Claude will try to be helpful and may fill the gap with a plausible guess. Every grounded use case — support, analysis, anything customer-facing — needs a stated fallback: what Claude should say or do when the answer is not available. This single line removes most hallucinated answers.'
+  },
+  {
+    title: 'Letting it go stale',
+    detail: 'Model behaviour, your product, and your policies all change. A system prompt that names a deprecated feature or an old refund policy will confidently steer Claude wrong. Review system prompts when you ship a product change, and re-test them when you move to a new Claude model — newer models often need less aggressive prompting than older ones.'
+  }
+]
+
+export default function ClaudeSystemPrompt() {
+  const [copiedId, setCopiedId] = useState(null)
+
+  const copyToClipboard = (text, id) => {
+    navigator.clipboard.writeText(text)
+    setCopiedId(id)
+    setTimeout(() => setCopiedId(null), 2000)
+  }
+
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude System Prompt: How to Write Effective System Prompts (With Templates)',
+    description: 'What a Claude system prompt is, how to write one that actually changes output, four copy-paste templates, and the common mistakes that make Claude ignore your instructions.',
+    url: 'https://promptwritingstudio.com/claude-system-prompt',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['claude system prompt', 'claude system prompt example', 'how to write a claude system prompt', 'claude system prompt template', 'anthropic system prompt']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude System Prompt: How to Write Effective System Prompts (With Templates) | PromptWritingStudio</title>
+        <meta name="description" content="What a Claude system prompt is, how to write one that changes output, four copy-paste templates, and the mistakes that make Claude ignore your instructions." />
+        <meta name="keywords" content="claude system prompt, claude system prompt example, claude system prompt template, how to write a claude system prompt, anthropic system prompt" />
+        <meta property="og:title" content="Claude System Prompt: How to Write Effective System Prompts" />
+        <meta property="og:description" content="What a Claude system prompt is, how to write one that changes output, four templates you can copy, and the mistakes that make Claude ignore your instructions." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-system-prompt" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-system-prompt" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              The Claude System Prompt Guide
+              <span className="block text-[#FFDE59]">Set the rules once, get them every turn</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                A Claude system prompt is a separate instruction block that sets Claude&apos;s role, rules, tone, and limits before the conversation starts. In the Anthropic API you pass it as the <code className="bg-black/30 px-1.5 py-0.5 rounded text-[#FFDE59]">system</code> field, and it applies to every turn. Define behaviour once instead of repeating it in every message. This guide covers what it is, how to write one that actually changes output, four templates you can copy, and the mistakes that make Claude ignore you.
+              </p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#how-to-write" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                How to write one
+              </a>
+              <a href="#templates" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Jump to templates
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">What is a Claude system prompt?</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-6">
+                A system prompt is the standing context you give Claude before any specific request. It tells Claude who it is, what it knows, how to respond, and what it must not do. In the Anthropic Messages API it is a dedicated parameter called <code className="bg-gray-100 px-1.5 py-0.5 rounded text-[#1A1A1A]">system</code>, passed separately from the <code className="bg-gray-100 px-1.5 py-0.5 rounded text-[#1A1A1A]">messages</code> array that holds the actual conversation.
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                The point is persistence. Anything in the system prompt applies to <strong>every turn</strong> of the conversation, so you set behaviour once rather than re-stating it in each message. Anthropic&apos;s own prompt-engineering guidance is blunt about its value: <em>&quot;Setting a role in the system prompt focuses Claude&apos;s behavior and tone for your use case. Even a single sentence makes a difference.&quot;</em>
+              </p>
+              <p className="text-lg text-[#333333] mb-6">
+                If you are writing one-off prompts in a chat, you may never touch a system prompt directly. If you are building anything that reuses Claude — a support bot, an internal tool, a content pipeline, a Claude.ai Project — the system prompt is where the real control lives.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">System prompt vs user prompt</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              The two are different jobs. Mixing them up is the single most common reason a system prompt fails to stick.
+            </p>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">System prompt</h3>
+                <ul className="space-y-2 text-[#333333]">
+                  <li>Standing rules that apply to every turn</li>
+                  <li>Role, tone, format, hard limits, domain context</li>
+                  <li>Set once, in the <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">system</code> field</li>
+                  <li>The end user usually never sees it</li>
+                </ul>
+              </div>
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">User prompt</h3>
+                <ul className="space-y-2 text-[#333333]">
+                  <li>The specific request for this one turn</li>
+                  <li>The question, the task, the input data</li>
+                  <li>Sent in the <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">messages</code> array</li>
+                  <li>Changes with every interaction</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Rule of thumb:</strong> the system prompt is the job description, the user prompt is the individual ticket. If a rule should hold no matter what the user asks next, it goes in the system prompt.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Where you set the system prompt</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Where it lives depends on how you use Claude. Three common cases:
+            </p>
+
+            <div className="space-y-4">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start gap-4">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0">1</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">The Anthropic API</h3>
+                    <p className="text-[#333333]">Pass your text in the <code className="bg-white px-1.5 py-0.5 rounded text-sm border border-gray-200">system</code> field on the <code className="bg-white px-1.5 py-0.5 rounded text-sm border border-gray-200">messages.create</code> call. This is the canonical way and the one every other surface is built on top of.</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start gap-4">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0">2</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Claude.ai Projects</h3>
+                    <p className="text-[#333333]">In Claude.ai, a Project&apos;s custom instructions act as a persistent system prompt for every chat inside that Project. Use them to set a standing role and rules without re-typing them in each conversation.</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                <div className="flex items-start gap-4">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0">3</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Apps and agents built on the API</h3>
+                    <p className="text-[#333333]">In a product — a chatbot, an internal tool, an agent — the developer sets the system prompt in code. The end user types only user prompts and never sees the rules governing the assistant.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-[#1A1A1A] rounded-lg overflow-hidden relative">
+              <pre className="text-green-400 p-6 overflow-x-auto font-mono text-sm leading-relaxed">{`# The system prompt is a dedicated parameter (Python SDK)
+message = client.messages.create(
+    model="claude-opus-4-...",
+    max_tokens=1024,
+    system="You are a helpful coding assistant specializing in Python.",
+    messages=[
+        {"role": "user", "content": "How do I sort a list of dicts by key?"}
+    ],
+)`}</pre>
+            </div>
+            <p className="text-sm text-gray-500 mt-3">Source: Anthropic prompt-engineering documentation. Use the current model string for whichever Claude model you are calling.</p>
+          </div>
+        </section>
+
+        <section id="how-to-write" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">How to write an effective Claude system prompt</h2>
+            <p className="text-lg text-[#333333] mb-10">Five moves do almost all the work. Start with a role, add only the rules you actually need to change a behaviour you have seen.</p>
+
+            <div className="space-y-6">
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">1. Give Claude a specific role</h3>
+                <p className="text-[#333333]">One sentence sets tone and focus. &quot;You are a customer support assistant for an accounting-software company&quot; outperforms &quot;You are a helpful assistant&quot;. Specificity beats length — name the job, the company type, and who the reader is.</p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">2. State rules as positives</h3>
+                <p className="text-[#333333]">Tell Claude what to do, not what to avoid. Replace &quot;don&apos;t be verbose&quot; with &quot;answer in 1-3 sentences, then stop&quot;. Anthropic&apos;s guidance is explicit on this: positive instructions are more reliable than prohibitions.</p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">3. Specify the output format</h3>
+                <p className="text-[#333333]">If you want a particular shape, say so: &quot;a direct answer first, then a numbered list of steps&quot;. Format drift is the most common complaint about Claude output, and it is almost always because the format was never stated.</p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">4. Structure with XML tags</h3>
+                <p className="text-[#333333]">Claude is trained to read XML tags. Wrap distinct content types in their own tags — <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">&lt;instructions&gt;</code>, <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">&lt;context&gt;</code>, <code className="bg-gray-100 px-1.5 py-0.5 rounded text-sm">&lt;examples&gt;</code> — so Claude can tell your rules apart from your reference data.</p>
+              </div>
+
+              <div className="bg-white p-6 rounded-lg border border-gray-200">
+                <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">5. Add an escape hatch</h3>
+                <p className="text-[#333333]">Tell Claude what to do when it does not know: &quot;If the answer is not in the provided documents, say so and stop.&quot; Without this line Claude tries to be helpful and may guess. One sentence removes most hallucinated answers.</p>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">
+                <strong>Adding context helps too.</strong> Anthropic notes that explaining <em>why</em> a rule matters improves compliance — &quot;answer in plain language because our readers are non-technical&quot; works better than the bare instruction, because Claude generalises from the reason.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section id="templates" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4">Four Claude system prompt templates</h2>
+              <p className="text-xl text-[#333333] max-w-3xl mx-auto">
+                Fill in the bracketed slots and paste into the <code className="bg-gray-100 px-1.5 py-0.5 rounded text-base">system</code> field or your Project instructions. Copy the shape — the value is in the structure, not the exact words.
+              </p>
+            </div>
+
+            <div className="space-y-8">
+              {templates.map(template => (
+                <div key={template.id} className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+                  <div className="p-6 border-b border-gray-200">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{template.label}</h3>
+                    <p className="text-[#333333]">{template.description}</p>
+                  </div>
+                  <div className="relative">
+                    <pre className="bg-[#1A1A1A] text-green-400 p-6 overflow-x-auto font-mono text-sm leading-relaxed">{template.content}</pre>
+                    <button
+                      onClick={() => copyToClipboard(template.content, template.id)}
+                      className="absolute top-4 right-4 bg-[#FFDE59] text-[#1A1A1A] text-xs font-semibold px-3 py-1.5 rounded hover:bg-[#E5C84F] transition"
+                    >
+                      {copiedId === template.id ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-10 bg-[#F9F9F9] border border-gray-200 rounded-lg p-6">
+              <p className="text-[#333333]">
+                Need ready-made prompts rather than system-prompt scaffolding? See our <Link href="/claude-prompts" className="text-blue-600 hover:underline font-semibold">Claude prompts library</Link> for task-level prompts, or build one interactively with the <Link href="/ai-prompt-generator/claude-prompt" className="text-blue-600 hover:underline font-semibold">Claude prompt generator</Link>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Common mistakes (and why Claude ignores you)</h2>
+            <p className="text-lg text-[#333333] mb-10">When a system prompt does not stick, it is almost always one of these six.</p>
+
+            <div className="space-y-5">
+              {mistakes.map((m, i) => (
+                <div key={i} className="bg-white p-6 rounded-lg border-l-4 border-red-300">
+                  <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">{m.title}</h3>
+                  <p className="text-[#333333]">{m.detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">A note on cost and model choice</h2>
+            <div className="prose max-w-none">
+              <p className="text-lg text-[#333333] mb-5">
+                The system prompt is sent on every request, so it is billed as input tokens each turn. On a high-traffic app a long system prompt is a recurring cost, not a one-off. Two things help: keep the prompt tight, and look at prompt caching so a stable system block is not reprocessed at full price on every call.
+              </p>
+              <p className="text-lg text-[#333333] mb-5">
+                Model choice matters too. Newer Claude models follow instructions more literally and often need <em>less</em> aggressive prompting than older ones — phrases like &quot;CRITICAL: you MUST&quot; that were needed before can cause over-triggering now. Re-test your system prompt when you change models. To estimate per-call cost across models, use our <Link href="/calculators/claude-prompt-cost" className="text-blue-600 hover:underline font-semibold">Claude prompt cost calculator</Link>.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions people ask when they first start writing system prompts for Claude.</p>
+
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              Want prompts that work without the trial and error?
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              System prompts are one layer. PromptWritingStudio teaches the full system — roles, structure, examples, and the patterns that get consistent output from Claude, ChatGPT, and Gemini — with templates you can reuse across every project.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+              <Link href="/claude-code-guide" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Read the Claude Code guide
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/claude-vs-gemini.js
+++ b/pages/claude-vs-gemini.js
@@ -1,0 +1,381 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import LastVerified from '../components/LastVerified'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import { getAIModelById, AI_MODELS_META } from '../lib/ai-models'
+
+// Pull current model facts from the central multi-vendor JSON so prices/names/context
+// windows update in one place. Never hardcode decaying numbers in prose.
+const opus = getAIModelById('claude-opus-4-7')
+const sonnet = getAIModelById('claude-sonnet-4-6')
+const haiku = getAIModelById('claude-haiku-4-5-20251001')
+const geminiPro = getAIModelById('gemini-2-5-pro')
+const geminiFlash = getAIModelById('gemini-2-5-flash')
+
+const VERIFIED_DATE = AI_MODELS_META.lastVerified
+
+function pricePerMTokens(m) {
+  if (m.input_per_million == null || m.output_per_million == null) {
+    return m.pricing_label
+  }
+  return `$${m.input_per_million} / $${m.output_per_million} per M tokens`
+}
+
+const faqs = [
+  {
+    question: "Is Claude or Gemini better for writing?",
+    answer: "Claude is the stronger writer for long-form and nuanced work — essays, reports, book drafts, and rewrites where tone and structure matter. It follows voice instructions more faithfully and produces fewer AI-tell patterns out of the box. Gemini writes competently and is faster, and it has a real edge when your writing task touches Google Docs, Gmail, or Sheets because it reads and edits those files directly. For pure prose quality, pick Claude. For writing that lives inside Google Workspace, Gemini saves you the copy-paste."
+  },
+  {
+    question: "Is Claude or Gemini better for coding?",
+    answer: "Both are strong. Claude tends to produce cleaner, more idiomatic code and is the clearer choice for agentic coding on your own repo through Claude Code — it reads files, runs tests, and manages git in a loop. Gemini's advantage is raw context: its Pro model handles 1M+ tokens (up to 2M), so you can drop an entire large codebase into a single prompt. For day-to-day development on real projects, Claude Code is the more capable tool. For one-shot reasoning over a huge codebase you can't chunk, Gemini's context window wins."
+  },
+  {
+    question: `How much context can Claude and Gemini handle?`,
+    answer: `${opus.display_name} and ${sonnet.display_name} ship with ${opus.context_window_label} context windows; ${haiku.display_name} has ${haiku.context_window_label}. ${geminiPro.display_name} goes further at ${geminiPro.context_window_label}, and ${geminiFlash.display_name} matches Claude's flagship at ${geminiFlash.context_window_label}. In practice you only feel the difference when pasting very large documents or whole codebases — for normal chat lengths both are effectively unlimited. Verified ${new Date(VERIFIED_DATE).toLocaleDateString('en-US', { year: 'numeric', month: 'long' })}.`
+  },
+  {
+    question: "How much does Claude vs Gemini cost?",
+    answer: "Both have a $20/month consumer tier: Claude Pro and Google's AI subscription (sold through the Google One AI tiers / Gemini Advanced). The free tiers differ — Gemini's free access is generous and tied to a Google account, while Claude Free has a tighter daily cap. On the API side, Gemini's flagship is cheaper per token than Claude's flagship, but Gemini's pricing is tiered by context length and inference mode, so the headline number isn't the whole story. Check the API pricing pages before quoting a per-token cost — both vendors change pricing often."
+  },
+  {
+    question: "Does the same prompt work in both Claude and Gemini?",
+    answer: "Mostly, yes. A well-structured prompt — clear role, explicit task, constraints, and an output format — transfers cleanly between Claude and Gemini. The differences show up at the margins: Claude follows long multi-step instructions and tone constraints more literally, while Gemini benefits from being pointed at specific Google Workspace files or asked to use real-time search. If you write good prompts, you can switch between the two without rewriting them. Lazy prompts expose the model's defaults in both."
+  },
+  {
+    question: "Which has better Google integration?",
+    answer: "Gemini, by a wide margin — that's its whole moat. It's built into Gmail, Google Docs, Sheets, Slides, Drive, and Android, and it can read and act on your files inside those apps. Claude integrates with Google Workspace too, but Gemini is native to it. If your work lives in Google's ecosystem and you want AI that's one click away inside the doc you're already editing, Gemini is the obvious pick."
+  },
+  {
+    question: "Should I use Claude or Gemini for everyday tasks?",
+    answer: "For everyday questions, drafting, summarising, and quick research, both are excellent and the gap is small. Gemini is faster and has real-time web access plus Google integration, which makes it convenient for quick lookups and anything tied to your inbox or calendar. Claude is calmer and more precise, which most people prefer for thinking-through tasks and writing. A reasonable setup: Gemini for fast, Google-connected everyday work, Claude when the quality of the output actually matters."
+  },
+  {
+    question: "Can I use both Claude and Gemini together?",
+    answer: "Yes, and many people do. They cost $20/month each and solve overlapping but distinct problems. A common split: Gemini for everyday tasks, Google Workspace work, and huge-context jobs; Claude for serious writing and agentic coding via Claude Code. Good prompting transfers between them, so running both adds capability without doubling your prompt-writing effort."
+  }
+]
+
+const modelRows = [
+  { tier: 'Flagship', claude: `${opus.display_name} (${pricePerMTokens(opus)})`, gemini: `${geminiPro.display_name} (${geminiPro.pricing_label})` },
+  { tier: 'Workhorse', claude: `${sonnet.display_name} (${pricePerMTokens(sonnet)})`, gemini: `${geminiFlash.display_name} (${geminiFlash.pricing_label})` },
+  { tier: 'Fast/cheap', claude: `${haiku.display_name} (${pricePerMTokens(haiku)})`, gemini: `${geminiFlash.display_name} (low-cost tier)` },
+  { tier: 'Context window', claude: `${opus.context_window_label} on ${opus.display_name} and ${sonnet.display_name}; ${haiku.context_window_label} on ${haiku.display_name}`, gemini: `${geminiPro.context_window_label} on ${geminiPro.display_name}; ${geminiFlash.context_window_label} on ${geminiFlash.display_name}` },
+  { tier: 'Released', claude: `${opus.released} (${opus.display_name})`, gemini: `${geminiPro.released} (${geminiPro.display_name})` }
+]
+
+const featureRows = [
+  { feature: 'Web search', claude: 'Yes (built-in)', gemini: 'Yes (built-in, real-time Google search)' },
+  { feature: 'File upload + analysis', claude: 'Yes (PDF, CSV, images, docs)', gemini: 'Yes (PDF, CSV, images, audio, video)' },
+  { feature: 'Image generation', claude: 'No', gemini: 'Yes (Imagen integration)' },
+  { feature: 'Native video understanding', claude: 'No', gemini: 'Yes (video input supported)' },
+  { feature: 'Google Workspace integration', claude: 'Connector-based', gemini: 'Native (Gmail, Docs, Sheets, Drive, Android)' },
+  { feature: 'Artifacts / rendered outputs', claude: 'Yes (Artifacts — HTML, SVG, React render live)', gemini: 'Yes (Canvas)' },
+  { feature: 'Agentic coding CLI', claude: 'Yes (Claude Code)', gemini: 'Yes (Gemini CLI)' },
+  { feature: 'Largest context window', claude: opus.context_window_label, gemini: geminiPro.context_window_label },
+  { feature: 'Custom instructions / system prompt', claude: 'Yes', gemini: 'Yes (Gems)' },
+  { feature: 'API', claude: 'Anthropic API (Python, TS SDKs)', gemini: 'Google AI / Vertex AI API' },
+  { feature: 'Free tier', claude: 'Yes, tighter daily cap', gemini: 'Yes, generous, tied to Google account' },
+  { feature: 'Main paid tier', claude: 'Pro — $20/mo', gemini: 'Google AI / Gemini Advanced — $20/mo' }
+]
+
+const useCases = [
+  {
+    title: 'Long-form writing',
+    winner: 'Claude',
+    body: 'Claude produces more natural prose, follows tone and structure instructions more faithfully, and holds a consistent voice across a long document. For essays, reports, book chapters, and thoughtful rewrites, it is the stronger writer. Gemini is competent and fast but reads more generic out of the box.'
+  },
+  {
+    title: 'Writing inside Google Docs / Gmail',
+    winner: 'Gemini',
+    body: 'If the document already lives in Google Workspace, Gemini reads and edits it in place — no copy-paste, no losing formatting. For email drafts, doc cleanups, and sheet summaries, the native integration beats a marginally better prose model you have to paste into.'
+  },
+  {
+    title: 'Agentic coding on your own repo',
+    winner: 'Claude',
+    body: 'Claude Code runs an agentic loop on your real files — read, edit, test, commit — and produces cleaner, more idiomatic code. Gemini has a CLI too, but for iterating on production code on your own machine, Claude Code is the more mature, more reliable tool today.'
+  },
+  {
+    title: 'Reasoning over a huge codebase or document',
+    winner: 'Gemini',
+    body: `When you genuinely cannot chunk the input — a whole monorepo, a 1,000-page filing, hours of transcript — ${geminiPro.display_name}'s ${geminiPro.context_window_label} context window lets you load it all into one prompt. That is the one place Gemini's window decisively beats Claude.`
+  },
+  {
+    title: 'Everyday questions and quick research',
+    winner: 'Close — slight Gemini edge',
+    body: 'Both answer everyday questions well. Gemini is faster and has real-time Google search baked in, which makes it convenient for "what is the current status of X." Claude tends to be more careful and cites more deliberately. For speed, Gemini; for caution, Claude.'
+  },
+  {
+    title: 'Multimodal work (image, audio, video)',
+    winner: 'Gemini',
+    body: 'Gemini ingests image, audio, and video natively and can generate images via Imagen. Claude reasons about images you upload but does not generate them and has no video input. If your task is multimodal at its core, Gemini is the only real choice between the two.'
+  },
+  {
+    title: 'Structured output via API',
+    winner: 'Tie',
+    body: 'Both APIs support structured outputs and tool use reliably. Choose whichever fits your stack. Gemini is cheaper per token at the flagship tier; Claude tends to produce slightly cleaner prose inside JSON fields. For most apps either is fine.'
+  },
+  {
+    title: 'Cost-sensitive high-volume jobs',
+    winner: 'Gemini',
+    body: `For high-volume classification, extraction, or summarisation where price dominates, ${geminiFlash.display_name} is hard to beat on cost. ${haiku.display_name} is Claude's answer and is very competitive, but Gemini's flagship-class pricing undercuts Claude's at the top tier.`
+  }
+]
+
+const promptDemo = {
+  prompt: `Role: You are a senior content editor.
+Task: Rewrite the paragraph below to be 30% shorter, keep the meaning, and use plain, concrete language. No marketing adjectives.
+Constraints: British spelling. One sentence per idea. Return only the rewrite.
+
+Paragraph: [PASTE YOUR PARAGRAPH HERE]`,
+  claude: 'Tends to honour every constraint literally — length cut, British spelling, no adjectives — and returns only the rewrite with no preamble. Strong default for editing work.',
+  gemini: 'Produces a solid rewrite and is faster, but more likely to add a short "Here is your rewrite:" preamble or soften the "no adjectives" rule. Add "Return only the rewrite, no preface" to tighten it.'
+}
+
+export default function ClaudeVsGemini() {
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'Claude vs Gemini (2026): Which AI for Writing, Everyday Work, and Coding',
+    description: 'Claude vs Gemini compared for writing, everyday tasks, and coding — models, pricing, context windows, Google integration, and the same prompt run in both. A clear recommendation for when each one wins.',
+    slug: 'claude-vs-gemini',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['Claude vs Gemini', 'Gemini vs Claude', 'Claude vs Gemini for writing', 'Claude vs Gemini for coding', 'is Claude or Gemini better', 'Claude Opus vs Gemini Pro']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>Claude vs Gemini (2026): Which AI for Writing, Everyday Work, and Coding | PromptWritingStudio</title>
+        <meta name="description" content="Claude vs Gemini compared for writing, everyday work, and coding — models, pricing, context windows, Google integration, and the same prompt run in both. Clear recommendation for when each wins." />
+        <meta name="keywords" content="Claude vs Gemini, Gemini vs Claude, Claude vs Gemini for writing, Claude vs Gemini for coding, is Claude or Gemini better, Claude Opus vs Gemini Pro" />
+        <meta property="og:title" content="Claude vs Gemini (2026): Which AI for Writing, Everyday Work, and Coding" />
+        <meta property="og:description" content="A head-to-head comparison of Claude and Gemini with a clear recommendation for each use case." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/claude-vs-gemini" />
+        <link rel="canonical" href="https://promptwritingstudio.com/claude-vs-gemini" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Last updated: June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              Claude vs Gemini
+              <span className="block text-[#FFDE59]">Which AI for writing, everyday work, and coding</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                Claude vs Gemini comes down to two different bets. Claude wins on writing quality and agentic coding via Claude Code — the prose is more natural and the code is cleaner. Gemini wins on Google Workspace integration, multimodal input, raw context window, and price. Both cost $20/month. If your work lives in Google Docs and Gmail, lean Gemini. If output quality and serious coding matter most, lean Claude. Many people run both and route work to whichever is stronger.
+              </p>
+            </div>
+
+            <LastVerified date={VERIFIED_DATE} source={geminiPro.verification_source} label="Model facts verified" className="text-gray-200 mb-6" />
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#at-a-glance" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                The short verdict
+              </a>
+              <a href="#use-cases" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Use-case breakdown
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section id="at-a-glance" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-8 text-center">The short verdict</h2>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-[#F9F9F9] p-8 rounded-lg border-2 border-[#FFDE59]">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">Pick Claude if...</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You write for a living or care about prose quality</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You ship serious code and want an agentic CLI (Claude Code)</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You want instructions and tone followed literally</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You prefer a calmer, less generic default voice</span></li>
+                </ul>
+              </div>
+              <div className="bg-[#F9F9F9] p-8 rounded-lg border-2 border-gray-200">
+                <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">Pick Gemini if...</h3>
+                <ul className="space-y-3">
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">Your work lives in Google Docs, Gmail, Sheets, or Drive</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You need image, audio, or video understanding</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You load huge codebases or documents in one prompt</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]">You want fast answers with real-time Google search</span></li>
+                </ul>
+              </div>
+            </div>
+            <p className="text-center text-[#666666] mt-8">At $20/month each, the overlap is smaller than it looks. If you can afford both, get both and route work to whichever wins the task.</p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The model lineups</h2>
+            <p className="text-lg text-[#333333] mb-8">Both vendors follow a similar pattern: a flagship, a fast workhorse, and long context across the board. The names differ, but the mental model maps cleanly.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Tier</th>
+                    <th className="p-4 text-left font-semibold">Claude</th>
+                    <th className="p-4 text-left font-semibold">Gemini</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {modelRows.map((row, index) => (
+                    <tr key={index} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                      <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A]">{row.tier}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333]">{row.claude}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333]">{row.gemini}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-sm text-[#666666] mt-4">API pricing shown is input / output per million tokens. Chat-interface users pay a flat monthly fee and never see token pricing. Gemini's API pricing is tiered by context length and inference mode — confirm at the source before quoting a per-token cost.</p>
+            <LastVerified date={VERIFIED_DATE} source={geminiPro.verification_source} label="Pricing and specs verified" className="mt-2" />
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Feature-by-feature</h2>
+            <p className="text-lg text-[#333333] mb-8">The capabilities that actually matter day-to-day.</p>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="bg-[#1A1A1A] text-white">
+                    <th className="p-4 text-left font-semibold">Feature</th>
+                    <th className="p-4 text-left font-semibold">Claude</th>
+                    <th className="p-4 text-left font-semibold">Gemini</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {featureRows.map((row, index) => (
+                    <tr key={index} className={index % 2 === 0 ? 'bg-gray-50' : 'bg-white'}>
+                      <td className="p-4 border-b border-gray-200 font-semibold text-[#1A1A1A] text-sm">{row.feature}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{row.claude}</td>
+                      <td className="p-4 border-b border-gray-200 text-[#333333] text-sm">{row.gemini}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The same prompt, run in both</h2>
+            <p className="text-lg text-[#333333] mb-8">Good prompts transfer between Claude and Gemini. Here is a copy-paste editing prompt and how each model tends to handle it — the differences show up at the edges, not the core.</p>
+            <div className="bg-white rounded-lg border border-gray-200 overflow-hidden mb-6">
+              <div className="bg-[#1A1A1A] text-white px-6 py-3 text-sm font-semibold uppercase tracking-wide">Copy-paste prompt</div>
+              <pre className="p-6 text-sm text-[#1A1A1A] whitespace-pre-wrap font-mono bg-[#FAFAFA]">{promptDemo.prompt}</pre>
+            </div>
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-white p-6 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">In Claude</h3>
+                <p className="text-[#333333] text-sm">{promptDemo.claude}</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border-l-4 border-gray-300">
+                <h3 className="font-bold text-[#1A1A1A] mb-2">In Gemini</h3>
+                <p className="text-[#333333] text-sm">{promptDemo.gemini}</p>
+              </div>
+            </div>
+            <p className="text-sm text-[#666666] mt-6"><strong>Takeaway:</strong> the model matters less than the prompt. A tight prompt with an explicit output format closes most of the gap between the two. Vague prompts expose each model's defaults.</p>
+            <p className="text-[#333333] mt-6">
+              Comparing within the Claude lineup instead? See <Link href="/claude-sonnet-vs-opus" className="text-[#1A1A1A] font-semibold underline">Sonnet vs Opus</Link> and the <Link href="/claude-context-window" className="text-[#1A1A1A] font-semibold underline">Claude context window</Link>. For costs, the <Link href="/anthropic-api-pricing" className="text-[#1A1A1A] font-semibold underline">Anthropic API pricing guide</Link> covers token rates.
+            </p>
+          </div>
+        </section>
+
+        <section id="use-cases" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Use cases: which one wins</h2>
+            <p className="text-lg text-[#333333] mb-10">Eight common tasks, with the honest call on which assistant to reach for.</p>
+
+            <div className="space-y-5">
+              {useCases.map((u, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                  <div className="flex flex-wrap items-start justify-between gap-4 mb-3">
+                    <h3 className="text-xl font-bold text-[#1A1A1A] flex-1 min-w-0">{u.title}</h3>
+                    <span className="bg-[#FFDE59] text-[#1A1A1A] text-sm font-bold px-3 py-1 rounded-full whitespace-nowrap">{u.winner}</span>
+                  </div>
+                  <p className="text-[#333333]">{u.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The honest caveats</h2>
+            <div className="space-y-5">
+              <div className="bg-white p-6 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Benchmarks are not real life</h3>
+                <p className="text-[#333333]">Both vendors publish charts where their model wins. The SWE-bench gap between the two flagships is often a point or two — noise next to the difference a clear prompt makes on your actual work. Run a week with each on real tasks, then decide.</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Model versions change every few months</h3>
+                <p className="text-[#333333]">A comparison true in June 2026 may not hold in September. Both vendors ship aggressively, and Gemini's pricing in particular is tiered and changes often. The model facts on this page are verified against vendor sources — check release notes before a long-term commitment.</p>
+              </div>
+              <div className="bg-white p-6 rounded-lg border-l-4 border-[#FFDE59]">
+                <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Your prompt matters more than the model</h3>
+                <p className="text-[#333333]">A well-scoped prompt in either tool beats a vague prompt in the "better" tool. The delta between Claude and Gemini is usually smaller than the delta between a lazy prompt and a clear one on the same model. Fix the prompt first.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions people ask most when choosing between Claude and Gemini.</p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              The model is half the answer. The prompt is the other half.
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              Whichever you pick, the single biggest lever on output quality is how you prompt it — and good prompts transfer between Claude and Gemini. Still deciding between the bigger players? Read the Claude vs ChatGPT breakdown. Ready to write better prompts in either tool? The free generator is the fastest start, and the course goes deeper.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center flex-wrap">
+              <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+              <Link href="/ai-prompt-generator" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Free AI Prompt Generator
+              </Link>
+              <Link href="/claude-vs-chatgpt" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Claude vs ChatGPT
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/how-to-use-claude.js
+++ b/pages/how-to-use-claude.js
@@ -1,0 +1,334 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+import { getAIModelById } from '../lib/ai-models'
+
+// Pull current model facts from the central JSON so prices/names update in one place.
+const opus = getAIModelById('claude-opus-4-7')
+const sonnet = getAIModelById('claude-sonnet-4-6')
+const haiku = getAIModelById('claude-haiku-4-5-20251001')
+
+const steps = [
+  {
+    n: '1',
+    title: 'Create a free account at claude.ai',
+    body: 'Go to claude.ai in any browser, sign up with an email or Google account, and you are in. There is nothing to install for normal use. The free tier runs on Claude Sonnet and gives you a daily message allowance — enough to learn the ropes before you decide whether to pay.'
+  },
+  {
+    n: '2',
+    title: 'Type a plain instruction in the message box',
+    body: 'Claude is a chat assistant. You write what you want in normal English and it replies. Start with something concrete you actually need done today — "Rewrite this paragraph to sound less formal" or "Explain how a 401k works to a 12-year-old." You do not need special syntax or commands.'
+  },
+  {
+    n: '3',
+    title: 'Give it context, not just a question',
+    body: 'The single biggest jump in quality comes from telling Claude who you are, who the output is for, and what good looks like. Paste the source text, name the audience, and state the format you want. A vague prompt gets a vague answer — every time.'
+  },
+  {
+    n: '4',
+    title: 'Refine in the same conversation',
+    body: 'Claude remembers everything inside a single chat. So you rarely get it perfect on the first try, and you do not need to. Reply with "Shorter," "More skeptical," or "Now turn that into five bullet points" and it builds on what came before. Treat it as a back-and-forth, not a vending machine.'
+  },
+  {
+    n: '5',
+    title: 'Use files, projects, and artifacts when you outgrow plain chat',
+    body: 'Upload a PDF, spreadsheet, or image and ask Claude about it. Create a Project to keep related chats and reference files in one persistent workspace. When Claude builds something visual — a table, a document, a snippet of working code — it opens in an Artifact panel beside the chat so you can read and copy it cleanly.'
+  }
+]
+
+const modelTiers = [
+  {
+    name: opus.display_name,
+    role: 'The deep-thinking model',
+    body: `Anthropic's most capable model. Reach for it on hard reasoning, long documents, and complex analysis where accuracy matters more than speed. Context window: ${opus.context_window_label}.`
+  },
+  {
+    name: sonnet.display_name,
+    role: 'The everyday workhorse',
+    body: `Fast, capable, and what most people should use for almost everything — drafting, rewriting, summarising, brainstorming. This is the model behind the free tier. Context window: ${sonnet.context_window_label}.`
+  },
+  {
+    name: haiku.display_name,
+    role: 'The quick, lightweight model',
+    body: `Built for speed on simple, high-volume tasks — short lookups, quick classifications, fast first drafts. Context window: ${haiku.context_window_label}.`
+  }
+]
+
+const beforeAfter = {
+  weak: 'Write a blog post about email marketing.',
+  weakResult: 'You get a generic 800-word article that could have come from any AI, on any site, with no point of view and a forgettable intro.',
+  strong: 'You are an email marketing consultant writing for solo founders who hate "salesy" copy. Write a 600-word blog post on the single biggest mistake beginners make with welcome emails. Open with a specific example, use plain language, no hype words, and end with one concrete action the reader can take today.',
+  strongResult: 'You get a focused, opinionated draft aimed at a real reader, in the tone you asked for, with a usable structure. The only difference is the prompt.'
+}
+
+const templates = [
+  {
+    title: 'Rewrite / improve existing text',
+    template: 'Rewrite the text below for [AUDIENCE]. Goal: [WHAT YOU WANT — clearer / shorter / friendlier / more persuasive]. Keep [WHAT MUST STAY]. Avoid [WORDS OR TONE TO CUT]. Here is the text:\n\n[PASTE TEXT]'
+  },
+  {
+    title: 'Explain something complex',
+    template: 'Explain [TOPIC] to [WHO — a beginner / my boss / a 10-year-old]. Use a real-world analogy, keep it under [LENGTH], and finish with the one thing I most need to remember.'
+  },
+  {
+    title: 'Summarise a long document',
+    template: 'Summarise the attached [DOCUMENT TYPE] for [PURPOSE]. Give me: (1) a three-sentence overview, (2) the [N] most important points as bullets, (3) anything that looks like a risk or a decision I need to make.'
+  },
+  {
+    title: 'Plan or draft from scratch',
+    template: 'I need to [TASK — write an email / plan a launch / outline an article]. Context: [SITUATION]. Audience: [WHO]. Constraints: [LENGTH, TONE, DEADLINE, MUST-INCLUDES]. Draft a first version, then list three things you would improve with more information from me.'
+  }
+]
+
+const faqs = [
+  {
+    question: 'Is Claude free to use?',
+    answer: 'Yes. Claude has a free tier at claude.ai that runs on Claude Sonnet with a daily message limit. It is enough to learn how Claude works and handle light daily use. The paid Claude Pro plan (around $20/month) raises your limits and unlocks access to the more capable Opus model. Heavy users can step up to Claude Max. If you only ever need occasional help with writing and questions, the free tier may be all you need.'
+  },
+  {
+    question: 'How do I start using Claude as a complete beginner?',
+    answer: 'Go to claude.ai, create a free account, and type what you want done in plain English — for example, "Summarise this article in five bullet points" with the article pasted below. There is no special syntax to learn and nothing to install. Claude replies, and you refine the result by chatting back ("shorter," "more formal," "add an example"). That loop is the whole skill.'
+  },
+  {
+    question: 'What is the difference between Claude Opus, Sonnet, and Haiku?',
+    answer: `Opus is the most capable model — use it for hard reasoning and long, complex documents (${opus.context_window_label} context). Sonnet is the everyday workhorse most people should use for drafting, rewriting, and summarising; it powers the free tier (${sonnet.context_window_label} context). Haiku is the fast, lightweight model for simple, high-volume tasks (${haiku.context_window_label} context). For most work, the default model is the right one — you only need to think about this when a task is unusually hard or unusually simple.`
+  },
+  {
+    question: 'What is the best way to write a prompt for Claude?',
+    answer: 'Give context, not just a question. Tell Claude who you are, who the output is for, what format you want, and what to avoid. Paste any source material directly into the chat. A prompt like "You are a recruiter writing for graduates — rewrite this job ad in plain language under 150 words, no buzzwords" beats "improve this job ad" every time. Then refine in the same conversation rather than starting over.'
+  },
+  {
+    question: 'Can Claude read PDFs, spreadsheets, and images?',
+    answer: 'Yes. You can upload PDFs, CSV and Excel files, images, and other documents directly into a chat and ask Claude to summarise, analyse, extract data, or answer questions about them. Claude can describe and reason about images you upload, but it does not generate images itself.'
+  },
+  {
+    question: 'What can I actually use Claude for?',
+    answer: 'Common beginner uses: rewriting and improving your own writing, summarising long documents, explaining complex topics, drafting emails and posts, brainstorming, planning, and answering research questions. Writers, in particular, lean on it for tone changes and first drafts. The fastest way to learn is to pick one real task from your week and run it through Claude today.'
+  }
+]
+
+export default function HowToUseClaude() {
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'How to Use Claude: A Beginner\'s Guide (2026)',
+    description: 'A plain-English beginner\'s guide to using Claude AI — how to start, how to write prompts that work, the Opus/Sonnet/Haiku models explained, free vs paid plans, and copy-paste prompt templates.',
+    url: 'https://promptwritingstudio.com/how-to-use-claude',
+    datePublished: '2026-06-16',
+    dateModified: '2026-06-16',
+    keywords: ['how to use claude', 'how to use claude ai', 'claude ai beginner guide', 'claude ai tutorial', 'getting started with claude']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>How to Use Claude: A Beginner's Guide (2026) | PromptWritingStudio</title>
+        <meta name="description" content="How to use Claude AI, explained for beginners: create an account, write prompts that work, understand the Opus/Sonnet/Haiku models, pick free vs paid, and copy-paste prompt templates to start today." />
+        <meta name="keywords" content="how to use claude, how to use claude ai, claude ai beginner guide, claude ai tutorial, getting started with claude, claude prompts for beginners" />
+        <meta property="og:title" content="How to Use Claude: A Beginner's Guide (2026)" />
+        <meta property="og:description" content="A plain-English beginner's guide to using Claude AI — accounts, prompting basics, the models explained, plans, and copy-paste templates." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/how-to-use-claude" />
+        <link rel="canonical" href="https://promptwritingstudio.com/how-to-use-claude" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Beginner's guide — updated June 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              How to Use Claude
+              <span className="block text-[#FFDE59]">A plain-English guide for beginners</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                To use Claude, go to claude.ai, create a free account, and type what you want done in plain English. Claude is an AI assistant from Anthropic that writes, summarises, explains, and analyses for you. The only skill that really matters is the prompt — giving Claude clear context gets dramatically better results than asking a vague question. This guide takes you from your first chat to prompts that actually work.
+              </p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#getting-started" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Start in 5 steps
+              </a>
+              <a href="#templates" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Copy-paste templates
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">What is Claude?</h2>
+            <p className="text-lg text-[#333333] mb-4">
+              <strong>Claude is an AI assistant built by Anthropic.</strong> You talk to it in normal language and it talks back — writing drafts, rewriting your text, summarising documents, explaining hard topics, and answering questions. It works in your browser at claude.ai, with no setup required for everyday use.
+            </p>
+            <p className="text-lg text-[#333333] mb-4">
+              If you have used ChatGPT, Claude will feel familiar. The differences show up in the work: Claude is widely preferred by writers for natural-sounding prose, and it is strong at following detailed instructions and handling long documents.
+            </p>
+            <p className="text-lg text-[#333333]">
+              This page is about using Claude in the chat app for everyday tasks. If you are a developer who wants Claude to edit files and run code in your terminal, that is a separate tool — see our <Link href="/claude-code-guide" className="text-[#1A1A1A] underline font-semibold">Claude Code guide</Link>.
+            </p>
+          </div>
+        </section>
+
+        <section id="getting-started" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">How to start using Claude in 5 steps</h2>
+            <p className="text-lg text-[#333333] mb-10">From a blank screen to a useful answer. No jargon.</p>
+            <div className="space-y-5">
+              {steps.map((s, i) => (
+                <div key={i} className="bg-white p-6 rounded-lg border border-gray-200 flex gap-5 items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold text-xl w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0">{s.n}</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{s.title}</h3>
+                    <p className="text-[#333333]">{s.body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The one skill that matters: prompting</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Most beginners are disappointed by Claude for one reason — they ask vague questions and get vague answers. The fix is not a better model. It is a clearer prompt. Here is the same task, twice.
+            </p>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border-2 border-gray-200">
+                <span className="inline-block bg-gray-200 text-[#333333] text-sm font-bold px-3 py-1 rounded-full mb-3">Weak prompt</span>
+                <p className="font-mono text-sm text-[#1A1A1A] bg-white p-4 rounded border border-gray-200 mb-3">{beforeAfter.weak}</p>
+                <p className="text-[#333333] text-sm">{beforeAfter.weakResult}</p>
+              </div>
+              <div className="bg-[#F9F9F9] p-6 rounded-lg border-2 border-[#FFDE59]">
+                <span className="inline-block bg-[#FFDE59] text-[#1A1A1A] text-sm font-bold px-3 py-1 rounded-full mb-3">Strong prompt</span>
+                <p className="font-mono text-sm text-[#1A1A1A] bg-white p-4 rounded border border-gray-200 mb-3">{beforeAfter.strong}</p>
+                <p className="text-[#333333] text-sm">{beforeAfter.strongResult}</p>
+              </div>
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]"><strong>The pattern:</strong> say who Claude is, who the output is for, what format you want, and what to avoid — then paste any source material. That is 90% of good prompting. For a deeper set of ready-made prompts, see our <Link href="/ai-prompt-generator/claude-prompts" className="text-[#1A1A1A] underline font-semibold">Claude prompts library</Link>.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The biggest beginner mistake to avoid</h2>
+            <div className="bg-white p-6 rounded-lg border-l-4 border-[#FFDE59]">
+              <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Trusting facts and numbers without checking</h3>
+              <p className="text-[#333333] mb-3">
+                Claude can state something with full confidence and still be wrong — a fabricated statistic, a misremembered date, a citation that does not exist. This is called a hallucination, and every AI assistant does it.
+              </p>
+              <p className="text-[#333333]">
+                <strong>How to avoid it:</strong> use Claude for thinking, drafting, and structure — then verify any specific fact, figure, quote, or legal or medical claim against a primary source before you rely on it. Ask Claude to flag what it is unsure about, and turn on web search when you need current information. Treat it as a brilliant, fast assistant who occasionally guesses — not an oracle.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Claude's models: Opus, Sonnet, and Haiku</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Claude comes in three sizes. You usually do not have to choose — Claude picks a sensible default — but it helps to know what they are.
+            </p>
+            <div className="grid md:grid-cols-3 gap-6">
+              {modelTiers.map((m, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                  <h3 className="text-xl font-bold text-[#1A1A1A] mb-1">{m.name}</h3>
+                  <p className="text-[#FFDE59] font-semibold text-sm mb-3 bg-[#1A1A1A] inline-block px-2 py-1 rounded">{m.role}</p>
+                  <p className="text-[#333333] text-sm">{m.body}</p>
+                </div>
+              ))}
+            </div>
+            <p className="text-sm text-[#666666] mt-6">Model names and capabilities change as Anthropic ships new versions. Figures here reflect the current lineup as of June 2026.</p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Free vs paid: which Claude plan do you need?</h2>
+            <p className="text-lg text-[#333333] mb-6">
+              Start free. Upgrade only when you hit the daily limit often or you want the more capable Opus model for heavier work. The free tier runs on Sonnet and is genuinely useful for light daily tasks.
+            </p>
+            <ul className="space-y-3 mb-8">
+              <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0 font-bold">+</span><span className="text-[#333333]"><strong>Free</strong> — Claude Sonnet with a daily message cap. Perfect for learning and occasional use.</span></li>
+              <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0 font-bold">+</span><span className="text-[#333333]"><strong>Claude Pro (around $20/month)</strong> — higher limits, access to Opus, and features like Projects. The right tier for most regular users.</span></li>
+              <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0 font-bold">+</span><span className="text-[#333333]"><strong>Claude Max</strong> — much higher limits for power users who live in Claude all day.</span></li>
+            </ul>
+            <div className="bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]">Not sure which paid tier fits — or whether to use the API instead? We break down the trade-offs in our <Link href="/claude-pro-vs-max-vs-api" className="text-[#1A1A1A] underline font-semibold">Claude Pro vs Max vs API guide</Link>. Pricing shifts, so check claude.ai for the current numbers before subscribing.</p>
+            </div>
+          </div>
+        </section>
+
+        <section id="templates" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">4 copy-paste prompt templates to start with</h2>
+            <p className="text-lg text-[#333333] mb-10">
+              Fill in the bracketed slots and paste straight into Claude. These cover the tasks beginners reach for most.
+            </p>
+            <div className="space-y-6">
+              {templates.map((t, i) => (
+                <div key={i} className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200">
+                  <h3 className="text-xl font-bold text-[#1A1A1A] mb-3">{t.title}</h3>
+                  <pre className="font-mono text-sm text-[#1A1A1A] bg-white p-4 rounded border border-gray-200 whitespace-pre-wrap">{t.template}</pre>
+                </div>
+              ))}
+            </div>
+            <p className="text-[#333333] mt-8">
+              Want more than four? Our <Link href="/claude-prompts" className="text-[#1A1A1A] underline font-semibold">Claude prompts library</Link> has dozens of tested prompts by task, and the <Link href="/ai-prompt-generator" className="text-[#1A1A1A] underline font-semibold">free AI prompt generator</Link> builds one for your exact situation. Once you settle on a way you like Claude to behave, lock it in with a <Link href="/claude-system-prompt" className="text-[#1A1A1A] underline font-semibold">Claude system prompt</Link>, or go deeper on longer pieces with <Link href="/claude-for-writing" className="text-[#1A1A1A] underline font-semibold">Claude for writing</Link>.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions beginners ask most when they first open Claude.</p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-50 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              Knowing how to use Claude is step one. Getting great output is the prompt.
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              The gap between a frustrating AI answer and a genuinely useful one is almost always the prompt — not the tool. PromptWritingStudio teaches the prompting system that works across Claude, ChatGPT, and Gemini, so you stop guessing and start getting the output you actually wanted.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="https://courses.becomeawritertoday.com/purchase?product_id=6640678" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Join Now
+              </a>
+              <Link href="/ai-prompt-generator/claude-prompts" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                Browse Claude prompts
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}


### PR DESCRIPTION
## What

19 net-new pages from the 2026-06-16 content plan (PromptWritingStudio), written draft-first then editor-reconciled. Every slug was dedup-verified absent against live + repo before writing; singular/plural and word-order keyword variants were collapsed into single canonical pages.

### Pages (by cluster)
- **Claude Code**: claude-code-pricing (27k vol), claude-code-review, claude-code-tutorial, claude-code-alternatives, claude-code-sub-agents, claude-code-slash-commands, claude-code-generator
- **Model / comparison**: claude-vs-gemini, claude-sonnet-vs-opus, claude-context-window, anthropic-api-pricing
- **Prompting / usage**: claude-prompts, claude-system-prompt, how-to-use-claude, claude-for-writing, claude-for-business, claude-for-coding, claude-artifacts, claude-projects

### Quality
- Pricing/model facts sourced live from `lib/claude-data.js` (no hardcoded decaying numbers); `LastVerified` badges on pricing pages.
- Internal links reconciled across the full new cluster; zero dead internal links.
- claude-code-tutorial differentiated from existing /claude-code-guide (beginner walkthrough vs reference).

### ⚠️ Before merge (not blocking preview)
- `lib/claude-data.js` is ~2 months stale (shows Opus 4.7; live is Opus 4.8). Run a freshness bump on the data JSONs before publishing the pricing/model pages — every figure inherits from the data file.
- A few pages came in light (<1.2k words): claude-sonnet-vs-opus, claude-code-generator, claude-for-business, claude-code-review — optional expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)