### PR TITLE
feat: Agent Prompt Grader — CLAUDE.md scoring with edits mode

### DIFF
--- a/__tests__/critique/agent-rubric-latency.test.js
+++ b/__tests__/critique/agent-rubric-latency.test.js
@@ -44,3 +44,11 @@ test('edits mode: single attempt, fabricated revision dropped via salvage', asyn
   expect(result.revisions).toHaveLength(1)
   expect(result.revisions[0].before_excerpt).toBe('You are the repo agent')
 })
+
+test('parseEnvelope tolerates an unterminated code fence', async () => {
+  const { parseEnvelope } = require('../../lib/critique/judge')
+  const obj = { safety_flag: '', criteria: [], failure_modes: [], revisions: [], summary: 'x' }
+  expect(parseEnvelope('```json\n' + JSON.stringify(obj))).toEqual(obj)
+  expect(parseEnvelope('```json\n' + JSON.stringify(obj) + '\n``')).toEqual(obj)
+  expect(() => parseEnvelope('```json\n{"truncated": tru')).toThrow(/non-JSON/)
+})

--- a/__tests__/critique/agent-rubric-latency.test.js
+++ b/__tests__/critique/agent-rubric-latency.test.js
@@ -1,0 +1,46 @@
+// Edits mode must run exactly ONE judge attempt (function-wall constraint) with
+// salvage active; full mode keeps its strict-then-salvage two attempts.
+import { critiquePrompt } from '../../lib/critique'
+
+const FILE = 'You are the repo agent. Build with npm run build. Never push to main. On errors, stop and report.'
+
+function countingFetch(payload) {
+  let n = 0
+  const fetchImpl = async () => {
+    n++
+    return {
+      ok: true, status: 200,
+      json: async () => ({ id: 'msg', content: [{ type: 'text', text: JSON.stringify(payload) }], usage: { input_tokens: 100, output_tokens: 100 } }),
+    }
+  }
+  return { fetchImpl, calls: () => n }
+}
+
+const agentEnvelope = {
+  safety_flag: '',
+  criteria: [
+    { id: 'identity_scope', score: 2, justification: 'Role stated.', evidence_span: 'You are the repo agent' },
+    { id: 'environment_context', score: 2, justification: 'Build cmd given.', evidence_span: 'Build with npm run build' },
+    { id: 'behavioral_rules', score: 2, justification: 'Concrete ban.', evidence_span: 'Never push to main' },
+    { id: 'failure_guidance', score: 2, justification: 'Error path given.', evidence_span: 'On errors, stop and report' },
+    { id: 'maintainability', score: 0, justification: 'No structure.', evidence_span: '' },
+  ],
+  failure_modes: ['No directory map: the agent will guess at paths.'],
+  revisions: [
+    { issue: 'Identity lacks project name', before_excerpt: 'You are the repo agent', after_excerpt: 'You are the agent for the ACME web repo' },
+    // one fabricated excerpt — salvage must DROP it on the single attempt, not retry
+    { issue: 'Fabricated', before_excerpt: 'this text is not in the file', after_excerpt: 'anything' },
+  ],
+  summary: 'Decent skeleton.',
+}
+
+test('edits mode: single attempt, fabricated revision dropped via salvage', async () => {
+  const { fetchImpl, calls } = countingFetch(agentEnvelope)
+  const result = await critiquePrompt({
+    targetPrompt: FILE, rubricId: 'agent-prompt', judgeModel: 'grader-haiku',
+    studioAnthropicKey: 'k', fetchImpl,
+  })
+  expect(calls()).toBe(1) // never retries in edits mode
+  expect(result.revisions).toHaveLength(1)
+  expect(result.revisions[0].before_excerpt).toBe('You are the repo agent')
+})

--- a/__tests__/critique/critique-gate.test.js
+++ b/__tests__/critique/critique-gate.test.js
@@ -43,11 +43,14 @@ describe('critique endpoint — free-metered grader policy', () => {
   })
   beforeEach(() => _resetGradeStoreForTesting())
 
-  it('GET lists rubrics without auth', async () => {
+  it('GET lists rubrics without auth — returns both rubrics', async () => {
     const res = mockRes()
     await handler({ method: 'GET', headers: {} }, res)
     expect(res.statusCode).toBe(200)
     expect(Array.isArray(res.body.rubrics)).toBe(true)
+    const ids = res.body.rubrics.map(r => r.id)
+    expect(ids).toContain('prompt-quality')
+    expect(ids).toContain('agent-prompt')
   })
 
   it('rejects a missing targetPrompt with 400 before metering', async () => {
@@ -98,9 +101,32 @@ describe('critique endpoint — free-metered grader policy', () => {
     }
   })
 
-  it('rejects an oversized prompt with 400', async () => {
+  it('rejects an oversized prompt (>8000) for the default chat rubric with 400', async () => {
     const res = mockRes()
     await handler(postReq({ body: { targetPrompt: 'x'.repeat(8001) } }), res)
     expect(res.statusCode).toBe(400)
+    expect(res.body.code).toBe('bad_request')
+  })
+
+  it('allows a >8000-char prompt for the agent-prompt rubric (24000 limit)', async () => {
+    const res = mockRes()
+    await handler(postReq({ body: { targetPrompt: 'x'.repeat(8001), rubricId: 'agent-prompt' } }), res)
+    // Passes the char limit gate → reaches the gateway → 401 (no API key in test env)
+    expect(res.statusCode).toBe(401)
+    expect(res.body.code).toBe('missing_key')
+  })
+
+  it('rejects a >24000-char prompt even for the agent-prompt rubric', async () => {
+    const res = mockRes()
+    await handler(postReq({ body: { targetPrompt: 'x'.repeat(24001), rubricId: 'agent-prompt' } }), res)
+    expect(res.statusCode).toBe(400)
+    expect(res.body.code).toBe('bad_request')
+  })
+
+  it('returns 404 for an unknown rubricId', async () => {
+    const res = mockRes()
+    await handler(postReq({ body: { targetPrompt: 'do a thing', rubricId: 'no-such-rubric' } }), res)
+    expect(res.statusCode).toBe(404)
+    expect(res.body.code).toBe('unknown_rubric')
   })
 })

--- a/__tests__/critique/critique.test.js
+++ b/__tests__/critique/critique.test.js
@@ -1,9 +1,50 @@
 import { critiquePrompt } from '../../lib/critique'
-import { getRubric } from '../../data/critique-rubrics'
+import { getRubric, listRubrics } from '../../data/critique-rubrics'
 import { renderJudgePrompt, parseJudgeResponse, computeOverall } from '../../lib/critique/judge'
 import { MalformedCritiqueError, UnknownRubricError } from '../../lib/critique/errors'
 
 const RUBRIC = getRubric('prompt-quality')
+const AGENT_RUBRIC = getRubric('agent-prompt')
+
+describe('rubric registry', () => {
+  it('lists both rubrics', () => {
+    const rubrics = listRubrics()
+    const ids = rubrics.map(r => r.id)
+    expect(ids).toContain('prompt-quality')
+    expect(ids).toContain('agent-prompt')
+  })
+
+  it('prompt-quality version hash has not drifted (v1-6dfd72d2)', () => {
+    expect(RUBRIC.version).toBe('v1-6dfd72d2')
+  })
+
+  it('agent-prompt rubric has rewriteMode edits and maxChars 24000', () => {
+    expect(AGENT_RUBRIC.rewriteMode).toBe('edits')
+    expect(AGENT_RUBRIC.maxChars).toBe(24000)
+    expect(AGENT_RUBRIC.criteria).toHaveLength(5)
+  })
+
+  it('agent-prompt rubric has the expected criterion ids', () => {
+    const ids = AGENT_RUBRIC.criteria.map(c => c.id)
+    expect(ids).toEqual(['identity_scope', 'environment_context', 'behavioral_rules', 'failure_guidance', 'maintainability'])
+  })
+})
+
+describe('agent rubric judge prompt', () => {
+  const AGENT_TARGET = '# Assistant\n\nYou are a helpful coding assistant. Use Node.js.'
+
+  it('renders edits-mode prompt containing "revisions" keyword, not "rewrite"', () => {
+    const p = renderJudgePrompt(AGENT_TARGET, AGENT_RUBRIC)
+    expect(p).toContain('revisions')
+    expect(p).not.toContain('"rewrite"')
+    for (const c of AGENT_RUBRIC.criteria) expect(p).toContain(c.id)
+  })
+
+  it('edits-mode prompt contains FILE TO CRITIQUE label', () => {
+    const p = renderJudgePrompt(AGENT_TARGET, AGENT_RUBRIC)
+    expect(p).toContain('FILE TO CRITIQUE')
+  })
+})
 
 // A prompt that contains a verbatim phrase for each criterion, so grounded
 // evidence spans can be validated.

--- a/__tests__/critique/grader.test.js
+++ b/__tests__/critique/grader.test.js
@@ -5,6 +5,42 @@ import { critiquePrompt, GRADER_JUDGE_MODEL } from '../../lib/critique'
 import { parseGraderExtras } from '../../lib/critique/judge'
 import { MalformedCritiqueError } from '../../lib/critique/errors'
 import { MissingKeyError } from '../../lib/gateway/errors'
+import { getRubric } from '../../data/critique-rubrics'
+
+const AGENT_RUBRIC = getRubric('agent-prompt')
+
+const AGENT_TARGET = `# Project assistant
+
+You are a helpful coding assistant. Stack: Next.js 13, Tailwind CSS.
+Always run npm run build before committing.
+If you are unsure about a destructive operation, ask the user first.`
+
+function goodAgentCriteria() {
+  return [
+    { id: 'identity_scope', score: 1, justification: 'Names a project but scope is thin.', evidence_span: 'You are a helpful coding assistant' },
+    { id: 'environment_context', score: 2, justification: 'Stack is named.', evidence_span: 'Next.js 13, Tailwind CSS' },
+    { id: 'behavioral_rules', score: 2, justification: 'Commit rule present.', evidence_span: 'run npm run build before committing' },
+    { id: 'failure_guidance', score: 2, justification: 'Escalation path present.', evidence_span: 'ask the user first' },
+    { id: 'maintainability', score: 1, justification: 'Minimal structure.', evidence_span: 'Project assistant' },
+  ]
+}
+
+function goodAgentEnvelope(overrides = {}) {
+  return {
+    safety_flag: '',
+    criteria: goodAgentCriteria(),
+    failure_modes: ['Stack versions are not pinned so the agent may assume the wrong Next.js APIs.'],
+    revisions: [
+      {
+        issue: 'Identity section does not state what project the agent is operating in.',
+        before_excerpt: 'You are a helpful coding assistant.',
+        after_excerpt: 'You are the coding assistant for the PromptWritingStudio Next.js site at github.com/org/repo.',
+      },
+    ],
+    summary: 'Thin but usable agent prompt.',
+    ...overrides,
+  }
+}
 
 const TARGET =
   'You are a senior copywriter. Write a 100-word product description in bullet points. Keep the tone friendly. For example, highlight benefits.'
@@ -177,6 +213,107 @@ describe('critiquePrompt via the Anthropic-direct grader judge', () => {
       fetchImpl,
     })
     expect(JSON.parse(calls[0].body).messages[0].content).toContain('ChatGPT')
+  })
+})
+
+describe('parseGraderExtras — edits mode (agent-prompt rubric)', () => {
+  it('accepts a valid envelope with grounded revisions', () => {
+    const extras = parseGraderExtras(goodAgentEnvelope(), AGENT_TARGET, AGENT_RUBRIC)
+    expect(extras.flagged).toBe(false)
+    expect(extras.revisions).toHaveLength(1)
+    expect(extras.revisions[0].before_excerpt).toBe('You are a helpful coding assistant.')
+    expect(extras.rewrite).toBe('')
+  })
+
+  it('drops revisions whose before_excerpt is not found verbatim in the target', () => {
+    const env = goodAgentEnvelope({
+      revisions: [
+        {
+          issue: 'Not grounded.',
+          before_excerpt: 'You are a world-class engineer with decades of experience',
+          after_excerpt: 'You are the dedicated assistant for the PromptWritingStudio repo.',
+        },
+      ],
+    })
+    expect(() => parseGraderExtras(env, AGENT_TARGET, AGENT_RUBRIC)).toThrow(/no grounded/)
+  })
+
+  it('throws when no revisions survive grounding', () => {
+    const env = goodAgentEnvelope({ revisions: [] })
+    expect(() => parseGraderExtras(env, AGENT_TARGET, AGENT_RUBRIC)).toThrow(/no grounded/)
+  })
+
+  it('drops revisions where before_excerpt equals after_excerpt', () => {
+    const env = goodAgentEnvelope({
+      revisions: [
+        {
+          issue: 'Identical',
+          before_excerpt: 'You are a helpful coding assistant.',
+          after_excerpt: 'You are a helpful coding assistant.',
+        },
+      ],
+    })
+    expect(() => parseGraderExtras(env, AGENT_TARGET, AGENT_RUBRIC)).toThrow(/no grounded/)
+  })
+
+  it('throws when revisions field is missing', () => {
+    const env = goodAgentEnvelope()
+    delete env.revisions
+    expect(() => parseGraderExtras(env, AGENT_TARGET, AGENT_RUBRIC)).toThrow(/revisions missing/)
+  })
+
+  it('returns the flagged path (safety) in edits mode without validating revisions', () => {
+    const env = goodAgentEnvelope({ safety_flag: 'Malicious.', revisions: [] })
+    const extras = parseGraderExtras(env, AGENT_TARGET, AGENT_RUBRIC)
+    expect(extras.flagged).toBe(true)
+    expect(extras.safetyReason).toBe('Malicious.')
+  })
+})
+
+describe('critiquePrompt — agent rubric end-to-end (mocked gateway)', () => {
+  function makeAnthropicFetch(payload) {
+    const content = typeof payload === 'string' ? payload : JSON.stringify(payload)
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: 'msg_test',
+        content: [{ type: 'text', text: content }],
+        usage: { input_tokens: 300, output_tokens: 200 },
+      }),
+    })
+    return { fetchImpl }
+  }
+
+  it('returns revisions (not rewrite) for the agent-prompt rubric', async () => {
+    const { fetchImpl } = makeAnthropicFetch(goodAgentEnvelope())
+    const result = await critiquePrompt({
+      targetPrompt: AGENT_TARGET,
+      rubricId: 'agent-prompt',
+      judgeModel: GRADER_JUDGE_MODEL,
+      studioAnthropicKey: 'sk-ant-STUDIO',
+      fetchImpl,
+    })
+    expect(result.flagged).toBe(false)
+    expect(result.rubricId).toBe('agent-prompt')
+    expect(result.revisions).toHaveLength(1)
+    expect(result.rewrite).toBeUndefined()
+    expect(result.target).toBeUndefined()
+    expect(result.criteria).toHaveLength(5)
+  })
+
+  it('does not reject an unknown target value in edits mode', async () => {
+    const { fetchImpl } = makeAnthropicFetch(goodAgentEnvelope())
+    await expect(
+      critiquePrompt({
+        targetPrompt: AGENT_TARGET,
+        rubricId: 'agent-prompt',
+        target: 'copilot',
+        judgeModel: GRADER_JUDGE_MODEL,
+        studioAnthropicKey: 'sk-ant-STUDIO',
+        fetchImpl,
+      })
+    ).resolves.toMatchObject({ rubricId: 'agent-prompt' })
   })
 })
 

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 
 const toolsItems = [
   { href: '/prompt-grader', label: '🧪 Prompt Grader', bold: true },
+  { href: '/agent-prompt-grader', label: '🤖 Agent Prompt Grader', bold: true },
   { href: '/calculators', label: '📊 Business Calculators', bold: true },
   { href: '/ai-prompt-generator', label: '🤖 AI Prompt Generator' },
   { href: '/gemini-prompt-generator', label: '💎 Gemini Prompt Generator' },

--- a/components/tools/PromptGrader.js
+++ b/components/tools/PromptGrader.js
@@ -29,6 +29,10 @@ const AGENT_EXAMPLES = [
     label: 'Partial CLAUDE.md',
     text: `# Project assistant\n\nYou help with a Next.js site. Use Tailwind for styling. Don't break existing pages.`,
   },
+  {
+    label: 'Strong CLAUDE.md',
+    text: `# PromptWritingStudio — Claude Code Rules\n\n## Project overview\nNext.js 13 (Pages Router) site on Netlify. Sells a single course via Teachable.\n\n## Stack\n- Framework: Next.js 13, Pages Router only — no App Router\n- Styling: Tailwind CSS only\n- DB: None. All state is client-side localStorage.\n- Deployment: Netlify, auto-deploys from main\n\n## Dev commands\n\`npm run dev\` — localhost:3000\n\`npm run build\` — production build\n\n## Rules\n- Never add App Router files under /app\n- Never link to courses.becomeawritertoday.com (course is closed)\n- Always run \`npm run build\` before committing\n- If a change touches the critique endpoint, run jest __tests__/critique first\n\n## Failure handling\nIf uncertain about a destructive operation (rm, force-push, db migration), stop and ask. Do not guess at deploy secrets — check CLAUDE.md or ask.`,
+  },
 ]
 
 // Free-plan history cap (client-side; the paid plan lifts it).
@@ -78,10 +82,12 @@ function ScoreBar({ score, max }) {
   )
 }
 
-function OverallBadge({ overall }) {
+function OverallBadge({ overall, editsMode = false }) {
   const pct = overall.percentage
   const tone = pct >= 75 ? 'text-green-600' : pct >= 45 ? 'text-amber-500' : 'text-red-500'
-  const verdict = pct >= 75 ? 'Strong prompt' : pct >= 45 ? 'Usable, with gaps' : 'Needs a rewrite'
+  const verdict = editsMode
+    ? pct >= 75 ? 'Strong agent prompt' : pct >= 45 ? 'Usable, with gaps' : 'Needs significant work'
+    : pct >= 75 ? 'Strong prompt' : pct >= 45 ? 'Usable, with gaps' : 'Needs a rewrite'
   return (
     <div className="text-center">
       <div className={`text-6xl font-bold ${tone}`}>{pct}</div>
@@ -290,7 +296,7 @@ export default function PromptGrader({
         <div className="mt-6 space-y-6">
           <div className="bg-white rounded-lg shadow-md border border-[#E5E5E5] p-6">
             <div className="grid md:grid-cols-3 gap-6 items-center">
-              <OverallBadge overall={result.overall} />
+              <OverallBadge overall={result.overall} editsMode={isEditsMode} />
               <div className="md:col-span-2">
                 <p className="text-[#333333]">{result.summary}</p>
                 {result.failureModes?.length > 0 && (

--- a/components/tools/PromptGrader.js
+++ b/components/tools/PromptGrader.js
@@ -8,7 +8,7 @@ const TARGETS = [
   { id: 'gemini', label: 'Gemini' },
 ]
 
-const EXAMPLES = [
+const CHAT_EXAMPLES = [
   { label: 'Weak prompt', text: 'write a blog post about productivity' },
   {
     label: 'Decent prompt',
@@ -17,6 +17,17 @@ const EXAMPLES = [
   {
     label: 'Strong prompt',
     text: 'You are an experienced productivity coach who writes for creative freelancers. Write a 600-word blog post about time-blocking for freelance designers juggling 3+ clients. Structure: a hook about context-switching costs, 3 practical time-blocking techniques with a concrete example each, and a closing action step. Friendly, direct tone. Avoid generic advice like "stay focused". Format with H2 subheadings and short paragraphs.',
+  },
+]
+
+const AGENT_EXAMPLES = [
+  {
+    label: 'Thin CLAUDE.md',
+    text: 'You are a helpful coding assistant. Help the user with their code.',
+  },
+  {
+    label: 'Partial CLAUDE.md',
+    text: `# Project assistant\n\nYou help with a Next.js site. Use Tailwind for styling. Don't break existing pages.`,
   },
 ]
 
@@ -30,22 +41,28 @@ function getLibrary() {
   return storage ? createSavedLibrary(storage) : null
 }
 
-function loadHistory() {
+function loadHistory(historySource) {
   const lib = getLibrary()
   if (!lib) return []
-  return lib.list().filter(it => it.source === 'prompt-grader')
+  return lib.list().filter(it => it.source === historySource)
 }
 
-function saveToHistory(prompt, result) {
+function saveToHistory(prompt, result, historySource) {
   const lib = getLibrary()
   if (!lib) return []
   const title = prompt.length > 64 ? `${prompt.slice(0, 64)}…` : prompt
-  const item = lib.save({ title, body: prompt, tags: [`score:${result.overall.percentage}`], source: 'prompt-grader' })
+  const rubricTag = `rubric:${result.rubricId || 'prompt-quality'}`
+  const item = lib.save({
+    title,
+    body: prompt,
+    tags: [`score:${result.overall.percentage}`, rubricTag],
+    source: historySource,
+  })
   lib.update(item.id, { grade: result })
-  // Free plan keeps the newest FREE_HISTORY_MAX grades.
-  const entries = lib.list().filter(it => it.source === 'prompt-grader')
+  // Free plan keeps the newest FREE_HISTORY_MAX grades per source.
+  const entries = lib.list().filter(it => it.source === historySource)
   entries.slice(FREE_HISTORY_MAX).forEach(old => lib.remove(old.id))
-  return loadHistory()
+  return loadHistory(historySource)
 }
 
 function ScoreBar({ score, max }) {
@@ -74,7 +91,24 @@ function OverallBadge({ overall }) {
   )
 }
 
-export default function PromptGrader() {
+export default function PromptGrader({
+  rubricId = 'prompt-quality',
+  historySource = 'prompt-grader',
+  placeholder,
+  examples,
+  heading,
+} = {}) {
+  const isEditsMode = rubricId === 'agent-prompt'
+  const effectiveExamples = examples ?? (isEditsMode ? AGENT_EXAMPLES : CHAT_EXAMPLES)
+  const effectivePlaceholder =
+    placeholder ??
+    (isEditsMode
+      ? 'Paste your CLAUDE.md or agent system prompt. The grader scores it on 5 agent-specific criteria and suggests targeted edits.'
+      : 'Paste the prompt you give ChatGPT, Claude, or Gemini. The grader scores it on 5 criteria and rewrites it.')
+  const effectiveHeading = heading ?? (isEditsMode ? 'Paste your CLAUDE.md or system prompt' : 'Paste your prompt')
+  const effectiveMaxLength = isEditsMode ? 24000 : 8000
+  const gradeButtonLabel = isEditsMode ? 'Grade my agent prompt' : 'Grade my prompt'
+
   const [prompt, setPrompt] = useState('')
   const [target, setTarget] = useState('claude')
   const [status, setStatus] = useState('idle') // idle | grading | done | error
@@ -86,9 +120,9 @@ export default function PromptGrader() {
   const [copied, setCopied] = useState(false)
 
   useEffect(() => {
-    setHistory(loadHistory())
-    setGradedOnce(loadHistory().length > 0)
-  }, [])
+    setHistory(loadHistory(historySource))
+    setGradedOnce(loadHistory(historySource).length > 0)
+  }, [historySource])
 
   async function grade() {
     if (!prompt.trim() || status === 'grading') return
@@ -96,10 +130,12 @@ export default function PromptGrader() {
     setError('')
     setCopied(false)
     try {
+      const body = { targetPrompt: prompt, rubricId }
+      if (!isEditsMode) body.target = target
       const res = await fetch('/api/studio/critique', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ targetPrompt: prompt, target }),
+        body: JSON.stringify(body),
       })
       const data = await res.json()
       if (!res.ok) {
@@ -113,7 +149,7 @@ export default function PromptGrader() {
       setStatus('done')
       setGradedOnce(true)
       if (!data.flagged) {
-        setHistory(saveToHistory(prompt, data))
+        setHistory(saveToHistory(prompt, data, historySource))
       }
     } catch (e) {
       setError('Could not reach the grader. Check your connection and try again.')
@@ -146,20 +182,20 @@ export default function PromptGrader() {
       {/* Input */}
       <div className="bg-white rounded-lg shadow-md border border-[#E5E5E5] p-6">
         <label htmlFor="grader-input" className="block font-bold text-[#1A1A1A] mb-2">
-          Paste your prompt
+          {effectiveHeading}
         </label>
         <textarea
           id="grader-input"
           value={prompt}
           onChange={e => setPrompt(e.target.value)}
-          rows={7}
-          maxLength={8000}
-          placeholder="Paste the prompt you give ChatGPT, Claude, or Gemini. The grader scores it on 5 criteria and rewrites it."
+          rows={isEditsMode ? 12 : 7}
+          maxLength={effectiveMaxLength}
+          placeholder={effectivePlaceholder}
           className="w-full border border-gray-300 rounded-lg p-4 text-[#333333] focus:outline-none focus:ring-2 focus:ring-[#FFDE59] resize-y"
         />
         <div className="flex flex-wrap items-center gap-2 mt-3">
           <span className="text-sm text-gray-500">No prompt handy? Try one:</span>
-          {EXAMPLES.map(ex => (
+          {effectiveExamples.map(ex => (
             <button
               key={ex.label}
               type="button"
@@ -172,30 +208,32 @@ export default function PromptGrader() {
         </div>
 
         <div className="flex flex-col sm:flex-row sm:items-center gap-4 mt-5">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold text-[#333333]">Rewrite for:</span>
-            {TARGETS.map(t => (
-              <button
-                key={t.id}
-                type="button"
-                onClick={() => setTarget(t.id)}
-                className={`text-sm px-3 py-1 rounded-full border transition ${
-                  target === t.id
-                    ? 'bg-[#1A1A1A] text-white border-[#1A1A1A]'
-                    : 'border-gray-300 text-[#333333] hover:border-gray-400'
-                }`}
-              >
-                {t.label}
-              </button>
-            ))}
-          </div>
+          {!isEditsMode && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-[#333333]">Rewrite for:</span>
+              {TARGETS.map(t => (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setTarget(t.id)}
+                  className={`text-sm px-3 py-1 rounded-full border transition ${
+                    target === t.id
+                      ? 'bg-[#1A1A1A] text-white border-[#1A1A1A]'
+                      : 'border-gray-300 text-[#333333] hover:border-gray-400'
+                  }`}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          )}
           <button
             type="button"
             onClick={grade}
             disabled={status === 'grading' || !prompt.trim() || outOfGrades}
-            className="sm:ml-auto bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition disabled:opacity-50 disabled:cursor-not-allowed"
+            className={`${!isEditsMode ? 'sm:ml-auto' : ''} bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition disabled:opacity-50 disabled:cursor-not-allowed`}
           >
-            {status === 'grading' ? 'Grading…' : 'Grade my prompt'}
+            {status === 'grading' ? 'Grading…' : gradeButtonLabel}
           </button>
         </div>
         {meter && !outOfGrades && (
@@ -294,26 +332,55 @@ export default function PromptGrader() {
             </div>
           </div>
 
-          <div className="bg-[#F9F9F9] rounded-lg border border-[#E5E5E5] p-6">
-            <div className="flex items-center justify-between gap-4 mb-3">
-              <h3 className="font-bold text-[#1A1A1A]">
-                Rewritten for {TARGETS.find(t => t.id === (result.target || target))?.label}
-              </h3>
-              <button
-                type="button"
-                onClick={copyRewrite}
-                className="bg-[#FFDE59] text-[#1A1A1A] px-4 py-2 rounded-lg font-bold hover:bg-[#E5C84F] transition text-sm"
-              >
-                {copied ? 'Copied!' : 'Copy rewrite'}
-              </button>
+          {isEditsMode && result.revisions?.length > 0 && (
+            <div className="bg-[#F9F9F9] rounded-lg border border-[#E5E5E5] p-6">
+              <h3 className="font-bold text-[#1A1A1A] mb-4">Suggested edits</h3>
+              <div className="space-y-4">
+                {result.revisions.map((rev, i) => (
+                  <div key={i} className="bg-white border border-[#E5E5E5] rounded-lg p-4">
+                    <p className="text-sm font-semibold text-[#1A1A1A] mb-2">{rev.issue}</p>
+                    <div className="space-y-2">
+                      <div>
+                        <span className="text-xs uppercase tracking-wide text-gray-400 font-semibold">Before</span>
+                        <pre className="whitespace-pre-wrap text-sm text-red-700 bg-red-50 border border-red-100 rounded p-3 mt-1 font-sans">
+                          {rev.before_excerpt}
+                        </pre>
+                      </div>
+                      <div>
+                        <span className="text-xs uppercase tracking-wide text-gray-400 font-semibold">After</span>
+                        <pre className="whitespace-pre-wrap text-sm text-green-800 bg-green-50 border border-green-100 rounded p-3 mt-1 font-sans">
+                          {rev.after_excerpt}
+                        </pre>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
-            <pre className="whitespace-pre-wrap text-sm text-[#333333] font-sans bg-white border border-gray-200 rounded-lg p-4">
-              {result.rewrite}
-            </pre>
-            <p className="text-sm text-gray-500 mt-3">
-              Anything in [BRACKETS] is a detail only you know. Fill it in before you run the prompt.
-            </p>
-          </div>
+          )}
+
+          {!isEditsMode && result.rewrite && (
+            <div className="bg-[#F9F9F9] rounded-lg border border-[#E5E5E5] p-6">
+              <div className="flex items-center justify-between gap-4 mb-3">
+                <h3 className="font-bold text-[#1A1A1A]">
+                  Rewritten for {TARGETS.find(t => t.id === (result.target || target))?.label}
+                </h3>
+                <button
+                  type="button"
+                  onClick={copyRewrite}
+                  className="bg-[#FFDE59] text-[#1A1A1A] px-4 py-2 rounded-lg font-bold hover:bg-[#E5C84F] transition text-sm"
+                >
+                  {copied ? 'Copied!' : 'Copy rewrite'}
+                </button>
+              </div>
+              <pre className="whitespace-pre-wrap text-sm text-[#333333] font-sans bg-white border border-gray-200 rounded-lg p-4">
+                {result.rewrite}
+              </pre>
+              <p className="text-sm text-gray-500 mt-3">
+                Anything in [BRACKETS] is a detail only you know. Fill it in before you run the prompt.
+              </p>
+            </div>
+          )}
 
           {gradedOnce && (
             <div className="bg-white rounded-lg shadow-md border border-[#E5E5E5] p-6">
@@ -322,7 +389,7 @@ export default function PromptGrader() {
                 Your last {FREE_HISTORY_MAX} grades are saved in this browser. Get prompt-writing tips and first
                 access to the unlimited plan by email.
               </p>
-              <EmailCapture source="prompt-grader" label="" buttonText="Subscribe" theme="light" />
+              <EmailCapture source={historySource} label="" buttonText="Subscribe" theme="light" />
             </div>
           )}
         </div>

--- a/data/critique-rubrics.js
+++ b/data/critique-rubrics.js
@@ -7,7 +7,7 @@
 //
 // Shape: { id, version, title, scale: {min,max,labels}, passThreshold (on the
 // normalized 0-max scale), judgeInstructions, criteria: [{ id, name,
-// description, weight }] }.
+// description, weight }], rewriteMode: 'full'|'edits', maxChars }.
 
 import { createHash } from 'crypto'
 
@@ -22,10 +22,23 @@ const SCALE = {
   },
 }
 
+const AGENT_SCALE = {
+  min: 0,
+  max: 3,
+  labels: {
+    0: 'Absent — the file says nothing about this',
+    1: 'Weak — mentioned but too vague to act on',
+    2: 'Adequate — clear enough to guide the agent',
+    3: 'Excellent — explicit, specific, and unambiguous',
+  },
+}
+
 const RUBRICS = [
   {
     id: 'prompt-quality',
     title: 'Prompt Quality',
+    rewriteMode: 'full',
+    maxChars: 8000,
     scale: SCALE,
     passThreshold: 2.0,
     judgeInstructions:
@@ -59,6 +72,53 @@ const RUBRICS = [
         id: 'examples_or_criteria',
         name: 'Examples or success criteria',
         description: 'Gives examples, or explicit quality/success criteria, to steer the result.',
+        weight: 1,
+      },
+    ],
+  },
+  {
+    id: 'agent-prompt',
+    title: 'Agent Prompt Quality',
+    rewriteMode: 'edits',
+    maxChars: 24000,
+    scale: AGENT_SCALE,
+    passThreshold: 2.0,
+    judgeInstructions:
+      'You are a senior AI-engineering reviewer specialising in CLAUDE.md files and agent system prompts. You are scoring a CLAUDE.md or agent system prompt — not a chat prompt. The file exists to give a persistent AI agent its identity, operating context, behavioural rules, and failure-handling guidance. Be strict: score only what is actually written. Never award points for intent, convention, or what a reasonable developer "probably meant". Quote verbatim from the file for every score above 0.',
+    criteria: [
+      {
+        id: 'identity_scope',
+        name: 'Identity and scope',
+        description:
+          "Declares what the agent is, what project or codebase it operates in, and what is in- and out-of-scope. A bare 'You are a helpful assistant' scores 0.",
+        weight: 1,
+      },
+      {
+        id: 'environment_context',
+        name: 'Environment and context',
+        description:
+          'Supplies the concrete facts the agent needs to act without guessing: stack, paths, commands, external dependencies, and any non-obvious constraints of the runtime environment.',
+        weight: 2,
+      },
+      {
+        id: 'behavioral_rules',
+        name: 'Behavioural rules',
+        description:
+          'States explicit do/do-not rules that govern agent behaviour: commit hygiene, secret handling, file-mutation policy, approval gates, tone. Vague advice ("be careful") scores 1 at most.',
+        weight: 2,
+      },
+      {
+        id: 'failure_guidance',
+        name: 'Failure and escalation guidance',
+        description:
+          'Explains what the agent should do when it is uncertain, hits an error, or encounters a decision that exceeds its authority — not just "ask the user".',
+        weight: 1,
+      },
+      {
+        id: 'maintainability',
+        name: 'Maintainability',
+        description:
+          'The file is structured so a new developer (or a future version of the agent) can navigate and update it without guessing: sections are labelled, the reasoning behind non-obvious rules is present, and stale or contradictory guidance is absent.',
         weight: 1,
       },
     ],

--- a/lib/critique/index.js
+++ b/lib/critique/index.js
@@ -35,6 +35,15 @@ export const GRADER_JUDGE_MODEL = 'grader-haiku'
 // Rewrite + failure modes need more room than scores alone.
 const JUDGE_MAX_TOKENS = 2000
 
+// Edits mode runs ONE bounded attempt instead of two: a rich agent file makes
+// the judge slow enough (~2.3k input tokens, generation near the cap) that a
+// retry cannot fit inside Netlify's ~30s function wall — observed as 504s on
+// an 8.8k-char CLAUDE.md on the PR #54 preview, twice. Lower cap bounds
+// generation time; salvage-from-the-start absorbs the failure class (unverifiable
+// excerpts/spans) that would otherwise trigger the retry. Fabricated content is
+// still dropped, never displayed.
+const JUDGE_MAX_TOKENS_EDITS = 1300
+
 export async function critiquePrompt({
   targetPrompt,
   rubricId,
@@ -60,17 +69,21 @@ export async function critiquePrompt({
 
   const judgePrompt = renderJudgePrompt(targetPrompt, rubric, { target })
 
-  // Deterministic judging: temperature 0. One retry when the judge output
-  // fails validation (fabricated span, missing rewrite, bad shape): rejecting
-  // ungrounded critiques is the contract, but the caller shouldn't pay for a
-  // judge hiccup when a second attempt usually parses clean.
+  // Deterministic judging: temperature 0.
+  // Full mode: one strict attempt + one salvaging retry (chat prompts are small;
+  // two attempts fit the function wall comfortably).
+  // Edits mode: ONE attempt with salvage active and a tighter token cap — see
+  // JUDGE_MAX_TOKENS_EDITS. A second attempt cannot fit the wall on big files.
+  const isEdits = rubric.rewriteMode === 'edits'
+  const maxAttempts = isEdits ? 1 : 2
+  const maxTokens = isEdits ? JUDGE_MAX_TOKENS_EDITS : JUDGE_MAX_TOKENS
   let judged, envelope, extras, criteria
   let lastErr = null
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     judged = await complete({
       prompt: judgePrompt,
       model: judgeModel,
-      params: { temperature: 0, maxTokens: JUDGE_MAX_TOKENS },
+      params: { temperature: 0, maxTokens },
       userKey,
       studioFreeKey,
       studioAnthropicKey,
@@ -80,11 +93,12 @@ export async function critiquePrompt({
     try {
       envelope = parseEnvelope(judged.output)
       extras = parseGraderExtras(envelope, targetPrompt, rubric)
-      // Attempt 1 is strict; the retry salvages a persistently unverifiable
-      // span (drops the quote, keeps the justified score) rather than 502ing.
+      // Salvage drops an unverifiable span/excerpt (keeps the justified score)
+      // rather than 502ing: last attempt in full mode, only attempt in edits.
+      const salvage = isEdits || attempt > 0
       criteria = extras.flagged
         ? null
-        : parseJudgeResponse(envelope, rubric, targetPrompt, { salvage: attempt > 0 })
+        : parseJudgeResponse(envelope, rubric, targetPrompt, { salvage })
       lastErr = null
       break
     } catch (err) {

--- a/lib/critique/index.js
+++ b/lib/critique/index.js
@@ -52,7 +52,9 @@ export async function critiquePrompt({
   }
   const rubric = getRubric(rubricId)
   if (!rubric) throw new UnknownRubricError(rubricId)
-  if (!REWRITE_TARGETS[target]) {
+  // In edits mode the target selector is not shown and the rewrite is not produced,
+  // so skip the target validation — any value (including the UI default) is fine.
+  if (rubric.rewriteMode !== 'edits' && !REWRITE_TARGETS[target]) {
     throw new MalformedCritiqueError(`Unknown rewrite target: ${target}`)
   }
 
@@ -77,7 +79,7 @@ export async function critiquePrompt({
     })
     try {
       envelope = parseEnvelope(judged.output)
-      extras = parseGraderExtras(envelope, targetPrompt)
+      extras = parseGraderExtras(envelope, targetPrompt, rubric)
       // Attempt 1 is strict; the retry salvages a persistently unverifiable
       // span (drops the quote, keeps the justified score) rather than 502ing.
       criteria = extras.flagged
@@ -112,17 +114,20 @@ export async function critiquePrompt({
   }
 
   const overall = computeOverall(criteria, rubric)
+  const isEditsMode = rubric.rewriteMode === 'edits'
 
   return {
     flagged: false,
     rubricId: rubric.id,
     rubricVersion: rubric.version,
     scale: { min: rubric.scale.min, max: rubric.scale.max },
-    target,
+    ...(isEditsMode ? {} : { target }),
     criteria,
     overall,
     failureModes: extras.failureModes,
-    rewrite: extras.rewrite,
+    ...(isEditsMode
+      ? { revisions: extras.revisions }
+      : { rewrite: extras.rewrite }),
     summary: typeof envelope.summary === 'string' ? envelope.summary : '',
     judge: judgeMeta,
   }

--- a/lib/critique/index.js
+++ b/lib/critique/index.js
@@ -35,14 +35,16 @@ export const GRADER_JUDGE_MODEL = 'grader-haiku'
 // Rewrite + failure modes need more room than scores alone.
 const JUDGE_MAX_TOKENS = 2000
 
-// Edits mode runs ONE bounded attempt instead of two: a rich agent file makes
-// the judge slow enough (~2.3k input tokens, generation near the cap) that a
+// Edits mode runs ONE attempt instead of two: a rich agent file makes the
+// judge slow enough (~2.3k input tokens, generation near the cap) that a
 // retry cannot fit inside Netlify's ~30s function wall — observed as 504s on
-// an 8.8k-char CLAUDE.md on the PR #54 preview, twice. Lower cap bounds
-// generation time; salvage-from-the-start absorbs the failure class (unverifiable
-// excerpts/spans) that would otherwise trigger the retry. Fabricated content is
-// still dropped, never displayed.
-const JUDGE_MAX_TOKENS_EDITS = 1300
+// an 8.8k-char CLAUDE.md on the PR #54 preview, twice. A single attempt at
+// the full 2000 budget completes in ~20s worst case; a tighter 1300 cap was
+// tried and truncated the judge mid-JSON on the same file. Salvage-from-the-
+// start absorbs the validation-failure class (unverifiable excerpts/spans)
+// that would otherwise want the retry. Fabricated content is still dropped,
+// never displayed.
+const JUDGE_MAX_TOKENS_EDITS = 2000
 
 export async function critiquePrompt({
   targetPrompt,

--- a/lib/critique/judge.js
+++ b/lib/critique/judge.js
@@ -31,10 +31,11 @@ export function renderJudgePrompt(targetPrompt, rubric, { target = DEFAULT_REWRI
   const outputSection = isEditsMode
     ? `EDITS:
 - The file may be thousands of words long — do NOT produce a full rewrite. Instead produce "revisions": an array of targeted edits.
-- Each revision: {"issue":"<one sentence naming the specific gap>","before_excerpt":"<verbatim quote, 5-30 words, copied exactly from the file>","after_excerpt":"<the improved replacement text>"}.
+- Each revision: {"issue":"<one sentence naming the specific gap>","before_excerpt":"<verbatim quote, 5-20 words, copied exactly from the file>","after_excerpt":"<the improved replacement text>"}.
 - "before_excerpt" must be a verbatim copy from the file above. If you cannot find exact text to quote, skip that revision.
-- "after_excerpt" must be non-empty and materially different from "before_excerpt".
-- Limit to the 4 highest-value revisions. Do not pad with minor style fixes.`
+- "after_excerpt" must be non-empty, materially different from "before_excerpt", and AT MOST 40 words — a surgical replacement, never a new section.
+- Limit to the 4 highest-value revisions. Do not pad with minor style fixes.
+- BUDGET (hard): keep the ENTIRE JSON response under 700 words. Long responses get cut off mid-JSON and rejected, which wastes the whole critique — brevity is a correctness requirement, not style.`
     : `REWRITE:
 - Produce "rewrite": a complete, improved version of the prompt that preserves the author's intent and fixes the weaknesses you scored.
 - Style it for ${REWRITE_TARGETS[target] || REWRITE_TARGETS[DEFAULT_REWRITE_TARGET]}

--- a/lib/critique/judge.js
+++ b/lib/critique/judge.js
@@ -26,7 +26,26 @@ export function renderJudgePrompt(targetPrompt, rubric, { target = DEFAULT_REWRI
   const scaleBlock = Object.entries(rubric.scale.labels)
     .map(([n, label]) => `  ${n} = ${label}`)
     .join('\n')
-  const rewriteStyle = REWRITE_TARGETS[target] || REWRITE_TARGETS[DEFAULT_REWRITE_TARGET]
+  const isEditsMode = rubric.rewriteMode === 'edits'
+
+  const outputSection = isEditsMode
+    ? `EDITS:
+- The file may be thousands of words long — do NOT produce a full rewrite. Instead produce "revisions": an array of targeted edits.
+- Each revision: {"issue":"<one sentence naming the specific gap>","before_excerpt":"<verbatim quote, 5-30 words, copied exactly from the file>","after_excerpt":"<the improved replacement text>"}.
+- "before_excerpt" must be a verbatim copy from the file above. If you cannot find exact text to quote, skip that revision.
+- "after_excerpt" must be non-empty and materially different from "before_excerpt".
+- Limit to the 4 highest-value revisions. Do not pad with minor style fixes.`
+    : `REWRITE:
+- Produce "rewrite": a complete, improved version of the prompt that preserves the author's intent and fixes the weaknesses you scored.
+- Style it for ${REWRITE_TARGETS[target] || REWRITE_TARGETS[DEFAULT_REWRITE_TARGET]}
+- Where the original is missing information only the author knows, insert a [PLACEHOLDER LIKE THIS] rather than inventing facts.
+- The rewrite must be self-contained and ready to paste. Do not include commentary.`
+
+  const outputShape = isEditsMode
+    ? `{"safety_flag":"<empty string, or one-sentence reason>","criteria":[{"id":"<criterion id>","score":<int>,"justification":"<one sentence>","evidence_span":"<verbatim quote or empty string>"}],"failure_modes":["<specific way this agent prompt will produce wrong behaviour>"],"revisions":[{"issue":"<gap>","before_excerpt":"<verbatim from file>","after_excerpt":"<improved text>"}],"summary":"<one-sentence overall takeaway>"}`
+    : `{"safety_flag":"<empty string, or one-sentence reason>","criteria":[{"id":"<criterion id>","score":<int>,"justification":"<one sentence>","evidence_span":"<verbatim quote or empty string>"}],"failure_modes":["<specific way this prompt goes wrong>"],"rewrite":"<the full improved prompt, or empty string if flagged>","summary":"<one-sentence overall takeaway>"}`
+
+  const fileLabel = isEditsMode ? 'FILE TO CRITIQUE' : 'PROMPT TO CRITIQUE'
 
   return `${rubric.judgeInstructions}
 
@@ -49,17 +68,13 @@ CALIBRATION (mandatory):
 FAILURE MODES:
 - List up to 4 "failure_modes": the concrete ways THIS prompt will go wrong when run (ambiguities the model must guess at, missing inputs it will invent, conflicting instructions). Each item must name the specific gap, not generic risk. If the prompt is airtight, return fewer items or an empty list.
 
-REWRITE:
-- Produce "rewrite": a complete, improved version of the prompt that preserves the author's intent and fixes the weaknesses you scored.
-- Style it for ${rewriteStyle}
-- Where the original is missing information only the author knows, insert a [PLACEHOLDER LIKE THIS] rather than inventing facts.
-- The rewrite must be self-contained and ready to paste. Do not include commentary.
+${outputSection}
 
 SAFETY:
-- If the prompt's purpose is to cause harm (weapons, malware, fraud, exploitation, targeted harassment or similar), set "safety_flag" to a one-sentence reason, score every criterion ${rubric.scale.min} with empty evidence_span and justification "not graded", and return an empty "rewrite" and empty "failure_modes". Do not improve harmful prompts.
+- If the prompt's purpose is to cause harm (weapons, malware, fraud, exploitation, targeted harassment or similar), set "safety_flag" to a one-sentence reason, score every criterion ${rubric.scale.min} with empty evidence_span and justification "not graded", and return an empty ${isEditsMode ? '"revisions": []' : '"rewrite"'} and empty "failure_modes". Do not improve harmful prompts.
 - Otherwise "safety_flag" must be an empty string. An edgy-but-legitimate prompt (e.g. a villain in fiction, security research framing) is NOT flagged.
 
-PROMPT TO CRITIQUE:
+${fileLabel}:
 <<<PROMPT
 ${targetPrompt}
 PROMPT
@@ -68,7 +83,7 @@ RUBRIC CRITERIA:
 ${criteriaBlock}
 
 Return ONLY this JSON, nothing else:
-{"safety_flag":"<empty string, or one-sentence reason>","criteria":[{"id":"<criterion id>","score":<int>,"justification":"<one sentence>","evidence_span":"<verbatim quote or empty string>"}],"failure_modes":["<specific way this prompt goes wrong>"],"rewrite":"<the full improved prompt, or empty string if flagged>","summary":"<one-sentence overall takeaway>"}`
+${outputShape}`
 }
 
 function stripCodeFence(text) {
@@ -105,12 +120,15 @@ export function parseEnvelope(text) {
 const MAX_FAILURE_MODES = 6
 
 // Validate the grader-specific fields of the envelope: safety flag, failure
-// modes, rewrite. Same philosophy as parseJudgeResponse — a malformed or
-// ungrounded field is REJECTED, never surfaced.
-export function parseGraderExtras(envelope, targetPrompt) {
+// modes, and either rewrite (full mode) or revisions (edits mode). A malformed
+// or ungrounded field is REJECTED, never surfaced.
+//
+// The third argument `rubric` is optional for backward compat with 2-arg tests;
+// when absent the function defaults to full/rewrite mode.
+export function parseGraderExtras(envelope, targetPrompt, rubric) {
   const safetyReason = typeof envelope.safety_flag === 'string' ? envelope.safety_flag.trim() : ''
   if (safetyReason !== '') {
-    return { flagged: true, safetyReason, failureModes: [], rewrite: '' }
+    return { flagged: true, safetyReason, failureModes: [], rewrite: '', revisions: [] }
   }
 
   const rawModes = envelope.failure_modes
@@ -122,6 +140,37 @@ export function parseGraderExtras(envelope, targetPrompt) {
     .filter(m => m !== '')
     .slice(0, MAX_FAILURE_MODES)
 
+  const isEditsMode = rubric?.rewriteMode === 'edits'
+
+  if (isEditsMode) {
+    const rawRevisions = envelope.revisions
+    if (!Array.isArray(rawRevisions)) {
+      throw new MalformedCritiqueError('revisions missing or not an array')
+    }
+    const groundableTarget = groundable(targetPrompt)
+    const revisions = rawRevisions
+      .filter(r => r && typeof r === 'object')
+      .filter(r => {
+        const before = typeof r.before_excerpt === 'string' ? r.before_excerpt.trim() : ''
+        const after = typeof r.after_excerpt === 'string' ? r.after_excerpt.trim() : ''
+        if (!before || !after) return false
+        if (normalize(before) === normalize(after)) return false
+        // before_excerpt must appear verbatim in the target (grounding contract)
+        return groundableTarget.includes(groundable(before))
+      })
+      .map(r => ({
+        issue: typeof r.issue === 'string' ? r.issue.trim() : '',
+        before_excerpt: r.before_excerpt.trim(),
+        after_excerpt: r.after_excerpt.trim(),
+      }))
+      .filter(r => r.issue !== '')
+    if (revisions.length === 0) {
+      throw new MalformedCritiqueError('revisions array has no grounded, non-identical entries')
+    }
+    return { flagged: false, safetyReason: '', failureModes, revisions, rewrite: '' }
+  }
+
+  // Full rewrite mode (default)
   const rewrite = typeof envelope.rewrite === 'string' ? envelope.rewrite.trim() : ''
   if (rewrite === '') {
     throw new MalformedCritiqueError('rewrite missing or empty')
@@ -130,7 +179,7 @@ export function parseGraderExtras(envelope, targetPrompt) {
     throw new MalformedCritiqueError('rewrite is identical to the original prompt')
   }
 
-  return { flagged: false, safetyReason: '', failureModes, rewrite }
+  return { flagged: false, safetyReason: '', failureModes, rewrite, revisions: [] }
 }
 
 // Parse + validate the judge's JSON against the rubric. Returns grounded

--- a/lib/critique/judge.js
+++ b/lib/critique/judge.js
@@ -88,8 +88,15 @@ ${outputShape}`
 }
 
 function stripCodeFence(text) {
-  const m = String(text).match(/^\s*```(?:json)?\s*\n([\s\S]*?)\n```\s*$/)
-  return m ? m[1] : text
+  const s = String(text)
+  const m = s.match(/^\s*```(?:json)?\s*\n([\s\S]*?)\n```\s*$/)
+  if (m) return m[1]
+  // Tolerate an unterminated fence (output cut at the token cap): strip the
+  // opening fence and any trailing backticks, and let JSON.parse be the judge
+  // of whether what remains is complete.
+  const open = s.match(/^\s*```(?:json)?\s*\n([\s\S]*)$/)
+  if (open) return open[1].replace(/\n`{1,3}\s*$/, '')
+  return s
 }
 
 const normalize = s => String(s).replace(/\s+/g, ' ').trim().toLowerCase()

--- a/pages/agent-prompt-grader.js
+++ b/pages/agent-prompt-grader.js
@@ -1,0 +1,184 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import PromptGrader from '../components/tools/PromptGrader'
+import { generateFAQSchema } from '../lib/schemaGenerator'
+
+const faqs = [
+  {
+    question: 'What is a CLAUDE.md file?',
+    answer:
+      'CLAUDE.md is a special file that Claude Code reads at the start of every session. It tells the agent what project it is working in, what rules to follow, what tools to use, and how to behave when things go wrong. A well-written CLAUDE.md is the difference between an agent that makes consistent decisions and one that guesses differently every session.',
+  },
+  {
+    question: 'How is this different from the chat prompt grader?',
+    answer:
+      'The chat prompt grader scores one-shot instructions you type into Claude or ChatGPT. The agent prompt grader scores persistent configuration files — CLAUDE.md files and system prompts that stay in place across many sessions. The criteria are different: agent files need to nail identity, environment context, behavioural rules, and failure guidance. A great chat prompt and a great CLAUDE.md are written for completely different purposes.',
+  },
+  {
+    question: 'What does the grader actually check?',
+    answer:
+      'Five criteria: identity and scope (does the file say what the agent is?), environment and context (stack, paths, commands — the facts the agent needs to act without guessing), behavioural rules (explicit do/do-not instructions that govern commits, secrets, and approvals), failure and escalation guidance (what happens when the agent is uncertain or exceeds its authority), and maintainability (can a new developer or future agent navigate and update the file without guessing?). Every score comes with a verbatim quote from your file as evidence.',
+  },
+  {
+    question: 'Why targeted edits instead of a full rewrite?',
+    answer:
+      'A CLAUDE.md or system prompt can be thousands of words long. Rewriting the entire file in one pass would erase context only you know — project history, intentional trade-offs, bespoke conventions. Targeted edits show you exactly which lines to change and why, leaving everything else intact.',
+  },
+  {
+    question: 'Is it free?',
+    answer:
+      'Yes. You get 3 free grades per day, no signup required. The same daily pool covers both the chat prompt grader and this agent grader. Pro removes the daily cap.',
+  },
+  {
+    question: 'Do you store my CLAUDE.md?',
+    answer:
+      'No. Grading happens in a single API call and your file is not saved on our servers. Your grade history lives in your own browser and never leaves your device.',
+  },
+  {
+    question: 'What if my CLAUDE.md scores high but the agent still misbehaves?',
+    answer:
+      "The grader scores what is written, not how well the agent follows it in practice. A high score means the file is clear and complete; runtime behaviour also depends on the model, the tools available, and how you invoke the agent. If the file scores well but behaviour is still wrong, the issue is likely in the invocation or the tool setup, not the instructions.",
+  },
+]
+
+const HOW_IT_WORKS = [
+  {
+    title: 'Identity and scope',
+    body: 'Does the file declare what the agent is, what project it operates in, and what is out of scope?',
+  },
+  {
+    title: 'Environment and context',
+    body: 'Stack, file paths, commands, dependencies: the concrete facts the agent needs to act without guessing.',
+  },
+  {
+    title: 'Behavioural rules',
+    body: 'Explicit do/do-not rules for commits, secrets, approvals, and tone. Vague advice scores low.',
+  },
+  {
+    title: 'Failure and escalation',
+    body: 'What the agent should do when uncertain or when a decision exceeds its authority.',
+  },
+  {
+    title: 'Maintainability',
+    body: 'Clear sections, reasoning behind non-obvious rules, no stale or contradictory guidance.',
+  },
+  {
+    title: 'Targeted edits',
+    body: 'Because the file may be thousands of words, the grader returns before/after patches, not a full rewrite.',
+  },
+]
+
+export default function AgentPromptGraderPage() {
+  return (
+    <Layout
+      title="Agent Prompt Grader: Score Your CLAUDE.md or System Prompt | PromptWritingStudio"
+      description="Paste your CLAUDE.md or agent system prompt and get a score on 5 agent-specific criteria — identity, environment context, behavioural rules, failure guidance, and maintainability — plus targeted edits. Free, 3 grades a day."
+    >
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(generateFAQSchema(faqs)) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebApplication',
+              name: 'Agent Prompt Grader',
+              url: 'https://promptwritingstudio.com/agent-prompt-grader',
+              applicationCategory: 'DeveloperApplication',
+              operatingSystem: 'Web',
+              offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+              description:
+                'Scores CLAUDE.md files and agent system prompts on five agent-specific criteria with evidence-grounded feedback and targeted edits.',
+            }),
+          }}
+        />
+      </Head>
+
+      {/* Hero */}
+      <section className="bg-[#1A1A1A] text-white py-16 md:py-20">
+        <div className="container mx-auto px-4 md:px-6 text-center">
+          <h1 className="text-4xl md:text-5xl font-bold">Is your CLAUDE.md doing its job?</h1>
+          <p className="mt-4 text-lg text-gray-300 max-w-2xl mx-auto">
+            Paste your CLAUDE.md or agent system prompt. Get a score on 5 agent-specific criteria, feedback that
+            quotes your exact words, and targeted edits you can apply immediately. Free, 3 grades a day.
+          </p>
+        </div>
+      </section>
+
+      {/* The tool */}
+      <section className="py-12 md:py-16 bg-[#F9F9F9]">
+        <div className="container mx-auto px-4 md:px-6">
+          <PromptGrader
+            rubricId="agent-prompt"
+            historySource="agent-prompt-grader"
+          />
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="py-16 md:py-24 bg-white">
+        <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+          <h2 className="text-3xl font-bold text-[#1A1A1A] text-center">What the grader checks</h2>
+          <div className="mt-8 grid md:grid-cols-2 gap-6">
+            {HOW_IT_WORKS.map(({ title, body }) => (
+              <div key={title} className="bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5">
+                <h3 className="font-bold text-[#1A1A1A]">{title}</h3>
+                <p className="text-[#333333] text-sm mt-1">{body}</p>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-[#333333] mt-8">
+            Every score must cite a verbatim quote from your file. If the judge returns feedback without evidence,
+            we reject it instead of showing it to you. That rule is enforced in code, not just in the prompt.
+          </p>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="py-16 md:py-24 bg-[#F9F9F9]">
+        <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+          <h2 className="text-3xl font-bold text-[#1A1A1A] text-center mb-8">Frequently asked questions</h2>
+          <div className="space-y-4">
+            {faqs.map(faq => (
+              <details key={faq.question} className="bg-white border border-[#E5E5E5] rounded-lg p-5">
+                <summary className="font-bold text-[#1A1A1A] cursor-pointer">{faq.question}</summary>
+                <p className="text-[#333333] mt-3">{faq.answer}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Cross-links */}
+      <section className="py-12 bg-white">
+        <div className="container mx-auto px-4 md:px-6 max-w-3xl text-center">
+          <h2 className="text-2xl font-bold text-[#1A1A1A]">Related tools and guides</h2>
+          <div className="mt-4 flex flex-wrap justify-center gap-3">
+            <Link
+              href="/prompt-grader"
+              className="border border-gray-300 px-5 py-2 rounded-lg font-semibold text-[#333333] hover:border-[#FFDE59] transition"
+            >
+              Chat prompt grader
+            </Link>
+            <Link
+              href="/claude-md-playbook"
+              className="border border-gray-300 px-5 py-2 rounded-lg font-semibold text-[#333333] hover:border-[#FFDE59] transition"
+            >
+              CLAUDE.md playbook
+            </Link>
+            <Link
+              href="/claude-code-guide"
+              className="border border-gray-300 px-5 py-2 rounded-lg font-semibold text-[#333333] hover:border-[#FFDE59] transition"
+            >
+              Claude Code guide
+            </Link>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -15,6 +15,7 @@ export default function handler(req, res) {
     { url: '/sitemap', priority: '0.7', changefreq: 'weekly' },
     { url: '/join', priority: '0.9', changefreq: 'monthly' },
     { url: '/prompt-grader', priority: '0.95', changefreq: 'weekly' },
+    { url: '/agent-prompt-grader', priority: '0.95', changefreq: 'weekly' },
     { url: '/ai-prompt-generator', priority: '0.9', changefreq: 'weekly' },
     { url: '/ai-prompt-examples', priority: '0.9', changefreq: 'weekly' },
     { url: '/chatgpt-prompt-templates', priority: '0.9', changefreq: 'weekly' },

--- a/pages/api/studio/critique.js
+++ b/pages/api/studio/critique.js
@@ -12,15 +12,13 @@
 // in the x-user-api-key header, is used in-memory for the judge call only, and
 // is never stored, logged, returned, or traced.
 
-import { critiquePrompt, listRubrics, DEFAULT_JUDGE_MODEL, GRADER_JUDGE_MODEL } from '../../../lib/critique'
+import { critiquePrompt, listRubrics, getRubric, DEFAULT_JUDGE_MODEL, GRADER_JUDGE_MODEL } from '../../../lib/critique'
 import { CritiqueError } from '../../../lib/critique/errors'
 import { GatewayError } from '../../../lib/gateway/errors'
 import { getModel } from '../../../lib/gateway/models'
 import { getTier, isFeatureAllowed } from '../../../lib/studio/entitlements'
 import { checkGradeRateLimit, GRADES_DAILY_MAX } from '../../../lib/studio/rateLimit'
 import { recordGradeSpend } from '../../../lib/studio/budget'
-
-const MAX_PROMPT_CHARS = 8000
 
 export default async function handler(req, res) {
   if (req.method === 'GET') {
@@ -37,9 +35,15 @@ export default async function handler(req, res) {
   if (typeof targetPrompt !== 'string' || targetPrompt.trim() === '') {
     return res.status(400).json({ error: 'targetPrompt is required', code: 'bad_request' })
   }
-  if (targetPrompt.length > MAX_PROMPT_CHARS) {
+
+  // Resolve rubric before the length check so the limit is per-rubric.
+  const rubric = getRubric(rubricId)
+  if (!rubric) {
+    return res.status(404).json({ error: `Unknown rubric: ${rubricId}`, code: 'unknown_rubric' })
+  }
+  if (targetPrompt.length > rubric.maxChars) {
     return res.status(400).json({
-      error: `Prompt exceeds ${MAX_PROMPT_CHARS} characters.`,
+      error: `Prompt exceeds ${rubric.maxChars} characters.`,
       code: 'bad_request',
     })
   }

--- a/pages/claude-code-guide.js
+++ b/pages/claude-code-guide.js
@@ -844,6 +844,11 @@ Next.js site with Tailwind CSS, deployed on Vercel.
                 <h3 className="font-bold text-[#1A1A1A] mb-2">CLAUDE.md Playbook</h3>
                 <p className="text-sm text-[#666666]">How to write a CLAUDE.md that keeps Claude Code on-rails.</p>
               </Link>
+              <Link href="/agent-prompt-grader" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
+                <div className="text-2xl mb-2">🧪</div>
+                <h3 className="font-bold text-[#1A1A1A] mb-2">Agent Prompt Grader</h3>
+                <p className="text-sm text-[#666666]">Score your CLAUDE.md on five agent-specific criteria and get targeted edits.</p>
+              </Link>
               <Link href="/claude-code-hooks-recipes" className="block p-6 bg-[#F9F9F9] rounded-lg border border-gray-200 hover:border-[#FFDE59] hover:bg-white transition">
                 <div className="text-2xl mb-2">🪝</div>
                 <h3 className="font-bold text-[#1A1A1A] mb-2">Claude Code Hooks Recipes</h3>

--- a/pages/claude-md-playbook.js
+++ b/pages/claude-md-playbook.js
@@ -487,6 +487,26 @@ export default function ClaudeMdPlaybook() {
             </div>
           </div>
         </section>
+
+        <section className="py-12 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+            <div className="bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-6 flex flex-col sm:flex-row sm:items-center gap-4">
+              <div className="flex-1">
+                <h2 className="text-xl font-bold text-[#1A1A1A]">Ready to grade your CLAUDE.md?</h2>
+                <p className="text-[#333333] mt-1 text-sm">
+                  Paste your file and get a score on five agent-specific criteria with feedback that quotes your
+                  exact words. Free, 3 grades a day.
+                </p>
+              </div>
+              <Link
+                href="/agent-prompt-grader"
+                className="shrink-0 bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition text-center"
+              >
+                Grade my CLAUDE.md
+              </Link>
+            </div>
+          </div>
+        </section>
       </Layout>
     </>
   )

--- a/pages/prompt-grader.js
+++ b/pages/prompt-grader.js
@@ -151,6 +151,27 @@ export default function PromptGraderPage() {
           </div>
         </div>
       </section>
+
+      {/* Agent grader cross-link */}
+      <section className="py-12 bg-[#F9F9F9]">
+        <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+          <div className="bg-white border border-[#E5E5E5] rounded-lg p-6 flex flex-col sm:flex-row sm:items-center gap-4">
+            <div className="flex-1">
+              <h2 className="text-xl font-bold text-[#1A1A1A]">Using Claude Code?</h2>
+              <p className="text-[#333333] mt-1 text-sm">
+                The Agent Prompt Grader scores your CLAUDE.md or agent system prompt on five agent-specific
+                criteria: identity, environment context, behavioural rules, failure guidance, and maintainability.
+              </p>
+            </div>
+            <Link
+              href="/agent-prompt-grader"
+              className="shrink-0 bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition text-center"
+            >
+              Grade my CLAUDE.md
+            </Link>
+          </div>
+        </div>
+      </section>
     </Layout>
   )
 }


### PR DESCRIPTION
## PRDs implemented

- PRD-1: `promptwritingstudio-PRD-1-agent-prompt-grader.md`

## DoD checklist

| # | Item | Status | Evidence |
|---|------|--------|---------|
| 1 | `agent-prompt` rubric in registry with 5 criteria and correct weights (1,2,2,1,1) | PASS | `data/critique-rubrics.js` lines 65-133 |
| 2 | `rewriteMode: 'edits'` flag; edits mode requests `revisions[]` from judge | PASS | `lib/critique/judge.js` — `isEditsMode` branch in both `renderJudgePrompt` and `parseGraderExtras` |
| 3 | `before_excerpt` grounding contract: drops ungrounded/identical pairs, throws if none survive | PASS | `parseGraderExtras` edits path; covered by 6 unit tests in `grader.test.js` |
| 4 | Endpoint resolves rubric first → 404 on unknown, then applies per-rubric `maxChars` limit | PASS | `pages/api/studio/critique.js` lines 37-46; tests in `critique-gate.test.js` |
| 5 | Chat rubric char limit unchanged at 8000; agent rubric at 24000 | PASS | `rubric.maxChars` on each rubric; tested both directions |
| 6 | `prompt-quality` version hash pinned to `v1-6dfd72d2` (pre-edit snapshot) | PASS | `__tests__/critique/critique.test.js` line 18 |
| 7 | `PromptGrader` prop-ified; defaults preserve existing chat-grader behaviour | PASS | All props default to current chat values; rendered unchanged on `/prompt-grader` |
| 8 | Edits mode: hides target selector, shows before/after revision cards, OverallBadge verdict is mode-aware | PASS | `PromptGrader.js` — `isEditsMode` branches; `OverallBadge` accepts `editsMode` prop |
| 9 | History isolated by `historySource`; entries tagged `rubric:agent-prompt` | PASS | `saveToHistory` uses `historySource` param; `rubric:${result.rubricId}` tag |
| 10 | `/agent-prompt-grader` page with hero, tool, how-it-works (5 criteria), FAQ (7 Qs), JSON-LD schemas | PASS | `pages/agent-prompt-grader.js` |
| 11 | Header nav, sitemap, cross-links on `/prompt-grader`, `/claude-md-playbook`, `/claude-code-guide` | PASS | All 5 files touched and verified in diff |
| 12 | 3 agent example chips (thin / partial / strong) | PASS | `AGENT_EXAMPLES` in `PromptGrader.js` |
| 13 | `npm run build` passes clean; `/agent-prompt-grader` in build output | PASS | Build output: `○ /agent-prompt-grader 2.95 kB 101 kB` |
| 14 | Jest: 103 → 120 tests, all passing | PASS | 17 new tests across 3 files |
| 15 | GET `/api/studio/critique` lists both rubrics | PASS | Tested in `critique-gate.test.js` |
| 16 | Real >8k file returns 5 criteria + revisions on deploy preview | VERIFY ON DEPLOY | Mocked in tests; live inference needed |
| 17 | Weak prompt scores ≥30 pts lower than strong on agent rubric | VERIFY ON DEPLOY | Cannot unit-test; requires live judge call |

## Deferred to deploy preview (Needs-Bryan)

These DoD items require a running Netlify preview with `ANTHROPIC_API_KEY` set:

```bash
# 1. Check both rubrics listed
curl https://<PREVIEW>/api/studio/critique

# 2. Check agent-prompt char limit passes (should return 200/401, not 400)
curl -X POST https://<PREVIEW>/api/studio/critique \
  -H "Content-Type: application/json" \
  -d "{\"targetPrompt\":\"$(python3 -c 'print("x"*8500)')\",\"rubricId\":\"agent-prompt\"}"

# 3. Grade a real CLAUDE.md (should return 5 criteria + revisions[])
curl -X POST https://<PREVIEW>/api/studio/critique \
  -H "Content-Type: application/json" \
  -H "x-user-api-key: $ANTHROPIC_API_KEY" \
  -d "{\"targetPrompt\":\"$(cat ~/.claude/CLAUDE.md | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')\",\"rubricId\":\"agent-prompt\"}"

# 4. Confirm chat grader still works unchanged
curl -X POST https://<PREVIEW>/api/studio/critique \
  -H "Content-Type: application/json" \
  -d "{\"targetPrompt\":\"Write a blog post.\"}"
```

**Revision lower bound note:** `parseGraderExtras` enforces ≥1 grounded revision. The DoD mentions 2-6 as a typical range; a highly specific CLAUDE.md might legitimately need only 1 edit. The lower bound is kept at 1 to avoid rejecting valid single-issue grades. If the live eval shows the judge systematically undershoots, revisit.

## pr-critic verdict

**DEPTH: ADEQUATE**

Two gaps fixed post-critic run:
1. `OverallBadge` "Needs a rewrite" in edits mode → fixed to "Needs significant work" (commit `6d8e49f`)
2. Missing strong agent example chip → added (commit `6d8e49f`)

Remaining MISS (lower bound 1 vs 2-6): kept at 1; documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)