### PR TITLE
fix: stale claude-opus-4-7 model id breaks build

### DIFF
--- a/pages/claude-for-writing.js
+++ b/pages/claude-for-writing.js
@@ -7,7 +7,7 @@ import { getAIModelById } from '../lib/ai-models'
 const COURSE_URL = 'https://courses.becomeawritertoday.com/purchase?product_id=6640678'
 
 // Pull live model facts from the central JSON so names/prices update in one place.
-const opus = getAIModelById('claude-opus-4-7')
+const opus = getAIModelById('claude-opus-4-8')
 const sonnet = getAIModelById('claude-sonnet-4-6')
 const haiku = getAIModelById('claude-haiku-4-5-20251001')
 

--- a/pages/claude-vs-gemini.js
+++ b/pages/claude-vs-gemini.js
@@ -7,7 +7,7 @@ import { getAIModelById, AI_MODELS_META } from '../lib/ai-models'
 
 // Pull current model facts from the central multi-vendor JSON so prices/names/context
 // windows update in one place. Never hardcode decaying numbers in prose.
-const opus = getAIModelById('claude-opus-4-7')
+const opus = getAIModelById('claude-opus-4-8')
 const sonnet = getAIModelById('claude-sonnet-4-6')
 const haiku = getAIModelById('claude-haiku-4-5-20251001')
 const geminiPro = getAIModelById('gemini-2-5-pro')

--- a/pages/how-to-use-claude.js
+++ b/pages/how-to-use-claude.js
@@ -5,7 +5,7 @@ import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator
 import { getAIModelById } from '../lib/ai-models'
 
 // Pull current model facts from the central JSON so prices/names update in one place.
-const opus = getAIModelById('claude-opus-4-7')
+const opus = getAIModelById('claude-opus-4-8')
 const sonnet = getAIModelById('claude-sonnet-4-6')
 const haiku = getAIModelById('claude-haiku-4-5-20251001')
 


### PR DESCRIPTION
## Problem
The `main` deploy has been failing since PR #50 (`6d5041a`):

```
TypeError: Cannot read properties of undefined (reading 'display_name')
Error: Failed to collect page data for /claude-for-writing
```

PR #50's new AEO pages call `getAIModelById('claude-opus-4-7')`, but `data/ai-models.json` was bumped to `claude-opus-4-8` (PR #48 era). The lookup returns `undefined`, and reading `.display_name` off it crashes `next build`.

(The `@anthropic-ai/sdk` "module not found" you may see locally is a stale-node_modules red herring — it's in package.json + lockfile and `npm ci` resolves it.)

## Fix
Updated the three pages that hardcoded the old id to `claude-opus-4-8`:
- `pages/claude-for-writing.js`
- `pages/claude-vs-gemini.js`
- `pages/how-to-use-claude.js`

Observatory data/run snapshots that reference `claude-opus-4-7` are historical records — left untouched.

`npm run build` now passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)