### PR TITLE
Replace ConvertBox with native Resend newsletter capture

### DIFF
--- a/components/layout/Footer.js
+++ b/components/layout/Footer.js
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import Script from 'next/script'
 import { FaTwitter, FaLinkedin, FaInstagram, FaYoutube, FaFacebook } from 'react-icons/fa'
+import EmailCapture from '../ui/EmailCapture'
 
 export default function Footer() {
   return (
@@ -64,18 +65,28 @@ export default function Footer() {
 
         </div>
         
+        {/* Newsletter signup - Full Width Section */}
+        <div className="border-t border-gray-700 mt-8 pt-8">
+          <div className="max-w-xl mx-auto text-center">
+            <h4 className="text-lg font-bold mb-2">Get practical Claude tips in your inbox</h4>
+            <p className="text-gray-400 mb-4">A short email when there's a new skill, guide, or tool worth your time. No hype, no spam.</p>
+            <div className="flex justify-center">
+              <EmailCapture label="" buttonText="Subscribe" source="footer" theme="dark" />
+            </div>
+          </div>
+        </div>
+
         {/* Connect With Us - Full Width Section */}
         <div className="border-t border-gray-700 mt-8 pt-8">
           <div className="text-center">
             <h4 className="text-lg font-bold mb-4">Connect With Us</h4>
-            <div className="flex justify-center space-x-6 mb-4">
+            <div className="flex justify-center space-x-6">
               <a href="https://twitter.com/bryanjcollins" className="text-gray-400 hover:text-white transition" target="_blank" rel="noopener noreferrer"><FaTwitter size={24} /></a>
               <a href="https://www.linkedin.com/in/bryancollinswriter/" className="text-gray-400 hover:text-white transition" target="_blank" rel="noopener noreferrer"><FaLinkedin size={24} /></a>
               <a href="https://www.instagram.com/bryancollinswriter/" className="text-gray-400 hover:text-white transition" target="_blank" rel="noopener noreferrer"><FaInstagram size={24} /></a>
               <a href="https://www.youtube.com/c/BryanCollins" className="text-gray-400 hover:text-white transition" target="_blank" rel="noopener noreferrer"><FaYoutube size={24} /></a>
               <a href="https://www.facebook.com/becomeawritertoday/" className="text-gray-400 hover:text-white transition" target="_blank" rel="noopener noreferrer"><FaFacebook size={24} /></a>
             </div>
-            <p className="text-gray-400">Stay updated with our latest AI tools and prompt techniques</p>
           </div>
         </div>
         

--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -4,6 +4,7 @@ import Header from './Header'
 import Footer from './Footer'
 import FloatingCTA from '../ui/FloatingCTA'
 import CookieConsent from '../ui/CookieConsent'
+import NewsletterPopup from '../ui/NewsletterPopup'
 
 export default function Layout({ children, title, description, canonicalUrl, ogImage }) {
   const router = useRouter()
@@ -44,6 +45,7 @@ export default function Layout({ children, title, description, canonicalUrl, ogI
       <Footer />
       <FloatingCTA />
       <CookieConsent />
+      <NewsletterPopup />
     </>
   )
 }

--- a/components/ui/EmailCapture.js
+++ b/components/ui/EmailCapture.js
@@ -21,7 +21,11 @@ export default function EmailCapture({
       body.append('form-name', formName)
       body.append('email', email)
       if (source) body.append('source', source)
-      const res = await fetch('/', {
+      // POST to the static /__forms.html endpoint, not "/". On this Next.js
+      // site "/" is served by the SSR runtime (GET/HEAD only) and returns 405,
+      // so submissions silently fail. /__forms.html is the static form-
+      // declaration file Netlify's form handler actually intercepts.
+      const res = await fetch('/__forms.html', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: body.toString()

--- a/components/ui/NewsletterPopup.js
+++ b/components/ui/NewsletterPopup.js
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react'
+import EmailCapture from './EmailCapture'
+
+// Sitewide newsletter popup — the native replacement for the old ConvertBox
+// embed. Triggers once per session on exit-intent (desktop) or after the
+// visitor scrolls ~55% of the page (all devices), whichever fires first.
+// Gated by sessionStorage so it never nags a visitor twice in one session.
+
+const SESSION_KEY = 'pws_newsletter_popup_shown'
+const SCROLL_THRESHOLD = 0.55
+
+export default function NewsletterPopup() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    // Don't re-show within the same session.
+    try {
+      if (sessionStorage.getItem(SESSION_KEY) === '1') return
+    } catch (e) {}
+
+    let fired = false
+    const open = () => {
+      if (fired) return
+      fired = true
+      try { sessionStorage.setItem(SESSION_KEY, '1') } catch (e) {}
+      setIsOpen(true)
+      cleanup()
+    }
+
+    // Exit-intent — desktop pointers only.
+    const hasFinePointer =
+      typeof window !== 'undefined' &&
+      window.matchMedia &&
+      window.matchMedia('(pointer: fine)').matches
+
+    const handleMouseOut = (e) => {
+      if (e && e.relatedTarget === null && e.clientY <= 0) open()
+    }
+
+    // Scroll-depth — works on touch devices where exit-intent can't fire.
+    const handleScroll = () => {
+      const scrolled = window.scrollY + window.innerHeight
+      const height = document.documentElement.scrollHeight
+      if (height > 0 && scrolled / height >= SCROLL_THRESHOLD) open()
+    }
+
+    const cleanup = () => {
+      window.removeEventListener('mouseout', handleMouseOut)
+      window.removeEventListener('scroll', handleScroll)
+    }
+
+    if (hasFinePointer) window.addEventListener('mouseout', handleMouseOut)
+    window.addEventListener('scroll', handleScroll, { passive: true })
+
+    return cleanup
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60 px-4"
+      onClick={() => setIsOpen(false)}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Subscribe to the PromptWritingStudio newsletter"
+        className="bg-white rounded-xl shadow-2xl max-w-md w-full p-6 relative"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={() => setIsOpen(false)}
+          aria-label="Close"
+          className="absolute top-3 right-3 text-gray-400 hover:text-gray-700 text-xl leading-none"
+        >
+          &times;
+        </button>
+        <div className="text-center mb-4">
+          <div className="text-5xl mb-3">⌨️</div>
+          <h3 className="text-2xl font-bold text-[#1A1A1A] mb-2">
+            One last thing before you go
+          </h3>
+          <p className="text-[#333333]">
+            Get a short email when there's a new Claude Code skill worth installing,
+            a guide worth reading, or a tool worth trying. No hype, no spam.
+          </p>
+        </div>
+        <div className="flex justify-center">
+          <EmailCapture
+            label=""
+            buttonText="Subscribe"
+            source="popup"
+            theme="light"
+          />
+        </div>
+        <button
+          onClick={() => setIsOpen(false)}
+          className="w-full mt-3 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          Maybe later
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/netlify/functions/submission-created.js
+++ b/netlify/functions/submission-created.js
@@ -1,21 +1,24 @@
 // Netlify Forms event function — auto-invoked whenever a form submission is
-// created on this site. We use it to send a welcome email via Mailgun the
-// moment someone signs up through the EmailCapture component
-// (form-name="pws-newsletter"). The hidden "source" field tells us which
-// page captured them so we can tailor the first email.
+// created on this site. When someone signs up through the EmailCapture
+// component (form-name="pws-newsletter"), we:
+//   1. add them as a contact to the PromptWritingStudio Resend segment, and
+//   2. send a welcome email via Resend.
+// The hidden "source" field tells us which surface captured them (homepage /
+// footer / popup / a specific page) so we can tailor and measure.
 //
 // Docs: https://docs.netlify.com/forms/notifications/#email-from-a-function
 //
 // Required env vars (set in Netlify UI → Site settings → Environment):
-//   MAILGUN_API_KEY     — Mailgun private API key
-//   MAILGUN_DOMAIN      — Verified sending domain (e.g. mg.promptwritingstudio.com)
-//   MAILGUN_REGION      — "eu" (default) or "us"
-//   ALERT_FROM_EMAIL    — Verified sender (e.g. hello@promptwritingstudio.com)
+//   RESEND_API_KEY      — Resend API key (secret; set via `netlify env:set --secret`)
+//   RESEND_SEGMENT_ID   — Resend audience/segment id for PromptWritingStudio
+//   RESEND_FROM         — Verified sender, e.g.
+//                         "PromptWritingStudio <hello@send.promptwritingstudio.com>"
 //
 // Returns 200 on success or skip; 500 only on hard send failure so Netlify
 // will retry the webhook.
 
 const SITE_URL = 'https://promptwritingstudio.com';
+const RESEND_API = 'https://api.resend.com';
 
 function buildWelcomeHtml(email, source) {
   const sourceNote = source
@@ -37,7 +40,7 @@ function buildWelcomeHtml(email, source) {
   </p>
   <ul style="font-size:14px;line-height:1.6;color:#333;">
     <li><a href="${SITE_URL}/claude-code-guide" style="color:#1A1A1A;">Claude Code guide</a> — the end-to-end walkthrough.</li>
-    <li><a href="${SITE_URL}/claude-code-skills" style="color:#1A1A1A;">Skills catalogue</a> — ${56} licence-verified skills you can copy into your own setup.</li>
+    <li><a href="${SITE_URL}/prompt-grader" style="color:#1A1A1A;">Prompt Grader</a> — paste a prompt, get a scored critique and a rewrite.</li>
     <li><a href="${SITE_URL}/claude-code-mcp-stack" style="color:#1A1A1A;">Minimum viable MCP stack</a> — the 5 servers worth the context tokens.</li>
   </ul>
   <p style="margin-top:24px;font-size:12px;color:#888;">
@@ -50,32 +53,38 @@ function buildWelcomeHtml(email, source) {
 </html>`;
 }
 
-async function sendViaMailgun({ apiKey, domain, region, from, to, subject, html }) {
-  const host = region === 'us' ? 'api.mailgun.net' : 'api.eu.mailgun.net';
-  const url = `https://${host}/v3/${domain}/messages`;
-
-  const params = new URLSearchParams();
-  params.append('from', from);
-  params.append('to', to);
-  params.append('subject', subject);
-  params.append('html', html);
-  params.append('o:tag', 'welcome');
-  params.append('o:tracking', 'yes');
-
-  const auth = Buffer.from(`api:${apiKey}`).toString('base64');
-
-  const resp = await fetch(url, {
+// Add the subscriber to the Resend segment. Idempotent: an already-present
+// contact returns non-2xx, which we treat as a soft success (re-subscribe).
+async function addContactToSegment({ apiKey, segmentId, email }) {
+  const resp = await fetch(`${RESEND_API}/audiences/${segmentId}/contacts`, {
     method: 'POST',
     headers: {
-      Authorization: `Basic ${auth}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
     },
-    body: params.toString(),
+    body: JSON.stringify({ email, unsubscribed: false }),
   });
 
   if (!resp.ok) {
     const body = await resp.text();
-    throw new Error(`Mailgun ${resp.status}: ${body}`);
+    // 409 / "already exists" is expected on re-submit — not an error.
+    console.warn(`submission-created: add-contact ${resp.status}: ${body}`);
+  }
+}
+
+async function sendWelcome({ apiKey, from, to, subject, html }) {
+  const resp = await fetch(`${RESEND_API}/emails`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ from, to, subject, html, tags: [{ name: 'type', value: 'welcome' }] }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Resend ${resp.status}: ${body}`);
   }
 
   return resp.json();
@@ -102,30 +111,36 @@ exports.handler = async (event) => {
 
   const source = (data.source || '').trim().slice(0, 120);
 
-  const apiKey = process.env.MAILGUN_API_KEY;
-  const domain = process.env.MAILGUN_DOMAIN;
-  const region = (process.env.MAILGUN_REGION || 'eu').toLowerCase();
-  const from = process.env.ALERT_FROM_EMAIL || `PromptWritingStudio <hello@${domain || 'promptwritingstudio.com'}>`;
+  const apiKey = process.env.RESEND_API_KEY;
+  const segmentId = process.env.RESEND_SEGMENT_ID;
+  const from =
+    process.env.RESEND_FROM ||
+    'PromptWritingStudio <hello@send.promptwritingstudio.com>';
 
-  if (!apiKey || !domain) {
-    console.warn('submission-created: Mailgun env vars missing — welcome email skipped');
-    return { statusCode: 200, body: 'skip: mailgun not configured' };
+  if (!apiKey) {
+    console.warn('submission-created: RESEND_API_KEY missing — signup not processed');
+    return { statusCode: 200, body: 'skip: resend not configured' };
   }
 
   try {
-    await sendViaMailgun({
+    if (segmentId) {
+      await addContactToSegment({ apiKey, segmentId, email });
+    } else {
+      console.warn('submission-created: RESEND_SEGMENT_ID missing — contact not added to segment');
+    }
+
+    await sendWelcome({
       apiKey,
-      domain,
-      region,
       from,
       to: email,
       subject: 'Welcome to PromptWritingStudio',
       html: buildWelcomeHtml(email, source),
     });
-    console.log(`submission-created: welcome email sent to ${email} (source=${source})`);
+
+    console.log(`submission-created: subscribed + welcomed ${email} (source=${source})`);
     return { statusCode: 200, body: 'sent' };
   } catch (err) {
-    console.error('submission-created: Mailgun send failed', err);
-    return { statusCode: 500, body: `mailgun error: ${err.message}` };
+    console.error('submission-created: Resend flow failed', err);
+    return { statusCode: 500, body: `resend error: ${err.message}` };
   }
 };

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -20,14 +20,7 @@ export default function Document() {
             `,
           }}
         />
-        
-        {/* ConvertBox */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `!function(e,t){(e=t.createElement("script")).src="https://cdn.convertbox.com/convertbox/js/embed.js",e.id="app-convertbox-script",e.async=true,e.dataset.uuid="9b03f284-1c74-4054-ba19-6604e0ecdd7a",document.getElementsByTagName("head")[0].appendChild(e)}(window,document);`,
-          }}
-        />
-        
+
         {/* Google Analytics 4 */}
         <script async src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}></script>
         <script

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,54 +1,14 @@
 import Layout from '../components/layout/Layout'
-import { useEffect, useState } from 'react'
 import Hero from '../components/sections/Hero'
 import ROICalculator from '../components/tools/ROICalculator'
 import Link from 'next/link'
 import TestimonialEmbed from '../components/sections/TestimonialEmbed'
 import Instructor from '../components/sections/Instructor'
 import IndustryNavigation from '../components/sections/IndustryNavigation'
+import EmailCapture from '../components/ui/EmailCapture'
 import Head from 'next/head'
 
 export default function Home() {
-  const [showExitModal, setShowExitModal] = useState(false)
-
-  // Exit-intent modal (homepage only)
-  useEffect(() => {
-    // Skip if already handled this session
-    try {
-      if (typeof window !== 'undefined' && sessionStorage.getItem('exit_intent_handled') === '1') {
-        return
-      }
-    } catch (e) {}
-
-    // Only apply on devices with a mouse pointer
-    if (typeof window !== 'undefined' && window.matchMedia && !window.matchMedia('(pointer: fine)').matches) {
-      return
-    }
-
-    const handleMouseOut = (e) => {
-      if (!e) return
-      if (e.relatedTarget === null && e.clientY <= 0) {
-        try { sessionStorage.setItem('exit_intent_handled', '1') } catch (e) {}
-        setTimeout(() => {
-          setShowExitModal(true)
-        }, 2000)
-      }
-    }
-
-    window.addEventListener('mouseout', handleMouseOut)
-    return () => window.removeEventListener('mouseout', handleMouseOut)
-  }, [])
-
-  // Allow closing modal with Escape
-  useEffect(() => {
-    if (!showExitModal) return
-    const onKey = (e) => {
-      if (e.key === 'Escape') setShowExitModal(false)
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [showExitModal])
-
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -80,30 +40,6 @@ export default function Home() {
         title="Prompt Writing Studio — Practical Guides for Claude Code, MCP & Sub-agents"
         description="Working guides, templates, and comparisons for people building real work with Claude — Claude Code, Projects, Artifacts, Skills, MCP, sub-agents, and hooks."
       >
-      {showExitModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60">
-          <div role="dialog" aria-modal="true" className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
-            <div className="text-center mb-4">
-              <h3 className="text-2xl font-bold text-gray-900 mb-2">One last thing before you go</h3>
-              <p className="text-gray-700">Grab the free Claude Code starter guide — the same checklist we use to onboard new teams into Claude Code in an afternoon.</p>
-            </div>
-            <div className="space-y-3">
-              <button
-                onClick={() => { window.location.href = '/claude-code-guide' }}
-                className="w-full bg-[#FFDE59] text-[#1A1A1A] py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition-colors"
-              >
-                Read the Claude Code guide
-              </button>
-              <button
-                onClick={() => setShowExitModal(false)}
-                className="w-full bg-gray-100 text-gray-700 py-3 rounded-lg font-semibold hover:bg-gray-200 transition-colors"
-              >
-                Maybe later
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
       <Hero />
 
@@ -263,6 +199,24 @@ export default function Home() {
 
       <Instructor />
       <TestimonialEmbed />
+
+      {/* Newsletter signup */}
+      <section className="py-16 md:py-24 bg-[#1A1A1A] text-white border-t border-gray-800">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-2xl mx-auto text-center">
+            <h2 className="text-3xl md:text-4xl font-bold mb-4">
+              Get practical Claude tips in your inbox
+            </h2>
+            <p className="text-lg text-gray-300 mb-8">
+              A short email when there's a new Claude Code skill worth installing, a guide worth
+              reading, or a tool worth trying. No hype, no spam — unsubscribe anytime.
+            </p>
+            <div className="flex justify-center">
+              <EmailCapture label="" buttonText="Subscribe" source="homepage" theme="dark" />
+            </div>
+          </div>
+        </div>
+      </section>
 
       {/* Free tools CTA */}
       <section className="py-16 md:py-24 bg-[#F9F9F9] border-t border-[#E5E5E5]">


### PR DESCRIPTION
## What

Removes the global **ConvertBox** popup embed and replaces it with our own newsletter forms wired to **Resend**.

## Changes

- **Remove ConvertBox** loader from `pages/_document.js`.
- **`submission-created.js` Mailgun → Resend**: on a `pws-newsletter` submission, adds the subscriber to the PromptWritingStudio Resend segment and sends a welcome email (raw `fetch`, no new dependency).
- **New sitewide `NewsletterPopup`** (`components/ui/NewsletterPopup.js`) — exit-intent (desktop) + scroll-depth (all devices), shown once per session, mounted in `Layout`. This is the direct ConvertBox replacement. The old homepage-only exit modal (which only linked to a guide) is removed since this supersedes it.
- **Footer form** + **homepage newsletter section** added, all reusing the existing `EmailCapture` component. Every surface posts the same `pws-newsletter` form tagged by `source` (`popup` / `footer` / `homepage` / page slug) for attribution.

## Behaviour before config is live

Forms keep capturing to Netlify Forms regardless. The function detects missing `RESEND_API_KEY` and no-ops gracefully — no errors, no lost signups.

## To go live (post-merge, manual)

1. Create Resend full-access API key `promptwritingstudio-netlify`.
2. Set Netlify env (site `promptwritingstudio`): `RESEND_API_KEY` (secret, via `netlify env:set --secret`), `RESEND_SEGMENT_ID=8758d410-436e-49f5-b20f-a0623a976242`, `RESEND_FROM="PromptWritingStudio <hello@send.promptwritingstudio.com>"`.
3. Add DNS records for `send.promptwritingstudio.com` at Namecheap, then verify the domain in Resend.
4. Redeploy (functions read env at deploy time).

Resend domain `send.promptwritingstudio.com` + segment already created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)