### PR TITLE
fix: pricing truth - refresh dated model pricing, wire dead calculator captures, strip fabricated stats

### DIFF
--- a/components/calculators/BusinessAIReadinessCalculator.js
+++ b/components/calculators/BusinessAIReadinessCalculator.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useCalculatorTracking } from '../ui/CalculatorAnalytics'
 import SocialShare from '../ui/SocialShare'
 import LoadingSpinner from '../ui/LoadingSpinner'
+import EmailCapture from '../ui/EmailCapture'
 
 export default function BusinessAIReadinessCalculator() {
   const [currentStep, setCurrentStep] = useState(1)
@@ -39,7 +40,6 @@ export default function BusinessAIReadinessCalculator() {
   const [results, setResults] = useState(null)
   const [isCalculating, setIsCalculating] = useState(false)
   const [showEmailCapture, setShowEmailCapture] = useState(false)
-  const [emailSubmitted, setEmailSubmitted] = useState(false)
 
   const { trackCalculatorStart, trackCalculatorComplete, trackCTAClick } = useCalculatorTracking('Business AI Readiness Calculator')
 
@@ -432,12 +432,6 @@ export default function BusinessAIReadinessCalculator() {
     return currentQuestions.every(question => formData[question.key])
   }
 
-  const handleEmailSubmit = (e) => {
-    e.preventDefault()
-    setEmailSubmitted(true)
-    setShowEmailCapture(false)
-  }
-
   if (results) {
     return (
       <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6 md:p-8" id="calculator-results">
@@ -661,41 +655,20 @@ export default function BusinessAIReadinessCalculator() {
             <p className="text-gray-600 mb-4">
               Enter your email to receive a personalized AI readiness report and implementation guide.
             </p>
-            <form onSubmit={handleEmailSubmit}>
-              <input
-                type="email"
-                name="email"
-                value={formData.email}
-                onChange={(e) => handleInputChange('email', e.target.value)}
-                placeholder="your@email.com"
-                required
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg mb-4"
-              />
-              <div className="flex gap-3">
-                <button
-                  type="submit"
-                  className="flex-1 bg-red-600 text-white py-2 px-4 rounded-lg hover:bg-red-700"
-                >
-                  Get Roadmap
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowEmailCapture(false)}
-                  className="px-4 py-2 text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
-                >
-                  Skip
-                </button>
-              </div>
-            </form>
+            <EmailCapture
+              theme="light"
+              source="calculator-business-ai-readiness"
+              label=""
+              buttonText="Get Roadmap"
+            />
+            <button
+              type="button"
+              onClick={() => setShowEmailCapture(false)}
+              className="mt-4 px-4 py-2 text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
+            >
+              Skip
+            </button>
           </div>
-        </div>
-      )}
-
-      {emailSubmitted && (
-        <div className="mt-4 bg-green-50 border border-green-200 rounded-lg p-4">
-          <p className="text-green-700 font-medium">
-            ✅ Roadmap sent! Check your email for your personalized AI implementation guide.
-          </p>
         </div>
       )}
     </div>

--- a/components/calculators/ContentSpeedCalculator.js
+++ b/components/calculators/ContentSpeedCalculator.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import EmailCapture from '../ui/EmailCapture';
 
 const ContentSpeedCalculator = () => {
   const [inputs, setInputs] = useState({
@@ -87,16 +88,6 @@ const ContentSpeedCalculator = () => {
     });
     
     setShowEmailCapture(true);
-  };
-
-  const handleEmailSubmit = (e) => {
-    e.preventDefault();
-    const email = e.target.email.value;
-    
-    // Here you would integrate with your email service
-    console.log('Email submitted:', email);
-    alert('Thanks! Check your email for the "Content Creation Automation Guide"');
-    setShowEmailCapture(false);
   };
 
   return (
@@ -279,30 +270,19 @@ const ContentSpeedCalculator = () => {
               <p className="text-gray-600 mb-6">
                 Learn the exact AI prompts and workflows that can 4-8x your content creation speed.
               </p>
-              <form onSubmit={handleEmailSubmit}>
-                <input
-                  type="email"
-                  name="email"
-                  placeholder="Enter your email address"
-                  required
-                  className="w-full p-3 border border-gray-300 rounded-lg mb-4 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                />
-                <div className="flex gap-3">
-                  <button
-                    type="submit"
-                    className="flex-1 bg-blue-600 text-white py-3 px-6 rounded-lg font-semibold hover:bg-blue-700 transition-colors"
-                  >
-                    Get Free Guide
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setShowEmailCapture(false)}
-                    className="px-4 py-3 text-gray-500 hover:text-gray-700"
-                  >
-                    Close
-                  </button>
-                </div>
-              </form>
+              <EmailCapture
+                theme="light"
+                source="calculator-content-speed"
+                label=""
+                buttonText="Get Free Guide"
+              />
+              <button
+                type="button"
+                onClick={() => setShowEmailCapture(false)}
+                className="mt-4 text-gray-500 hover:text-gray-700"
+              >
+                Close
+              </button>
             </div>
           </div>
         )}

--- a/components/calculators/CostComparisonCalculator.js
+++ b/components/calculators/CostComparisonCalculator.js
@@ -358,7 +358,7 @@ export default function CostComparisonCalculator() {
               </div>
             </div>
 
-            {/* Newsletter capture — real Netlify Forms -> Resend pipeline */}
+            {/* Newsletter capture: real Netlify Forms -> Resend pipeline */}
             <div className="border-t border-gray-200 pt-6">
               <div className="text-center mb-4">
                 <h4 className="text-lg font-semibold text-gray-800 mb-2">

--- a/components/calculators/CostComparisonCalculator.js
+++ b/components/calculators/CostComparisonCalculator.js
@@ -1,77 +1,77 @@
 import { useState } from 'react'
+import EmailCapture from '../ui/EmailCapture'
+import LastVerified from '../LastVerified'
+import subscriptionPricing from '../../data/subscription-pricing.json'
 
 export default function CostComparisonCalculator() {
   const [formData, setFormData] = useState({
     taskType: '',
     volume: '',
     humanCost: '',
-    aiTool: '',
-    email: ''
+    aiTool: ''
   })
   const [results, setResults] = useState(null)
-  const [showEmailCapture, setShowEmailCapture] = useState(false)
-  const [emailSubmitted, setEmailSubmitted] = useState(false)
 
   const taskTypes = [
-    { 
-      value: 'content-writing', 
-      label: 'Content Writing', 
+    {
+      value: 'content-writing',
+      label: 'Content Writing',
       unit: 'articles/month',
       humanTime: 3,
       aiTime: 0.5,
       quality: 0.85
     },
-    { 
-      value: 'customer-support', 
-      label: 'Customer Support', 
+    {
+      value: 'customer-support',
+      label: 'Customer Support',
       unit: 'tickets/month',
       humanTime: 0.25,
       aiTime: 0.05,
       quality: 0.80
     },
-    { 
-      value: 'data-analysis', 
-      label: 'Data Analysis', 
+    {
+      value: 'data-analysis',
+      label: 'Data Analysis',
       unit: 'reports/month',
       humanTime: 8,
       aiTime: 1.5,
       quality: 0.90
     },
-    { 
-      value: 'social-media', 
-      label: 'Social Media Management', 
+    {
+      value: 'social-media',
+      label: 'Social Media Management',
       unit: 'posts/month',
       humanTime: 0.5,
       aiTime: 0.1,
       quality: 0.75
     },
-    { 
-      value: 'email-marketing', 
-      label: 'Email Marketing', 
+    {
+      value: 'email-marketing',
+      label: 'Email Marketing',
       unit: 'emails/month',
       humanTime: 2,
       aiTime: 0.25,
       quality: 0.85
     },
-    { 
-      value: 'product-descriptions', 
-      label: 'Product Descriptions', 
+    {
+      value: 'product-descriptions',
+      label: 'Product Descriptions',
       unit: 'descriptions/month',
       humanTime: 0.75,
       aiTime: 0.1,
       quality: 0.90
     },
-    { 
-      value: 'research', 
-      label: 'Research & Analysis', 
+    {
+      value: 'research',
+      label: 'Research & Analysis',
       unit: 'research projects/month',
       humanTime: 12,
       aiTime: 2,
       quality: 0.85
     },
-    { 
-      value: 'translations', 
-      label: 'Translation Services', 
+    {
+      value: 'translations',
+      label: 'Translation Services',
       unit: 'pages/month',
       humanTime: 0.5,
       aiTime: 0.05,
@@ -79,12 +79,14 @@ export default function CostComparisonCalculator() {
     }
   ]
 
-  const aiTools = [
-    { value: 'chatgpt-plus', label: 'ChatGPT Plus', cost: 20 },
-    { value: 'claude-pro', label: 'Claude Pro', cost: 20 },
-    { value: 'multiple-tools', label: 'Multiple AI Tools', cost: 60 },
-    { value: 'enterprise-ai', label: 'Enterprise AI Suite', cost: 200 }
-  ]
+  // AI subscription prices come from the dated data/subscription-pricing.json
+  // source (each plan carries its own source_url + last_verified), never
+  // hardcoded here.
+  const aiTools = subscriptionPricing.plans.map(plan => ({
+    value: plan.id,
+    label: plan.label,
+    cost: plan.monthly_usd
+  }))
 
   const handleInputChange = (e) => {
     setFormData({
@@ -98,7 +100,7 @@ export default function CostComparisonCalculator() {
     const humanCostPerHour = parseFloat(formData.humanCost)
     const selectedTask = taskTypes.find(task => task.value === formData.taskType)
     const selectedAI = aiTools.find(tool => tool.value === formData.aiTool)
-    
+
     if (!volume || !humanCostPerHour || !selectedTask || !selectedAI) return
 
     // Human calculations
@@ -142,15 +144,6 @@ export default function CostComparisonCalculator() {
     }
 
     setResults(calculatedResults)
-    setShowEmailCapture(true)
-  }
-
-  const handleEmailSubmit = async (e) => {
-    e.preventDefault()
-    
-    // TODO: Integration with email service
-    console.log('Email submitted:', formData.email, 'Results:', results)
-    setEmailSubmitted(true)
   }
 
   const resetCalculator = () => {
@@ -158,12 +151,9 @@ export default function CostComparisonCalculator() {
       taskType: '',
       volume: '',
       humanCost: '',
-      aiTool: '',
-      email: ''
+      aiTool: ''
     })
     setResults(null)
-    setShowEmailCapture(false)
-    setEmailSubmitted(false)
   }
 
   return (
@@ -256,6 +246,11 @@ export default function CostComparisonCalculator() {
                   </option>
                 ))}
               </select>
+              <LastVerified
+                date={subscriptionPricing.last_updated}
+                label="Plan prices last verified"
+                className="mt-2"
+              />
             </div>
 
             <button
@@ -266,14 +261,14 @@ export default function CostComparisonCalculator() {
               Compare Costs
             </button>
           </div>
-        ) : !emailSubmitted ? (
+        ) : (
           // Results + Email Capture
           <div className="space-y-6">
             <div className="text-center mb-6">
               <h3 className="text-2xl font-bold text-gray-800 mb-4">
                 AI vs Human: Cost Comparison Results
               </h3>
-              
+
               <div className="grid md:grid-cols-2 gap-6 mb-6">
                 {/* Human Cost Card */}
                 <div className="bg-red-50 border border-red-200 p-6 rounded-lg">
@@ -363,99 +358,35 @@ export default function CostComparisonCalculator() {
               </div>
             </div>
 
-            {!showEmailCapture ? (
-              <button
-                onClick={() => setShowEmailCapture(true)}
-                className="w-full bg-blue-600 text-white py-4 rounded-lg font-bold text-lg hover:bg-blue-700 transition-colors duration-200"
-              >
-                Get Detailed Implementation Guide
-              </button>
-            ) : (
-              <form onSubmit={handleEmailSubmit} className="space-y-4">
-                <div className="text-center mb-4">
-                  <h4 className="text-lg font-semibold text-gray-800 mb-2">
-                    Get Your AI vs Human Implementation Guide
-                  </h4>
-                  <p className="text-gray-600">
-                    Receive a detailed breakdown with specific tools, implementation steps, and ROI tracking templates.
-                  </p>
-                </div>
-                
-                <input
-                  type="email"
-                  name="email"
-                  value={formData.email}
-                  onChange={handleInputChange}
-                  placeholder="your@email.com"
-                  required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                />
-                
-                <button
-                  type="submit"
-                  className="w-full bg-gray-800 text-white py-4 rounded-lg font-bold text-lg hover:bg-gray-900 transition-colors duration-200"
-                >
-                  Send My Implementation Guide
-                </button>
-                
-                <p className="text-xs text-gray-500 text-center">
-                  We'll also send you our weekly AI automation insights. Unsubscribe anytime.
+            {/* Newsletter capture — real Netlify Forms -> Resend pipeline */}
+            <div className="border-t border-gray-200 pt-6">
+              <div className="text-center mb-4">
+                <h4 className="text-lg font-semibold text-gray-800 mb-2">
+                  Get Your AI vs Human Implementation Guide
+                </h4>
+                <p className="text-gray-600">
+                  Receive a detailed breakdown with specific tools, implementation steps, and ROI tracking templates.
                 </p>
-              </form>
-            )}
-
-            <button
-              onClick={resetCalculator}
-              className="w-full text-gray-500 hover:text-gray-700 py-2"
-            >
-              Compare a different task →
-            </button>
-          </div>
-        ) : (
-          // Success State
-          <div className="text-center space-y-6">
-            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto">
-              <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
-              </svg>
-            </div>
-            
-            <div>
-              <h3 className="text-2xl font-bold text-gray-800 mb-2">
-                Check Your Email!
-              </h3>
-              <p className="text-gray-600 mb-4">
-                We've sent your AI vs Human implementation guide to <strong>{formData.email}</strong>
-              </p>
-              <p className="text-gray-600 mb-6">
-                Your potential yearly savings: <span className="text-2xl font-bold text-green-600">${results.yearlySavings}</span>
-              </p>
-            </div>
-
-            <div className="bg-gray-50 p-6 rounded-lg">
-              <h4 className="font-semibold text-gray-800 mb-3">
-                Ready to implement AI in your business?
-              </h4>
-              <p className="text-gray-600 mb-4">
-                Browse our free AI prompt examples to find the exact prompts and processes to achieve these savings.
-              </p>
-              <a
-                href="/ai-prompt-examples"
-                className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-bold hover:bg-blue-700 transition-colors duration-200"
-              >
-                Browse Free Prompt Examples
-              </a>
+              </div>
+              <div className="flex justify-center">
+                <EmailCapture
+                  source="calculator-ai-cost-comparison"
+                  theme="light"
+                  label="We'll also send you our weekly AI automation insights. Unsubscribe anytime."
+                  buttonText="Send My Implementation Guide"
+                />
+              </div>
             </div>
 
             <button
               onClick={resetCalculator}
               className="w-full text-gray-500 hover:text-gray-700 py-2"
             >
-              Compare another task →
+              Compare a different task
             </button>
           </div>
         )}
       </div>
     </div>
   )
-} 
+}

--- a/components/calculators/CustomerServiceAICalculator.js
+++ b/components/calculators/CustomerServiceAICalculator.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useCalculatorTracking } from '../ui/CalculatorAnalytics'
 import SocialShare from '../ui/SocialShare'
 import LoadingSpinner from '../ui/LoadingSpinner'
+import EmailCapture from '../ui/EmailCapture'
 
 export default function CustomerServiceAICalculator() {
   const [formData, setFormData] = useState({
@@ -16,7 +17,6 @@ export default function CustomerServiceAICalculator() {
   const [results, setResults] = useState(null)
   const [isCalculating, setIsCalculating] = useState(false)
   const [showEmailCapture, setShowEmailCapture] = useState(false)
-  const [emailSubmitted, setEmailSubmitted] = useState(false)
 
   const { trackCalculatorStart, trackCalculatorComplete, trackCTAClick } = useCalculatorTracking('Customer Service AI Calculator')
 
@@ -129,13 +129,6 @@ export default function CustomerServiceAICalculator() {
       yearlySavings: yearlySavings,
       roi: calculatedResults.roi
     })
-  }
-
-  const handleEmailSubmit = (e) => {
-    e.preventDefault()
-    setEmailSubmitted(true)
-    setShowEmailCapture(false)
-    // Here you would typically send the email and results to your backend
   }
 
   return (
@@ -366,41 +359,20 @@ export default function CustomerServiceAICalculator() {
             <p className="text-gray-600 mb-4">
               Enter your email to receive a comprehensive AI implementation roadmap based on your results.
             </p>
-            <form onSubmit={handleEmailSubmit}>
-              <input
-                type="email"
-                name="email"
-                value={formData.email}
-                onChange={handleInputChange}
-                placeholder="your@email.com"
-                required
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg mb-4"
-              />
-              <div className="flex gap-3">
-                <button
-                  type="submit"
-                  className="flex-1 bg-indigo-600 text-white py-2 px-4 rounded-lg hover:bg-indigo-700"
-                >
-                  Get Report
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowEmailCapture(false)}
-                  className="px-4 py-2 text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
-                >
-                  Skip
-                </button>
-              </div>
-            </form>
+            <EmailCapture
+              theme="light"
+              source="calculator-customer-service-ai"
+              label=""
+              buttonText="Get Report"
+            />
+            <button
+              type="button"
+              onClick={() => setShowEmailCapture(false)}
+              className="mt-4 px-4 py-2 text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
+            >
+              Skip
+            </button>
           </div>
-        </div>
-      )}
-
-      {emailSubmitted && (
-        <div className="mt-4 bg-green-50 border border-green-200 rounded-lg p-4">
-          <p className="text-green-700 font-medium">
-            ✅ Report sent! Check your email for the detailed AI implementation roadmap.
-          </p>
         </div>
       )}
     </div>

--- a/components/calculators/EcommerceAICalculator.js
+++ b/components/calculators/EcommerceAICalculator.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import EmailCapture from '../ui/EmailCapture';
 
 const EcommerceAICalculator = () => {
   const [inputs, setInputs] = useState({
@@ -132,16 +133,6 @@ const EcommerceAICalculator = () => {
     });
     
     setShowEmailCapture(true);
-  };
-
-  const handleEmailSubmit = (e) => {
-    e.preventDefault();
-    const email = e.target.email.value;
-    
-    // Here you would integrate with your email service
-    console.log('Email submitted:', email);
-    alert('Thanks! Check your email for the "E-commerce AI Toolkit"');
-    setShowEmailCapture(false);
   };
 
   return (
@@ -468,30 +459,19 @@ const EcommerceAICalculator = () => {
               <p className="text-gray-600 mb-6">
                 Download ready-to-use AI prompts for product descriptions, customer service responses, and marketing content that can save you thousands.
               </p>
-              <form onSubmit={handleEmailSubmit}>
-                <input
-                  type="email"
-                  name="email"
-                  placeholder="Enter your email address"
-                  required
-                  className="w-full p-3 border border-gray-300 rounded-lg mb-4 focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                />
-                <div className="flex gap-3">
-                  <button
-                    type="submit"
-                    className="flex-1 bg-purple-600 text-white py-3 px-6 rounded-lg font-semibold hover:bg-purple-700 transition-colors"
-                  >
-                    Get Free Toolkit
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setShowEmailCapture(false)}
-                    className="px-4 py-3 text-gray-500 hover:text-gray-700"
-                  >
-                    Close
-                  </button>
-                </div>
-              </form>
+              <EmailCapture
+                theme="light"
+                source="calculator-ecommerce-ai"
+                label=""
+                buttonText="Get Free Toolkit"
+              />
+              <button
+                type="button"
+                onClick={() => setShowEmailCapture(false)}
+                className="mt-4 text-gray-500 hover:text-gray-700"
+              >
+                Close
+              </button>
             </div>
           </div>
         )}

--- a/components/tools/ROICalculator.js
+++ b/components/tools/ROICalculator.js
@@ -4,12 +4,9 @@ export default function ROICalculator() {
   const [formData, setFormData] = useState({
     hoursPerWeek: '',
     hourlyRate: '',
-    taskType: '',
-    email: ''
+    taskType: ''
   })
   const [results, setResults] = useState(null)
-  const [showEmailCapture, setShowEmailCapture] = useState(false)
-  const [emailSubmitted, setEmailSubmitted] = useState(false)
 
   const taskTypes = [
     { value: 'content-creation', label: 'Content Creation', timeSaved: 0.7 },
@@ -34,7 +31,7 @@ export default function ROICalculator() {
     const hours = parseFloat(formData.hoursPerWeek)
     const rate = parseFloat(formData.hourlyRate)
     const selectedTask = taskTypes.find(task => task.value === formData.taskType)
-    
+
     if (!hours || !rate || !selectedTask) return
 
     const timeSavedPercent = selectedTask.timeSaved
@@ -53,35 +50,15 @@ export default function ROICalculator() {
     }
 
     setResults(calculatedResults)
-    setShowEmailCapture(true)
-  }
-
-  const handleEmailSubmit = async (e) => {
-    e.preventDefault()
-    
-    // TODO: Integration with email service (ConvertKit/Mailchimp)
-    console.log('Email submitted:', formData.email, 'Results:', results)
-    
-    // For now, just show success message
-    setEmailSubmitted(true)
-    
-    // In real implementation, you would:
-    // 1. Send email to your email service
-    // 2. Generate and send PDF report
-    // 3. Add to email sequence
-    // 4. Track conversion in analytics
   }
 
   const resetCalculator = () => {
     setFormData({
       hoursPerWeek: '',
       hourlyRate: '',
-      taskType: '',
-      email: ''
+      taskType: ''
     })
     setResults(null)
-    setShowEmailCapture(false)
-    setEmailSubmitted(false)
   }
 
   return (
@@ -160,14 +137,14 @@ export default function ROICalculator() {
               Calculate My Savings
             </button>
           </div>
-        ) : !emailSubmitted ? (
-          // Results + Email Capture
+        ) : (
+          // Results
           <div className="space-y-6">
             <div className="text-center">
               <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">
                 Your AI Automation Savings Potential
               </h3>
-              
+
               <div className="grid md:grid-cols-3 gap-4 mb-6">
                 <div className="bg-[#F9F9F9] p-4 rounded-lg border">
                   <div className="text-3xl font-bold text-[#1A1A1A]">
@@ -191,105 +168,21 @@ export default function ROICalculator() {
 
               <div className="bg-blue-50 p-4 rounded-lg mb-6">
                 <p className="text-blue-800">
-                  <strong>AI can save you {results.timeSavedPercent}% of the time</strong> you currently spend on {results.taskType.toLowerCase()}, 
+                  <strong>AI can save you {results.timeSavedPercent}% of the time</strong> you currently spend on {results.taskType.toLowerCase()},
                   freeing up <strong>{results.hoursSevedPerWeek} hours per week</strong> for higher-value activities.
                 </p>
               </div>
             </div>
 
-            {!showEmailCapture ? (
-              <button
-                onClick={() => setShowEmailCapture(true)}
-                className="w-full bg-[#FFDE59] text-[#1A1A1A] py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200"
-              >
-                Get Detailed Report & Action Plan
-              </button>
-            ) : (
-              <form onSubmit={handleEmailSubmit} className="space-y-4">
-                <div className="text-center mb-4">
-                  <h4 className="text-lg font-semibold text-[#1A1A1A] mb-2">
-                    Get Your Personalized AI Implementation Plan
-                  </h4>
-                  <p className="text-gray-600">
-                    Enter your email to receive a detailed report with specific prompts and strategies for your business.
-                  </p>
-                </div>
-                
-                <input
-                  type="email"
-                  name="email"
-                  value={formData.email}
-                  onChange={handleInputChange}
-                  placeholder="your@email.com"
-                  required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#FFDE59] focus:border-transparent"
-                />
-                
-                <button
-                  type="submit"
-                  className="w-full bg-[#1A1A1A] text-white py-4 rounded-lg font-bold text-lg hover:bg-gray-800 transition-colors duration-200"
-                >
-                  Send My Free Report
-                </button>
-                
-                <p className="text-xs text-gray-500 text-center">
-                  We'll also send you weekly AI automation tips. Unsubscribe anytime.
-                </p>
-              </form>
-            )}
-
             <button
               onClick={resetCalculator}
               className="w-full text-gray-500 hover:text-gray-700 py-2"
             >
-              Calculate for a different task →
-            </button>
-          </div>
-        ) : (
-          // Success State
-          <div className="text-center space-y-6">
-            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto">
-              <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
-              </svg>
-            </div>
-            
-            <div>
-              <h3 className="text-2xl font-bold text-[#1A1A1A] mb-2">
-                Check Your Email!
-              </h3>
-              <p className="text-gray-600 mb-4">
-                We've sent your personalized AI implementation report to <strong>{formData.email}</strong>
-              </p>
-              <p className="text-gray-600 mb-6">
-                Your potential yearly savings: <span className="text-2xl font-bold text-green-600">${results.yearlySavings}</span>
-              </p>
-            </div>
-
-            <div className="bg-[#F9F9F9] p-6 rounded-lg">
-              <h4 className="font-semibold text-[#1A1A1A] mb-3">
-                Ready to start saving time and money?
-              </h4>
-              <p className="text-gray-600 mb-4">
-                Our free AI prompt examples show you exactly how to implement these AI automations in your business.
-              </p>
-              <a
-                href="/ai-prompt-examples"
-                className="inline-block bg-[#FFDE59] text-[#1A1A1A] px-6 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition-colors duration-200"
-              >
-                Browse Free Prompt Examples
-              </a>
-            </div>
-
-            <button
-              onClick={resetCalculator}
-              className="w-full text-gray-500 hover:text-gray-700 py-2"
-            >
-              Calculate for another task →
+              Calculate for a different task
             </button>
           </div>
         )}
       </div>
     </div>
   )
-} 
+}

--- a/components/ui/PromptLibrary.js
+++ b/components/ui/PromptLibrary.js
@@ -16,7 +16,7 @@ export default function PromptLibrary({ onPromptSelect }) {
   const [userPrompts, setUserPrompts] = useState([])
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false)
   const [showNewPromptModal, setShowNewPromptModal] = useState(false)
-  const [sortBy, setSortBy] = useState('popularity') // popularity, recent, alphabetical
+  const [sortBy, setSortBy] = useState('recent') // recent, alphabetical
   const [filterBy, setFilterBy] = useState('all') // all, beginner, intermediate, advanced
 
   const categories = ['all', ...getPromptCategories(), 'user-created']
@@ -70,10 +70,7 @@ export default function PromptLibrary({ onPromptSelect }) {
       useCase: promptData.useCase || '',
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      author: 'You',
-      likes: 0,
-      uses: 0,
-      optimizationScore: 70 // Default score for user prompts
+      author: 'You'
     }
     
     const updatedUserPrompts = [...userPrompts, newPrompt]
@@ -92,19 +89,6 @@ export default function PromptLibrary({ onPromptSelect }) {
     }
     setFavorites(newFavorites)
     localStorage.setItem('favoritePrompts', JSON.stringify([...newFavorites]))
-  }
-
-  // Increment usage count
-  const incrementUsage = (promptId) => {
-    if (promptId.startsWith('user_')) {
-      const updatedUserPrompts = userPrompts.map(prompt => 
-        prompt.id === promptId 
-          ? { ...prompt, uses: prompt.uses + 1 }
-          : prompt
-      )
-      setUserPrompts(updatedUserPrompts)
-      localStorage.setItem('userPrompts', JSON.stringify(updatedUserPrompts))
-    }
   }
 
   // Filter and sort prompts
@@ -133,17 +117,11 @@ export default function PromptLibrary({ onPromptSelect }) {
 
     // Sort
     switch (sortBy) {
-      case 'popularity':
-        filtered.sort((a, b) => ((b.likes || 0) + (b.uses || 0)) - ((a.likes || 0) + (a.uses || 0)))
-        break
       case 'recent':
         filtered.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
         break
       case 'alphabetical':
         filtered.sort((a, b) => a.title.localeCompare(b.title))
-        break
-      case 'optimization':
-        filtered.sort((a, b) => (b.optimizationScore || 0) - (a.optimizationScore || 0))
         break
     }
 
@@ -233,10 +211,8 @@ export default function PromptLibrary({ onPromptSelect }) {
             onChange={(e) => setSortBy(e.target.value)}
             className="p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
           >
-            <option value="popularity">Most Popular</option>
             <option value="recent">Most Recent</option>
             <option value="alphabetical">A-Z</option>
-            <option value="optimization">Best Optimized</option>
           </select>
 
           {/* Favorites Toggle */}
@@ -272,9 +248,6 @@ export default function PromptLibrary({ onPromptSelect }) {
                     <span className={`px-2 py-1 rounded text-xs font-medium ${getDifficultyColor(prompt.difficulty)}`}>
                       {prompt.difficulty}
                     </span>
-                    <span className="text-xs text-gray-500">
-                      Score: {prompt.optimizationScore}/100
-                    </span>
                   </div>
                 </div>
                 <button
@@ -308,8 +281,6 @@ export default function PromptLibrary({ onPromptSelect }) {
               {/* Stats and Actions */}
               <div className="flex justify-between items-center text-sm text-gray-500 mb-3">
                 <div className="flex gap-4">
-                  <span>♥ {prompt.likes || 0}</span>
-                  <span>↗ {prompt.uses || 0}</span>
                   {prompt.estimatedTime && <span>⏱ {prompt.estimatedTime}</span>}
                 </div>
               </div>

--- a/data/api-pricing.json
+++ b/data/api-pricing.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-05-25",
+  "last_updated": "2026-07-15",
   "note": "Prices in USD per 1M tokens. Cache write cost excluded from calculator (amortized across calls). Gemini context cache excludes per-hour storage cost.",
   "models": [
     {
@@ -12,8 +12,8 @@
       "cache_read_per_1m": 0.50,
       "cache_type": "anthropic",
       "cache_note": "Read price is 10% of input. Write is 1.25x input. 5-min TTL default.",
-      "last_verified": "2026-05-25",
-      "source_url": "https://claude.com/pricing",
+      "last_verified": "2026-07-15",
+      "source_url": "https://platform.claude.com/docs/en/about-claude/models/overview",
       "verified": true
     },
     {
@@ -26,8 +26,8 @@
       "cache_read_per_1m": 0.30,
       "cache_type": "anthropic",
       "cache_note": "Read price is 10% of input. Write is 1.25x input. 5-min TTL default.",
-      "last_verified": "2026-05-25",
-      "source_url": "https://claude.com/pricing",
+      "last_verified": "2026-07-15",
+      "source_url": "https://platform.claude.com/docs/en/about-claude/models/overview",
       "verified": true
     },
     {
@@ -40,8 +40,8 @@
       "cache_read_per_1m": 0.10,
       "cache_type": "anthropic",
       "cache_note": "Read price is 10% of input. Write is 1.25x input. 5-min TTL default.",
-      "last_verified": "2026-05-25",
-      "source_url": "https://claude.com/pricing",
+      "last_verified": "2026-07-15",
+      "source_url": "https://platform.claude.com/docs/en/about-claude/models/overview",
       "verified": true
     },
     {
@@ -56,7 +56,8 @@
       "last_verified": "2026-05-25",
       "source_url": "https://openai.com/api/pricing/",
       "verified": false,
-      "price_unverified_as_of": "2026-05-25"
+      "price_unverified_as_of": "2026-05-25",
+      "verify_note": "Could not re-verify 2026-07-15: OpenAI's current API pricing page (developers.openai.com/api/docs/pricing) no longer lists GPT-4o. Left stale pending a citable source."
     },
     {
       "id": "gpt-4o-mini",
@@ -70,7 +71,8 @@
       "last_verified": "2026-05-25",
       "source_url": "https://openai.com/api/pricing/",
       "verified": false,
-      "price_unverified_as_of": "2026-05-25"
+      "price_unverified_as_of": "2026-05-25",
+      "verify_note": "Could not re-verify 2026-07-15: OpenAI's current API pricing page (developers.openai.com/api/docs/pricing) no longer lists GPT-4o mini. Left stale pending a citable source."
     },
     {
       "id": "gemini-2-5-pro",
@@ -81,8 +83,8 @@
       "cache_read_per_1m": 0.125,
       "cache_type": "gemini",
       "cache_note": "Context cache input at $0.125/1M (under 200K context). Storage billed separately at $4.50/1M tokens/hour.",
-      "last_verified": "2026-05-25",
-      "source_url": "https://ai.google.dev/pricing",
+      "last_verified": "2026-07-15",
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
       "verified": true
     },
     {
@@ -94,8 +96,8 @@
       "cache_read_per_1m": 0.03,
       "cache_type": "gemini",
       "cache_note": "Context cache input at $0.03/1M (text/image/video). Storage billed separately at $1.00/1M tokens/hour.",
-      "last_verified": "2026-05-25",
-      "source_url": "https://ai.google.dev/pricing",
+      "last_verified": "2026-07-15",
+      "source_url": "https://ai.google.dev/gemini-api/docs/pricing",
       "verified": true
     }
   ]

--- a/data/prompt-library.js
+++ b/data/prompt-library.js
@@ -34,12 +34,9 @@ Be direct, data-driven, and focus on practical implementation.`,
       difficulty: 'advanced',
       useCase: 'Strategic planning and business analysis',
       estimatedTime: '10-15 minutes',
-      optimizationScore: 95,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 234,
-      uses: 1250
     },
     {
       id: 'bus_002',
@@ -74,12 +71,9 @@ Prioritize actionable insights over theoretical analysis.`,
       difficulty: 'intermediate',
       useCase: 'Market research and competitive analysis',
       estimatedTime: '8-12 minutes',
-      optimizationScore: 88,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 156,
-      uses: 890
     }
   ],
 
@@ -125,12 +119,9 @@ Output: Hook + full content script + posting strategy`,
       difficulty: 'advanced',
       useCase: 'Creating high-engagement social media content',
       estimatedTime: '5-8 minutes',
-      optimizationScore: 92,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 421,
-      uses: 3200
     },
     {
       id: 'cont_002',
@@ -175,12 +166,9 @@ Output: Complete blog post outline + introduction + first section written in ful
       difficulty: 'intermediate',
       useCase: 'Creating comprehensive blog posts',
       estimatedTime: '10-15 minutes',
-      optimizationScore: 90,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 312,
-      uses: 2100
     }
   ],
 
@@ -237,12 +225,9 @@ Output: Complete sales page copy with headlines, sections, and CTAs`,
       difficulty: 'advanced',
       useCase: 'Creating high-converting sales pages',
       estimatedTime: '15-20 minutes',
-      optimizationScore: 94,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 567,
-      uses: 1890
     },
     {
       id: 'copy_002',
@@ -304,12 +289,9 @@ Output: Complete email sequence with subject lines, preview text, and full copy`
       difficulty: 'advanced',
       useCase: 'Building automated email marketing sequences',
       estimatedTime: '20-25 minutes',
-      optimizationScore: 91,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 389,
-      uses: 1456
     }
   ],
 
@@ -376,12 +358,9 @@ Output: Complete customer avatar with marketing strategy recommendations`,
       difficulty: 'intermediate',
       useCase: 'Understanding and targeting ideal customers',
       estimatedTime: '12-15 minutes',
-      optimizationScore: 89,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 278,
-      uses: 1123
     }
   ],
 
@@ -448,12 +427,9 @@ Be specific with line numbers and provide actionable improvements.`,
       difficulty: 'advanced',
       useCase: 'Reviewing and improving code quality',
       estimatedTime: '8-12 minutes',
-      optimizationScore: 87,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 445,
-      uses: 2890
     }
   ],
 
@@ -521,12 +497,9 @@ Output:
       difficulty: 'advanced',
       useCase: 'Planning SEO content strategy',
       estimatedTime: '15-20 minutes',
-      optimizationScore: 93,
       createdAt: '2024-01-15',
       updatedAt: '2024-01-15',
       author: 'Prompt Writing Studio',
-      likes: 356,
-      uses: 1567
     }
   ]
 };
@@ -555,10 +528,9 @@ export const getPromptById = (id) => {
 };
 
 export const getTopPrompts = (limit = 10) => {
-  const allPrompts = getAllPrompts();
-  return allPrompts
-    .sort((a, b) => (b.likes + b.uses) - (a.likes + a.uses))
-    .slice(0, limit);
+  // No engagement stats are tracked, so surface a stable slice of the library
+  // rather than ranking by fabricated likes/uses.
+  return getAllPrompts().slice(0, limit);
 };
 
 export const getPromptCategories = () => {

--- a/data/subscription-pricing.json
+++ b/data/subscription-pricing.json
@@ -8,7 +8,8 @@
       "vendor": "OpenAI",
       "monthly_usd": 20,
       "source_url": "https://chatgpt.com/pricing/",
-      "last_verified": "2026-07-15"
+      "last_verified": "2026-07-15",
+      "verify_note": "Confirmed 2026-07-15 via in-session web search of the official chatgpt.com/pricing page (direct fetch returned 403). Re-pull from the page directly when possible."
     },
     {
       "id": "claude-pro",
@@ -32,7 +33,8 @@
       "vendor": "OpenAI",
       "monthly_usd": 200,
       "source_url": "https://chatgpt.com/pricing/",
-      "last_verified": "2026-07-15"
+      "last_verified": "2026-07-15",
+      "verify_note": "Confirmed 2026-07-15 via in-session web search of the official chatgpt.com/pricing page (direct fetch returned 403). Re-pull from the page directly when possible."
     }
   ]
 }

--- a/data/subscription-pricing.json
+++ b/data/subscription-pricing.json
@@ -1,0 +1,38 @@
+{
+  "last_updated": "2026-07-15",
+  "note": "Consumer AI subscription plan prices in USD per month. Each price re-verified against the vendor's public pricing page on the last_verified date. Never interpolate or invent a plan price; leave stale and flag if a page is unreachable.",
+  "plans": [
+    {
+      "id": "chatgpt-plus",
+      "label": "ChatGPT Plus",
+      "vendor": "OpenAI",
+      "monthly_usd": 20,
+      "source_url": "https://chatgpt.com/pricing/",
+      "last_verified": "2026-07-15"
+    },
+    {
+      "id": "claude-pro",
+      "label": "Claude Pro",
+      "vendor": "Anthropic",
+      "monthly_usd": 20,
+      "source_url": "https://claude.com/pricing",
+      "last_verified": "2026-07-15"
+    },
+    {
+      "id": "claude-max",
+      "label": "Claude Max",
+      "vendor": "Anthropic",
+      "monthly_usd": 100,
+      "source_url": "https://claude.com/pricing",
+      "last_verified": "2026-07-15"
+    },
+    {
+      "id": "chatgpt-pro",
+      "label": "ChatGPT Pro",
+      "vendor": "OpenAI",
+      "monthly_usd": 200,
+      "source_url": "https://chatgpt.com/pricing/",
+      "last_verified": "2026-07-15"
+    }
+  ]
+}

--- a/pages/ai-prompt-generator/enhanced.js
+++ b/pages/ai-prompt-generator/enhanced.js
@@ -262,7 +262,7 @@ export default function EnhancedAIPromptGenerator() {
 
                     {/* Top Prompts */}
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-800 mb-4">Popular Prompts</h3>
+                      <h3 className="text-lg font-semibold text-gray-800 mb-4">Prompts to Try</h3>
                       <div className="space-y-3">
                         {topPrompts.map(prompt => (
                           <div key={prompt.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
@@ -270,8 +270,6 @@ export default function EnhancedAIPromptGenerator() {
                               <div className="font-medium text-gray-800 text-sm truncate">{prompt.title}</div>
                               <div className="text-xs text-gray-600 flex items-center gap-2">
                                 <span className="bg-gray-200 px-2 py-0.5 rounded text-xs">{prompt.category}</span>
-                                <span>♥ {prompt.likes}</span>
-                                <span>↗ {prompt.uses}</span>
                               </div>
                             </div>
                             <button
@@ -377,7 +375,7 @@ export default function EnhancedAIPromptGenerator() {
                 <span className="text-2xl">📚</span>
               </div>
               <h3 className="text-lg font-semibold text-gray-800 mb-2">Professional Library</h3>
-              <p className="text-gray-600">Access curated prompt templates with optimization scores, usage analytics, and community favorites</p>
+              <p className="text-gray-600">Access curated prompt templates organized by category and difficulty</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Kill the pricing decay + wire the dead calculator captures + strip fabricated stats

**PRD:** `/Users/bryancollins/.claude/handoff/newsletter-flywheel-2026-07-14/promptwritingstudio-PRD-2-pricing-refresh-calculator-truth.md`

Three live defects fixed: (1) hardcoded/undated AI prices on the cost calculator, (2) dead email-capture stubs on six calculators, (3) fabricated engagement stats in the prompt library.

### Live URLs affected
- https://promptwritingstudio.com/calculators/ai-cost-comparison
- https://promptwritingstudio.com/api-pricing
- https://promptwritingstudio.com/anthropic-api-pricing
- https://promptwritingstudio.com/roi-calculator
- https://promptwritingstudio.com/ai-prompt-generator/enhanced

---

## ⚠️ NEEDS-BRYAN — ratify prices at morning review

Every price below was fetched from the vendor's public page **in this session** (2026-07-15). Nothing was invented or interpolated. Please ratify before merge.

- **Two OpenAI API entries could NOT be re-verified and were LEFT STALE:** `gpt-4o` and `gpt-4o-mini`. OpenAI's current API pricing page (`developers.openai.com/api/docs/pricing`, reached via 301 from `platform.openai.com/docs/pricing`) no longer lists the GPT-4o family (it shows the gpt-5.x lineup). Per the "never invent" rule, both entries keep their old prices, `last_verified: 2026-05-25`, and `verified: false`, and now carry a `verify_note`. `lib/gateway/models.js` references `pricingId: "gpt-4o"`, so the entry was kept (not deleted).
- **ChatGPT consumer prices via in-session WebSearch (direct WebFetch of `chatgpt.com/pricing/` returned 403 bot-block).** WebSearch surfaced the official `chatgpt.com/pricing` page plus multiple corroborating 2026 sources: ChatGPT Plus $20/mo, ChatGPT Pro $200/mo. Flag if you want these re-pulled from the page directly.

### Repo-over-PRD deviations (flagged per instructions)
- **Model IDs were NOT renamed to Opus 4.8 / Sonnet 5.** `lib/gateway/models.js` line 120 looks up pricing via `apiPricing.models.find(p => p.id === m.pricingId)` with `pricingId: "claude-opus-4-7"` / `"claude-sonnet-4-6"`. Renaming the `id`s would break the gateway lookup and the gateway tests. Opus 4.7 / Sonnet 4.6 / Haiku 4.5 are all still **active** models (per the Anthropic model catalog) and their prices re-verified **unchanged**, so "use current dated model IDs" is already satisfied. No new entries added (would be pure churn; no DoD item requires them).
- **ROICalculator: the dead in-component capture was REMOVED, not replaced with a second EmailCapture.** Both host pages (`pages/index.js`, `pages/roi-calculator.js`) already render a page-level `<EmailCapture>`. Adding another would create two submission paths per page; removal also deletes a currently-**false** "We've sent your report to X" success screen. One submission path per page preserved.

---

## Before / after price table (fetched-source quote per entry)

### API token prices — `data/api-pricing.json` (`last_updated` 2026-05-25 → 2026-07-15)

| Entry | Before ($/1M in/out) | After | State | Source fetched in-session | Quote from source |
|---|---|---|---|---|---|
| `claude-opus-4-7` | 5.00 / 25.00 | 5.00 / 25.00 | re-verified UNCHANGED; date bumped | platform.claude.com/docs/en/about-claude/models/overview | "Claude Opus 4.7 … $5 / input MTok $25 / output MTok" |
| `claude-sonnet-4-6` | 3.00 / 15.00 | 3.00 / 15.00 | re-verified UNCHANGED; date bumped | (same) | "Claude Sonnet 4.6 … $3 / input MTok $15 / output MTok" |
| `claude-haiku-4-5` | 1.00 / 5.00 | 1.00 / 5.00 | re-verified UNCHANGED; date bumped | (same) | "Claude Haiku 4.5 … $1 / input MTok $5 / output MTok" |
| `gemini-2-5-pro` | 1.25 / 10.00 (cache 0.125) | unchanged | re-verified UNCHANGED; date bumped | ai.google.dev/gemini-api/docs/pricing | "$1.25, prompts <= 200k tokens" / "$10.00, prompts <= 200k tokens" / cache "$0.125, prompts <= 200k tokens" |
| `gemini-2-5-flash` | 0.30 / 2.50 (cache 0.03) | unchanged | re-verified UNCHANGED; date bumped | (same) | "$0.30 (text / image / video)" / "$2.50" / cache "$0.03 (text / image / video)" |
| `gpt-4o` | 2.50 / 10.00 | 2.50 / 10.00 | **STALE — unverifiable this session** | developers.openai.com/api/docs/pricing | Page no longer lists GPT-4o (shows gpt-5.x). Left stale, `verified:false`, `last_verified` 2026-05-25. |
| `gpt-4o-mini` | 0.15 / 0.60 | 0.15 / 0.60 | **STALE — unverifiable this session** | (same) | Page no longer lists GPT-4o mini. Left stale. |

Anthropic cache write/read values follow the documented 1.25×-input / 0.10×-input formula from the (unchanged) base input price, so they are unchanged too.

### Consumer subscription prices — NEW `data/subscription-pricing.json` (replaces the hardcoded/invented calculator prices)

| Plan | Old calculator value | New (sourced) | Source fetched in-session | Quote |
|---|---|---|---|---|
| ChatGPT Plus | `cost: 20` (hardcoded, no source) | $20/mo | chatgpt.com/pricing/ (WebSearch; 403 on direct fetch) | "ChatGPT Plus is a subscription plan that provides enhanced access … for $20/month" |
| Claude Pro | `cost: 20` (hardcoded, no source) | $20/mo | claude.com/pricing (WebFetch) | "Claude Pro: $20 if billed monthly" |
| Claude Max | was "Multiple AI Tools" `cost: 60` (**invented**, no vendor) | $100/mo | claude.com/pricing (WebFetch) | "Claude Max 5x: From $100 per month" |
| ChatGPT Pro | was "Enterprise AI Suite" `cost: 200` (**invented**, no vendor) | $200/mo | chatgpt.com/pricing/ (WebSearch; 403 on direct fetch) | "The two Pro tiers are $100 and $200/month … Pro $200" |

The two invented composite tiers ($60 "Multiple AI Tools", $200 "Enterprise AI Suite") are gone, replaced by four real, single-vendor named plans that each carry their own `source_url` + `last_verified`.

---

## Definition of Done — PASS/MISS

- [x] **`api-pricing.json` `last_updated` prints the PR date** — PASS. `python3 -c "import json;print(json.load(open('data/api-pricing.json'))['last_updated'])"` → `2026-07-15`.
- [x] **Every touched entry has `source_url` + `last_verified` = PR date; unverifiable entries listed** — PASS. Opus 4.7, Sonnet 4.6, Haiku 4.5, Gemini 2.5 Pro, Gemini 2.5 Flash → `last_verified: 2026-07-15` + fetched `source_url`. `gpt-4o` / `gpt-4o-mini` left stale and listed above.
- [x] **`grep -n "cost: 20\|cost: 60\|cost: 200" components/calculators/CostComparisonCalculator.js` returns nothing** — PASS (prices now mapped from `subscription-pricing.json`).
- [x] **`grep -rn "console.log('Email submitted'" components` returns nothing** — PASS (all four stubs removed).
- [x] **`grep -n "EmailCapture" components/calculators/CostComparisonCalculator.js` hits with a distinct source** — PASS (`source="calculator-ai-cost-comparison"`).
- [x] **A "last verified" date renders on `/calculators/ai-cost-comparison` from the data file** — PASS (`<LastVerified date={subscriptionPricing.last_updated} label="Plan prices last verified" />`).
- [x] **`npm test` passes; `npm run build` exits 0** — PASS (12 suites / **136 tests** pass; build exit 0).
- [x] **Rendered check: `/calculators/ai-cost-comparison`, `/api-pricing`, `/anthropic-api-pricing`, `/roi-calculator` build non-empty** — PASS (all emit static HTML; sizes in build output).

### Bonus (PRD "quick audit" SHOULD)
Extended the capture fix to `ContentSpeedCalculator`, `EcommerceAICalculator`, `CustomerServiceAICalculator`, `BusinessAIReadinessCalculator` — all six calculators now POST to the live `pws-newsletter` form (→ `submission-created.js` → Resend) with a distinct `source`, each rendered with `theme="light"` so the label is visible on the white calculator cards.

### Fabricated-stats strip (defect 3)
`data/prompt-library.js` no longer carries `likes` / `uses` / `optimizationScore` (invented numbers presented as real). Removed from the data and from every UI that rendered them: `PromptLibrary.js` (Score badge, ♥ likes / ↗ uses, popularity + optimization sort options, usage-increment, user-prompt stat defaults) and `ai-prompt-generator/enhanced.js` (likes/uses badges, "Popular Prompts" → "Prompts to Try", the false "usage analytics / community favorites" copy). `getTopPrompts` no longer ranks by fabricated engagement. `PromptOptimizer.js`'s live-computed `optimizationScores` is unrelated and untouched.

### Not done / notes
- No CTAs added to `/chatgpt-prompts-for/*` modifier pages (intentional per house rule). No course CTAs.
- Netlify deploy check after merge (per memory rule).

Do NOT merge — prices await Bryan's ratification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
