### PR TITLE
Email the grade report as a signup, and give the prompt library citable per-prompt URLs

### DIFF
--- a/.github/workflows/prompt-of-the-week.yml
+++ b/.github/workflows/prompt-of-the-week.yml
@@ -1,0 +1,52 @@
+name: Prompt of the week (draft only)
+
+# DISARMED. PromptWritingStudio is off-sprint (bench), so there is no schedule.
+# This workflow only ASSEMBLES a broadcast draft and uploads it as an artifact.
+# It never sends email and has no access to any Resend secret. Sending stays
+# manual: Bryan downloads the artifact (or reads the committed draft) and sends
+# the first broadcast from Resend himself.
+#
+# To arm later (needs Bryan): uncomment the schedule block below, pick a cadence
+# day/time, and only THEN wire in a send step with the RESEND secrets. Until the
+# send path is deliberately added, arming the schedule just produces drafts on a
+# timer, which is still safe.
+#
+#     schedule:
+#       - cron: '0 14 * * 4'   # example: Thursday 14:00 UTC (commented = DISARMED)
+
+on:
+  workflow_dispatch:
+    inputs:
+      week:
+        description: 'Override ISO week selection index (blank = current week)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate broadcast draft (no LLM, no send)
+        run: |
+          if [ -n "${{ inputs.week }}" ]; then
+            node scripts/generate-prompt-of-the-week.js --week "${{ inputs.week }}" --write
+          else
+            node scripts/generate-prompt-of-the-week.js --write
+          fi
+
+      - name: Upload draft artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: prompt-of-the-week-draft
+          path: broadcasts/prompt-of-the-week-*.md
+          if-no-files-found: error

--- a/__tests__/grades/reportEmail.test.js
+++ b/__tests__/grades/reportEmail.test.js
@@ -1,0 +1,121 @@
+import { renderGradeReportEmail, reportEmailSource, isEditsRecord } from '../../lib/grades/reportEmail'
+
+// A chat-grade record with one GROUNDED criterion (quote should surface) and
+// one UNGROUNDED criterion whose evidenceSpan is non-empty (quote must be
+// suppressed purely by the grounded:false flag, not by an empty span).
+function chatRecord(overrides = {}) {
+  return {
+    id: 'abc123',
+    public: false,
+    flagged: false,
+    grade: {
+      flagged: false,
+      rubricId: 'prompt-quality',
+      rubricVersion: 3,
+      scale: { min: 0, max: 4 },
+      target: 'claude',
+      overall: { score: 2.5, max: 4, percentage: 62, pass: false },
+      summary: 'Usable, with gaps in structure.',
+      failureModes: ['The model must guess the audience.'],
+      criteria: [
+        {
+          id: 'clarity',
+          name: 'Clarity',
+          score: 3,
+          justification: 'The ask is specific.',
+          evidenceSpan: 'friendly tone',
+          grounded: true,
+        },
+        {
+          id: 'context',
+          name: 'Context',
+          score: 2,
+          justification: 'Some context is present.',
+          evidenceSpan: 'ghost quote that was dropped',
+          grounded: false,
+        },
+      ],
+      rewrite: 'You are a coach. Write about [TOPIC] for [AUDIENCE].',
+    },
+    ...overrides,
+  }
+}
+
+function agentRecord() {
+  return {
+    id: 'def456',
+    public: false,
+    flagged: false,
+    grade: {
+      flagged: false,
+      rubricId: 'agent-prompt',
+      rubricVersion: 1,
+      scale: { min: 0, max: 4 },
+      overall: { score: 3, max: 4, percentage: 75, pass: true },
+      summary: 'Strong agent prompt.',
+      failureModes: [],
+      criteria: [
+        { id: 'scope', name: 'Scope', score: 3, justification: 'Bounded.', evidenceSpan: 'Never add App Router', grounded: true },
+      ],
+      revisions: [
+        { issue: 'No failure handling.', before_excerpt: 'Help the user', after_excerpt: 'Help the user, and stop on destructive ops' },
+      ],
+    },
+  }
+}
+
+describe('grades/reportEmail', () => {
+  describe('renderGradeReportEmail', () => {
+    it('surfaces the grounded evidence quote and suppresses the ungrounded one', () => {
+      const { html } = renderGradeReportEmail(chatRecord())
+      expect(html).toContain('friendly tone')
+      expect(html).not.toContain('ghost quote')
+    })
+
+    it('puts the overall score in the subject line', () => {
+      const { subject } = renderGradeReportEmail(chatRecord())
+      expect(subject).toContain('62')
+    })
+
+    it('renders the rewrite for a chat grade', () => {
+      const { html } = renderGradeReportEmail(chatRecord())
+      expect(html).toContain('Rewritten prompt')
+      expect(html).toContain('[TOPIC]')
+    })
+
+    it('renders suggested edits (not a rewrite) for an agent grade', () => {
+      const { html } = renderGradeReportEmail(agentRecord())
+      expect(html).toContain('Suggested edits')
+      expect(html).not.toContain('Rewritten prompt')
+    })
+
+    it('contains no em dashes and no course CTA', () => {
+      const { subject, html } = renderGradeReportEmail(chatRecord())
+      expect(subject).not.toContain('—')
+      expect(html).not.toContain('—')
+      expect(html.toLowerCase()).not.toContain('course')
+    })
+
+    it('includes the public share link only when a shareUrl is passed', () => {
+      const withShare = renderGradeReportEmail(chatRecord({ public: true }), {
+        shareUrl: 'https://promptwritingstudio.com/g/abc123',
+      })
+      expect(withShare.html).toContain('/g/abc123')
+      const withoutShare = renderGradeReportEmail(chatRecord())
+      expect(withoutShare.html).not.toContain('/g/abc123')
+    })
+
+    it('throws when the record has no grade', () => {
+      expect(() => renderGradeReportEmail({ id: 'x' })).toThrow()
+    })
+  })
+
+  describe('reportEmailSource / isEditsRecord', () => {
+    it('labels chat and agent surfaces distinctly', () => {
+      expect(reportEmailSource(chatRecord())).toBe('prompt-grader-report')
+      expect(reportEmailSource(agentRecord())).toBe('agent-prompt-grader-report')
+      expect(isEditsRecord(chatRecord())).toBe(false)
+      expect(isEditsRecord(agentRecord())).toBe(true)
+    })
+  })
+})

--- a/broadcasts/prompt-of-the-week-2026-W29.md
+++ b/broadcasts/prompt-of-the-week-2026-W29.md
@@ -1,0 +1,74 @@
+# Prompt of the week (2026-W29)
+
+Subject: Code Review Assistant: a prompt worth saving
+
+Hi there,
+
+This week's prompt from the PromptWritingStudio library is Code Review Assistant. Comprehensive code review with security and performance insights.
+
+It is a full-length template, so fill in anything in [BRACKETS] with your own detail before you run it.
+
+---
+
+You are a senior software engineer with 10+ years of experience in [PROGRAMMING_LANGUAGE] and expertise in code security, performance optimization, and best practices.
+
+Review the following code and provide comprehensive feedback:
+
+```[PROGRAMMING_LANGUAGE]
+[CODE_TO_REVIEW]
+```
+
+**Review Areas**:
+
+**1. Code Quality**:
+- Readability and maintainability
+- Naming conventions
+- Code organization and structure
+- Documentation and comments
+
+**2. Performance**:
+- Time complexity analysis
+- Memory usage optimization
+- Potential bottlenecks
+- Scalability considerations
+
+**3. Security**:
+- Vulnerability assessment
+- Input validation
+- Authentication/authorization
+- Data handling best practices
+
+**4. Best Practices**:
+- Design patterns usage
+- SOLID principles adherence
+- DRY principle application
+- Error handling
+
+**5. Testing**:
+- Test coverage suggestions
+- Edge cases to consider
+- Unit test recommendations
+
+**Output Format**:
+- Overall assessment (1-10 score)
+- Critical issues (must fix)
+- Suggestions (should fix)
+- Optimizations (nice to have)
+- Refactored code snippets for key improvements
+
+**Variables**:
+- [PROGRAMMING_LANGUAGE]: Python, JavaScript, Java, etc.
+- [CODE_TO_REVIEW]: The actual code
+- [PROJECT_CONTEXT]: Web app, mobile, API, etc.
+
+Be specific with line numbers and provide actionable improvements.
+
+---
+
+Copy the latest version, see how to use it, and grade your own edit here:
+https://promptwritingstudio.com/prompt-library/code-review-assistant
+
+Until next week,
+Bryan
+
+You are getting this because you subscribed at promptwritingstudio.com. The unsubscribe link is at the bottom of this email.

--- a/components/tools/PromptGrader.js
+++ b/components/tools/PromptGrader.js
@@ -130,6 +130,15 @@ export default function PromptGrader({
   const [shareUrl, setShareUrl] = useState('')
   const [shareError, setShareError] = useState('')
   const [shareCopied, setShareCopied] = useState(false)
+  const [reportEmail, setReportEmail] = useState('')
+  const [reportStatus, setReportStatus] = useState('idle') // idle | sending | sent | error
+  const [reportError, setReportError] = useState('')
+  const [reportSentTo, setReportSentTo] = useState('')
+
+  // Source attribution so the two grader surfaces stay measurable. The API
+  // re-derives the authoritative source from the stored record; this value is
+  // sent as a hint and keeps the surfaces distinct client-side.
+  const reportSource = isEditsMode ? 'agent-prompt-grader-report' : 'prompt-grader-report'
 
   useEffect(() => {
     setHistory(loadHistory(historySource))
@@ -165,6 +174,11 @@ export default function PromptGrader({
       setShareOptIn(false)
       setShareUrl('')
       setShareError('')
+      // Reset the report-email capture for the fresh result.
+      setReportStatus('idle')
+      setReportError('')
+      setReportSentTo('')
+      setReportEmail('')
       if (!data.flagged) {
         setHistory(saveToHistory(prompt, data, historySource))
       }
@@ -226,6 +240,33 @@ export default function PromptGrader({
     }
     setShareUrl('')
     setShare(null)
+  }
+
+  async function sendReport(e) {
+    if (e) e.preventDefault()
+    const address = reportEmail.trim()
+    if (!share?.id || !address || reportStatus === 'sending') return
+    setReportStatus('sending')
+    setReportError('')
+    try {
+      const res = await fetch(`/api/grade/${share.id}/email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: address, source: reportSource }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setReportError(data.error || 'Could not send the report. Try again.')
+        setReportStatus('error')
+        return
+      }
+      setReportSentTo(data.email || address)
+      setReportStatus('sent')
+      setReportEmail('')
+    } catch (err) {
+      setReportError('Could not reach the server. Try again in a moment.')
+      setReportStatus('error')
+    }
   }
 
   function restore(item) {
@@ -499,6 +540,49 @@ export default function PromptGrader({
               <p className="text-sm text-gray-500 mt-3">
                 Anything in [BRACKETS] is a detail only you know. Fill it in before you run the prompt.
               </p>
+            </div>
+          )}
+
+          {/* Email me this report: capture at the value moment (source={reportSource}) */}
+          {share?.id && (
+            <div className="bg-white rounded-lg shadow-md border border-[#E5E5E5] p-6">
+              {reportStatus === 'sent' ? (
+                <>
+                  <h3 className="font-bold text-[#1A1A1A]">Report sent</h3>
+                  <p className="text-sm text-[#333333] mt-1">
+                    Your full report is on its way to {reportSentTo}. Check your inbox, and your spam folder if you do
+                    not see it in a minute.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h3 className="font-bold text-[#1A1A1A]">Email me this full report</h3>
+                  <p className="text-sm text-[#333333] mt-1 mb-3">
+                    Get the score, the full criterion breakdown, and the {isEditsMode ? 'suggested edits' : 'rewrite'} in
+                    your inbox, and join the PromptWritingStudio list for practical prompt tips. No spam.
+                  </p>
+                  <form onSubmit={sendReport} className="flex flex-col sm:flex-row gap-2 w-full max-w-md">
+                    <input
+                      type="email"
+                      value={reportEmail}
+                      onChange={e => setReportEmail(e.target.value)}
+                      placeholder="Your email address"
+                      required
+                      aria-label="Email address"
+                      disabled={reportStatus === 'sending'}
+                      className="flex-grow min-w-0 px-4 py-3 rounded-lg text-[#1A1A1A] bg-white border border-gray-300 focus:outline-none focus:ring-2 focus:ring-[#FFDE59]"
+                    />
+                    <button
+                      type="submit"
+                      disabled={reportStatus === 'sending' || !reportEmail.trim()}
+                      className="bg-[#FFDE59] text-[#1A1A1A] px-5 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition disabled:opacity-60 disabled:cursor-not-allowed whitespace-nowrap"
+                    >
+                      {reportStatus === 'sending' ? 'Sending…' : 'Email me this report'}
+                    </button>
+                  </form>
+                  {reportError && <p className="text-sm text-red-600 mt-3">{reportError}</p>}
+                </>
+              )}
             </div>
           )}
 

--- a/data/prompt-library-slugs.json
+++ b/data/prompt-library-slugs.json
@@ -1,0 +1,11 @@
+{
+  "cont_002": "blog-post-optimizer",
+  "bus_001": "business-strategy-analysis",
+  "tech_001": "code-review-assistant",
+  "mkt_001": "customer-avatar-deep-dive",
+  "copy_002": "email-sequence-builder",
+  "copy_001": "high-converting-sales-page",
+  "seo_001": "keyword-research-strategy",
+  "bus_002": "market-research-framework",
+  "cont_001": "viral-content-framework"
+}

--- a/lib/email/resend.js
+++ b/lib/email/resend.js
@@ -1,0 +1,49 @@
+// Slim ESM Resend REST helper for Next.js API routes (the grade-report email).
+//
+// This is a deliberate, minimal duplicate of the send + add-contact logic in
+// netlify/functions/submission-created.js. That function is CommonJS and runs
+// on the Netlify Forms webhook runtime; reusing it here would couple two
+// runtimes, so the ~15 shared lines are duplicated on purpose rather than
+// refactored. Both paths read the same RESEND_* env vars, so a key rotation
+// moves them together (single source, acceptable coupling).
+
+const RESEND_API = 'https://api.resend.com'
+
+// Add a subscriber to the Resend audience/segment. Idempotent: an
+// already-present contact returns non-2xx, which we treat as a soft success
+// (re-subscribe), matching the Netlify Forms path.
+export async function addContactToSegment({ apiKey, segmentId, email }) {
+  if (!segmentId) return { added: false, reason: 'no_segment' }
+  const resp = await fetch(`${RESEND_API}/audiences/${segmentId}/contacts`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, unsubscribed: false }),
+  })
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    console.warn(`resend add-contact ${resp.status}: ${body.slice(0, 200)}`)
+    return { added: false, reason: `status_${resp.status}` }
+  }
+  return { added: true }
+}
+
+// Send a transactional email. Throws on a hard send failure so the caller can
+// return a 5xx and the user can retry.
+export async function sendEmail({ apiKey, from, to, subject, html, tags = [] }) {
+  const resp = await fetch(`${RESEND_API}/emails`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ from, to, subject, html, tags }),
+  })
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`Resend ${resp.status}: ${body.slice(0, 200)}`)
+  }
+  return resp.json()
+}

--- a/lib/grades/emailRateLimit.js
+++ b/lib/grades/emailRateLimit.js
@@ -1,0 +1,59 @@
+// Per-IP daily cap on grade-report emails. In-memory and best-effort in
+// serverless (a cold start resets it), same shape as lib/studio/rateLimit.
+//
+// The report email renders an already-persisted, already-paid-for grade record
+// and never calls the AI gateway, so this is anti-spam on the Resend send (and
+// on segment writes), not a spend cap. A determined abuser can exceed it across
+// cold starts; the ceiling that matters (AI cost) is untouched.
+
+import { createHash } from 'crypto'
+
+const store = new Map()
+
+export const REPORT_EMAILS_DAILY_MAX = 5
+export const REPORT_EMAILS_WINDOW_MS = 24 * 60 * 60 * 1000
+
+function getIp(req) {
+  // Prefer Netlify's real-connection header over x-forwarded-for, whose first
+  // entry a client can spoof to reset the meter.
+  const nf = req.headers['x-nf-client-connection-ip']
+  if (nf) return nf
+  const fwd = req.headers['x-forwarded-for']
+  if (fwd) return fwd.split(',')[0].trim()
+  return req.socket?.remoteAddress || 'unknown'
+}
+
+function hashIp(ip) {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 16)
+}
+
+export function checkReportEmailRateLimit(
+  req,
+  { max = REPORT_EMAILS_DAILY_MAX, windowMs = REPORT_EMAILS_WINDOW_MS } = {}
+) {
+  const key = hashIp(getIp(req))
+  const now = Date.now()
+  const windowStart = now - windowMs
+
+  const prev = store.get(key) || []
+  const recent = prev.filter(t => t > windowStart)
+
+  if (recent.length >= max) {
+    return { allowed: false, remaining: 0, retryAfterSec: Math.ceil(windowMs / 1000) }
+  }
+
+  recent.push(now)
+  store.set(key, recent)
+
+  if (store.size > 10000) {
+    for (const [k, times] of store.entries()) {
+      if (!times.some(t => t > windowStart)) store.delete(k)
+    }
+  }
+
+  return { allowed: true, remaining: max - recent.length, retryAfterSec: 0 }
+}
+
+export function _resetReportEmailStoreForTesting() {
+  store.clear()
+}

--- a/lib/grades/reportEmail.js
+++ b/lib/grades/reportEmail.js
@@ -1,0 +1,152 @@
+// Deterministic HTML renderer for the grade-report email. Pure logic only: it
+// builds the email body from a stored grade record (lib/grades/record.js shape)
+// with no network or Blobs access, so it unit-tests without infra.
+//
+// Grounding contract carried through from the judge: an evidence quote is shown
+// ONLY when the criterion's `grounded` flag is true. The salvage path in
+// lib/critique/judge.js drops unverifiable spans (grounded:false), and this
+// renderer must never surface a quote that was not verbatim from the prompt.
+//
+// House rules honored here: no em dashes in any copy, no course CTA, the only
+// links are the two grader pages and the public share URL when the grade is
+// public. Inline styles match the welcome email in submission-created.js.
+
+import { overallPct, verdictFor } from './record'
+
+const SITE_URL = 'https://promptwritingstudio.com'
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+// True when the record came from the agent-prompt grader (edits mode): its
+// grade carries a rubricId of 'agent-prompt' and a revisions array instead of
+// a single rewrite.
+export function isEditsRecord(record) {
+  const grade = record?.grade || {}
+  return grade.rubricId === 'agent-prompt' || Array.isArray(grade.revisions)
+}
+
+// Source attribution so the two grader surfaces stay measurable in Resend.
+export function reportEmailSource(record) {
+  return isEditsRecord(record) ? 'agent-prompt-grader-report' : 'prompt-grader-report'
+}
+
+function criterionBlock(criterion, maxScore) {
+  const name = escapeHtml(criterion.name || criterion.id || 'Criterion')
+  const score = Number.isFinite(criterion.score) ? criterion.score : 0
+  const justification = escapeHtml(criterion.justification || '')
+  // Evidence quote is gated on the grounded flag: a false flag means the span
+  // could not be verified verbatim and must not be surfaced.
+  const showQuote = criterion.grounded === true && typeof criterion.evidenceSpan === 'string' && criterion.evidenceSpan.trim() !== ''
+  const quote = showQuote
+    ? `<p style="font-size:13px;color:#777;margin:4px 0 0;">From your prompt: <span style="font-style:italic;">"${escapeHtml(criterion.evidenceSpan.trim())}"</span></p>`
+    : ''
+
+  return `<tr>
+    <td style="padding:10px 0;border-bottom:1px solid #EEEEEE;">
+      <p style="margin:0;font-weight:600;color:#1A1A1A;font-size:14px;">${name} <span style="color:#888;font-weight:400;">${score} / ${maxScore}</span></p>
+      <p style="font-size:13px;color:#444;margin:4px 0 0;">${justification}</p>
+      ${quote}
+    </td>
+  </tr>`
+}
+
+function rewriteSection(grade) {
+  if (typeof grade.rewrite !== 'string' || grade.rewrite.trim() === '') return ''
+  return `<h3 style="font-size:16px;color:#1A1A1A;margin:24px 0 8px;">Rewritten prompt</h3>
+    <pre style="white-space:pre-wrap;font-family:ui-monospace,Menlo,monospace;font-size:13px;color:#333;background:#F9F9F9;border:1px solid #E5E5E5;border-radius:8px;padding:14px;margin:0;">${escapeHtml(grade.rewrite.trim())}</pre>
+    <p style="font-size:12px;color:#888;margin:8px 0 0;">Anything in [BRACKETS] is a detail only you know. Fill it in before you run the prompt.</p>`
+}
+
+function revisionsSection(grade) {
+  if (!Array.isArray(grade.revisions) || grade.revisions.length === 0) return ''
+  const rows = grade.revisions
+    .map(
+      rev => `<div style="border:1px solid #E5E5E5;border-radius:8px;padding:12px;margin:0 0 10px;">
+        <p style="margin:0 0 6px;font-weight:600;color:#1A1A1A;font-size:14px;">${escapeHtml(rev.issue || '')}</p>
+        <p style="margin:0 0 2px;font-size:11px;text-transform:uppercase;letter-spacing:0.04em;color:#999;">Before</p>
+        <pre style="white-space:pre-wrap;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#9A3412;background:#FEF2F2;border:1px solid #FECACA;border-radius:6px;padding:8px;margin:0 0 8px;">${escapeHtml(rev.before_excerpt || '')}</pre>
+        <p style="margin:0 0 2px;font-size:11px;text-transform:uppercase;letter-spacing:0.04em;color:#999;">After</p>
+        <pre style="white-space:pre-wrap;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#166534;background:#F0FDF4;border:1px solid #BBF7D0;border-radius:6px;padding:8px;margin:0;">${escapeHtml(rev.after_excerpt || '')}</pre>
+      </div>`
+    )
+    .join('')
+  return `<h3 style="font-size:16px;color:#1A1A1A;margin:24px 0 8px;">Suggested edits</h3>${rows}`
+}
+
+function failureModesSection(grade) {
+  if (!Array.isArray(grade.failureModes) || grade.failureModes.length === 0) return ''
+  const items = grade.failureModes
+    .map(m => `<li style="margin:0 0 4px;">${escapeHtml(m)}</li>`)
+    .join('')
+  return `<h3 style="font-size:16px;color:#1A1A1A;margin:24px 0 8px;">How this prompt goes wrong</h3>
+    <ul style="font-size:13px;color:#444;line-height:1.5;padding-left:18px;margin:0;">${items}</ul>`
+}
+
+// Build the report email. Returns { subject, html, source }.
+export function renderGradeReportEmail(record, { shareUrl = null } = {}) {
+  if (!record || !record.grade) {
+    throw new Error('renderGradeReportEmail requires a record with a grade')
+  }
+  const grade = record.grade
+  const editsMode = isEditsRecord(record)
+  const pct = overallPct(grade)
+  const verdict = verdictFor(pct, { editsMode })
+  const scoreLabel = typeof pct === 'number' ? `${pct}/100` : 'not scored'
+  const maxScore = grade.scale?.max ?? 4
+
+  const subject =
+    typeof pct === 'number'
+      ? `Your prompt scored ${pct} out of 100: ${verdict}`
+      : `Your prompt grade report`
+
+  const summary = grade.summary ? `<p style="font-size:14px;color:#444;line-height:1.55;margin:0 0 4px;">${escapeHtml(grade.summary)}</p>` : ''
+
+  const criteria = Array.isArray(grade.criteria) ? grade.criteria : []
+  const breakdown = criteria.length
+    ? `<h3 style="font-size:16px;color:#1A1A1A;margin:24px 0 8px;">Score breakdown</h3>
+       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+         ${criteria.map(c => criterionBlock(c, maxScore)).join('')}
+       </table>`
+    : ''
+
+  const improvement = editsMode ? revisionsSection(grade) : rewriteSection(grade)
+
+  const shareLink = shareUrl
+    ? `<li style="margin:0 0 4px;"><a href="${escapeHtml(shareUrl)}" style="color:#1A1A1A;">Your public result page</a></li>`
+    : ''
+
+  const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:system-ui,sans-serif;max-width:640px;margin:0 auto;padding:24px;color:#1A1A1A;">
+  <p style="font-size:13px;color:#888;margin:0 0 4px;text-transform:uppercase;letter-spacing:0.05em;">Your prompt grade</p>
+  <h1 style="font-size:40px;margin:0;line-height:1;">${escapeHtml(scoreLabel)}</h1>
+  <p style="font-size:16px;font-weight:600;color:#1A1A1A;margin:6px 0 16px;">${escapeHtml(verdict)}</p>
+  ${summary}
+  ${failureModesSection(grade)}
+  ${breakdown}
+  ${improvement}
+  <hr style="border:none;border-top:1px solid #E5E5E5;margin:28px 0 16px;">
+  <p style="font-size:13px;color:#444;margin:0 0 6px;">Grade another prompt any time:</p>
+  <ul style="font-size:13px;color:#444;line-height:1.6;padding-left:18px;margin:0;">
+    <li style="margin:0 0 4px;"><a href="${SITE_URL}/prompt-grader" style="color:#1A1A1A;">Prompt Grader</a> for chat prompts</li>
+    <li style="margin:0 0 4px;"><a href="${SITE_URL}/agent-prompt-grader" style="color:#1A1A1A;">Agent Prompt Grader</a> for CLAUDE.md and system prompts</li>
+    ${shareLink}
+  </ul>
+  <p style="margin-top:24px;font-size:12px;color:#999;">
+    You are getting this because you asked for your grade report at
+    <a href="${SITE_URL}" style="color:#777;">promptwritingstudio.com</a> and joined the list.
+    Reply to unsubscribe.
+  </p>
+</body>
+</html>`
+
+  return { subject, html, source: reportEmailSource(record) }
+}

--- a/lib/promptLibrary.js
+++ b/lib/promptLibrary.js
@@ -1,0 +1,102 @@
+// Read-only view layer over data/prompt-library.js for the public AEO surface.
+//
+// data/prompt-library.js is treated as immutable here (it is also consumed by
+// the client-side studio library and generator, so this module never edits it).
+// This layer does two things the raw data cannot do safely:
+//   1. Derives a STABLE per-prompt slug so each prompt gets a canonical URL.
+//      Slugs come from data/prompt-library-slugs.json (an id -> slug map) when
+//      present, so a future title edit never moves a published URL; a prompt
+//      with no map entry falls back to a slug derived from its title.
+//   2. Returns only real, author-provided fields. Any invented engagement
+//      metrics in the raw data are never read or forwarded here (portfolio ban
+//      on model-inlined numbers), so they cannot reach a public page.
+
+import fs from 'fs'
+import path from 'path'
+import { promptLibraryData } from '../data/prompt-library.js'
+
+// Load the id -> slug map. Read via fs (not a JSON import) so this module loads
+// identically under Next's build, the sitemap route, and a bare-node script
+// (native ESM would need an import attribute webpack does not emit). A missing
+// or unreadable map is non-fatal: slugs fall back to the title-derived form.
+function loadSlugMap() {
+  try {
+    const p = path.join(process.cwd(), 'data', 'prompt-library-slugs.json')
+    return JSON.parse(fs.readFileSync(p, 'utf8'))
+  } catch (err) {
+    return {}
+  }
+}
+
+const slugMap = loadSlugMap()
+
+// Category -> human label for the index and breadcrumbs.
+export const CATEGORY_LABELS = {
+  business: 'Business & Strategy',
+  'content-creation': 'Content Creation',
+  copywriting: 'Copywriting',
+  marketing: 'Marketing',
+  technical: 'Technical & Development',
+  seo: 'SEO',
+}
+
+export function slugifyTitle(title) {
+  return String(title || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+// The only fields forwarded to public surfaces. Explicit allow-list: anything
+// not named here (including any invented metrics on the raw entry) is dropped.
+function toSafePrompt(entry) {
+  const slug = slugMap[entry.id] || slugifyTitle(entry.title)
+  return {
+    id: entry.id,
+    slug,
+    title: entry.title || '',
+    description: entry.description || '',
+    prompt: entry.prompt || '',
+    category: entry.category || '',
+    categoryLabel: CATEGORY_LABELS[entry.category] || entry.category || '',
+    tags: Array.isArray(entry.tags) ? entry.tags : [],
+    difficulty: entry.difficulty || '',
+    useCase: entry.useCase || '',
+    estimatedTime: entry.estimatedTime || '',
+  }
+}
+
+function rawEntries() {
+  return Object.values(promptLibraryData).flat()
+}
+
+// All prompts as safe objects, ordered by slug so any index-based selection
+// (e.g. the prompt of the week) is stable across runs.
+export function getAllSafePrompts() {
+  return rawEntries()
+    .map(toSafePrompt)
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+// Lighter shape for the index grid (no full prompt body).
+export function getAllPromptSummaries() {
+  return getAllSafePrompts().map(({ prompt, ...rest }) => rest)
+}
+
+export function getAllSlugs() {
+  return getAllSafePrompts().map(p => p.slug)
+}
+
+export function getPromptBySlug(slug) {
+  return getAllSafePrompts().find(p => p.slug === slug) || null
+}
+
+// Deterministic selection for the prompt-of-the-week broadcast: index into the
+// slug-sorted list by week number, so a given week always resolves to the same
+// prompt (no LLM, no randomness).
+export function getPromptOfTheWeek(weekNumber) {
+  const all = getAllSafePrompts()
+  if (all.length === 0) return null
+  const idx = ((Number(weekNumber) % all.length) + all.length) % all.length
+  return all[idx]
+}

--- a/pages/api/grade/[id]/email.js
+++ b/pages/api/grade/[id]/email.js
@@ -1,0 +1,113 @@
+// POST /api/grade/[id]/email  { email, source? }
+// Emails the full grade report for a stored grade record to the given address
+// and adds the address to the PromptWritingStudio Resend segment. This is the
+// capture at the value moment: a completed grade converts to a list signup.
+//
+// The report renders an already-persisted, already-paid-for record and never
+// calls the AI gateway. Ownership is not required: the record id is a ~72-bit
+// unguessable handle minted at grade time, and a per-IP daily cap limits abuse.
+// The report email IS the welcome moment, so no separate welcome email fires.
+
+import { getRecord } from '../../../../lib/grades/store'
+import { renderGradeReportEmail, isEditsRecord } from '../../../../lib/grades/reportEmail'
+import { checkReportEmailRateLimit, REPORT_EMAILS_DAILY_MAX } from '../../../../lib/grades/emailRateLimit'
+import { addContactToSegment, sendEmail } from '../../../../lib/email/resend'
+
+// Source attribution applied at the API boundary so the two grader surfaces
+// stay measurable in Resend: prompt-grader-report vs agent-prompt-grader-report.
+function reportSourceFor(record) {
+  return isEditsRecord(record) ? 'agent-prompt-grader-report' : 'prompt-grader-report'
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function shareUrlIfPublic(req, record) {
+  if (!record?.public) return null
+  const proto = req.headers['x-forwarded-proto'] || 'https'
+  const host = req.headers.host
+  return `${proto}://${host}/g/${record.id}`
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { id } = req.query
+  const { email } = req.body || {}
+  if (!id) {
+    return res.status(400).json({ error: 'Missing grade id.', code: 'bad_request' })
+  }
+
+  const clean = typeof email === 'string' ? email.trim().toLowerCase() : ''
+  if (!EMAIL_RE.test(clean)) {
+    // Validate before consuming the rate budget so a bad address is cheap.
+    return res.status(400).json({ error: 'Enter a valid email address.', code: 'bad_email' })
+  }
+
+  const { allowed, retryAfterSec } = checkReportEmailRateLimit(req)
+  if (!allowed) {
+    res.setHeader('Retry-After', String(retryAfterSec))
+    return res.status(429).json({
+      error: `You have sent your ${REPORT_EMAILS_DAILY_MAX} report emails for today. Try again tomorrow.`,
+      code: 'rate_limited',
+    })
+  }
+
+  let record
+  try {
+    record = await getRecord(id, { strong: true })
+  } catch (err) {
+    console.error('Report email load failed:', err?.name || 'UnknownError')
+    return res.status(500).json({ error: 'Could not load this grade.' })
+  }
+
+  // Same 404 for missing, flagged, and scoreless so a caller cannot probe ids.
+  if (!record || record.flagged || !record.grade) {
+    return res.status(404).json({ error: 'Grade not found.', code: 'not_found' })
+  }
+
+  const apiKey = process.env.RESEND_API_KEY
+  const from =
+    process.env.RESEND_FROM ||
+    'PromptWritingStudio <hello@send.promptwritingstudio.com>'
+  const segmentId = process.env.RESEND_SEGMENT_ID
+
+  if (!apiKey) {
+    console.warn('Report email: RESEND_API_KEY missing, send skipped')
+    return res.status(503).json({ error: 'Email is not configured right now. Try again later.', code: 'not_configured' })
+  }
+
+  const { subject, html } = renderGradeReportEmail(record, {
+    shareUrl: shareUrlIfPublic(req, record),
+  })
+  const source = reportSourceFor(record)
+
+  try {
+    await sendEmail({
+      apiKey,
+      from,
+      to: clean,
+      subject,
+      html,
+      tags: [
+        { name: 'type', value: 'grade-report' },
+        { name: 'source', value: source },
+      ],
+    })
+  } catch (err) {
+    console.error('Report email send failed:', err?.message ? String(err.message).slice(0, 120) : 'UnknownError')
+    return res.status(502).json({ error: 'Could not send the report. Try again in a moment.' })
+  }
+
+  // Segment add is best-effort: the user already has their report, so a segment
+  // failure must not turn a delivered email into an error response.
+  try {
+    await addContactToSegment({ apiKey, segmentId, email: clean })
+  } catch (err) {
+    console.warn('Report email add-contact failed:', err?.name || 'UnknownError')
+  }
+
+  return res.status(200).json({ sent: true, email: clean, source })
+}

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -7,6 +7,7 @@ import { LEARN_MODULES } from '../../data/learn/modules'
 import aiModels from '../../data/ai-models.json'
 import claudeCodeSkills from '../../data/claude-code-skills.json'
 import { AI_WORKFORCE_MODULES } from '../../data/ai-workforce'
+import { getAllSlugs as getAllPromptLibrarySlugs } from '../../lib/promptLibrary'
 
 // THE live sitemap. `next.config.js` rewrites /sitemap.xml here — there is
 // deliberately NO static public/sitemap.xml (a stale hand-committed copy
@@ -77,6 +78,7 @@ const STATIC_ROUTES = [
   { url: '/learn', priority: '0.8', changefreq: 'monthly' },
   { url: '/ai-workforce', priority: '0.8', changefreq: 'monthly' },
   { url: '/prompt-examples', priority: '0.85', changefreq: 'weekly' },
+  { url: '/prompt-library', priority: '0.85', changefreq: 'weekly' },
   { url: '/ai-models', priority: '0.85', changefreq: 'weekly' },
   { url: '/ai-prompt-generator/ai-art-prompts', priority: '0.7', changefreq: 'monthly' },
   { url: '/what-is-rag', priority: '0.85', changefreq: 'monthly' },
@@ -174,6 +176,11 @@ export default function handler(req, res) {
     .forEach(f => {
       xml += urlEntry(baseUrl, today, `/prompt-examples/${f.replace('.json', '')}`)
     })
+
+  // /prompt-library/[slug] — one URL per library prompt (slug from lib/promptLibrary)
+  getAllPromptLibrarySlugs().forEach(slug => {
+    xml += urlEntry(baseUrl, today, `/prompt-library/${slug}`, 'monthly', '0.7')
+  })
 
   // /model-prompting-guide/[model]
   getAllModelSlugs().forEach(slug => {

--- a/pages/prompt-library/[slug].js
+++ b/pages/prompt-library/[slug].js
@@ -1,0 +1,189 @@
+import { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import EmailCapture from '../../components/ui/EmailCapture'
+import { getAllSlugs, getPromptBySlug, getAllPromptSummaries } from '../../lib/promptLibrary'
+import { generateBreadcrumbSchema, generateArticleSchema } from '../../lib/schemaGenerator'
+
+const DIFFICULTY_LABELS = {
+  beginner: 'Beginner',
+  intermediate: 'Intermediate',
+  advanced: 'Advanced',
+}
+
+export default function PromptLibraryPage({ prompt, related }) {
+  const [copied, setCopied] = useState(false)
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(prompt.prompt)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const pageUrl = `https://promptwritingstudio.com/prompt-library/${prompt.slug}`
+  const seoTitle = `${prompt.title} Prompt (Copy-Ready) | PromptWritingStudio`
+
+  const breadcrumbSchema = generateBreadcrumbSchema([
+    { name: 'Home', url: 'https://promptwritingstudio.com' },
+    { name: 'Prompt Library', url: 'https://promptwritingstudio.com/prompt-library' },
+    { name: prompt.title, url: pageUrl },
+  ])
+  const articleSchema = generateArticleSchema({
+    title: prompt.title,
+    description: prompt.description,
+    url: pageUrl,
+    datePublished: '2025-01-15',
+    dateModified: '2026-07-15',
+    keywords: [...prompt.tags, prompt.categoryLabel, 'prompt template', 'AI prompt'],
+  })
+
+  return (
+    <Layout title={seoTitle} description={prompt.description} canonicalUrl={pageUrl}>
+      <Head>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      {/* Hero */}
+      <section className="gradient-bg text-white py-16 md:py-20">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-3xl mx-auto">
+            <div className="flex flex-wrap gap-2 mb-4">
+              <span className="bg-white/20 text-white px-3 py-1 rounded-full text-sm font-medium">{prompt.categoryLabel}</span>
+              {prompt.difficulty && (
+                <span className="bg-[#FFDE59]/20 text-[#FFDE59] px-3 py-1 rounded-full text-sm font-medium">
+                  {DIFFICULTY_LABELS[prompt.difficulty] || prompt.difficulty}
+                </span>
+              )}
+            </div>
+            <h1 className="text-3xl md:text-4xl font-bold mb-4">{prompt.title}</h1>
+            <p className="text-lg text-gray-200">{prompt.description}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-16 bg-white">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-4xl mx-auto">
+
+            {/* The prompt */}
+            <div className="mb-8">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <h2 className="text-xl font-bold text-[#1A1A1A]">The prompt</h2>
+                <button
+                  onClick={copyToClipboard}
+                  className="bg-[#FFDE59] text-[#1A1A1A] text-sm font-semibold px-4 py-2 rounded-lg hover:bg-[#E5C84F] transition"
+                >
+                  {copied ? 'Copied!' : 'Copy prompt'}
+                </button>
+              </div>
+              <div className="bg-[#F9F9F9] border border-[#E5E5E5] rounded-lg p-5">
+                <pre className="font-mono text-gray-800 text-sm leading-relaxed whitespace-pre-wrap">{prompt.prompt}</pre>
+              </div>
+              <p className="text-sm text-gray-500 mt-3">
+                Anything in [BRACKETS] is a placeholder. Replace it with your own detail before you run the prompt.
+              </p>
+            </div>
+
+            {/* How to use it */}
+            <div className="mb-10 bg-white border border-[#E5E5E5] rounded-lg p-6">
+              <h2 className="text-lg font-bold text-[#1A1A1A] mb-4">How to use this prompt</h2>
+              <dl className="grid sm:grid-cols-2 gap-4 text-sm">
+                {prompt.useCase && (
+                  <div>
+                    <dt className="font-semibold text-gray-500 uppercase tracking-wide text-xs mb-1">Best for</dt>
+                    <dd className="text-[#333333]">{prompt.useCase}</dd>
+                  </div>
+                )}
+                {prompt.estimatedTime && (
+                  <div>
+                    <dt className="font-semibold text-gray-500 uppercase tracking-wide text-xs mb-1">Time to run</dt>
+                    <dd className="text-[#333333]">{prompt.estimatedTime}</dd>
+                  </div>
+                )}
+                {prompt.difficulty && (
+                  <div>
+                    <dt className="font-semibold text-gray-500 uppercase tracking-wide text-xs mb-1">Level</dt>
+                    <dd className="text-[#333333]">{DIFFICULTY_LABELS[prompt.difficulty] || prompt.difficulty}</dd>
+                  </div>
+                )}
+                <div>
+                  <dt className="font-semibold text-gray-500 uppercase tracking-wide text-xs mb-1">Category</dt>
+                  <dd className="text-[#333333]">{prompt.categoryLabel}</dd>
+                </div>
+              </dl>
+              {prompt.tags.length > 0 && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {prompt.tags.map(tag => (
+                    <span key={tag} className="text-xs bg-[#F9F9F9] border border-[#E5E5E5] text-gray-600 px-2 py-1 rounded-full">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Grade it */}
+            <div className="mb-10 border-l-4 border-[#FFDE59] pl-5">
+              <h2 className="text-lg font-bold text-[#1A1A1A] mb-2">Make it yours, then grade it</h2>
+              <p className="text-gray-700 leading-relaxed">
+                Once you fill in the placeholders, paste your version into the free Prompt Grader. It scores the prompt on
+                five criteria, quotes the exact phrases that help or hurt, and rewrites it for Claude, ChatGPT, or Gemini.
+              </p>
+              <Link
+                href="/prompt-grader"
+                className="inline-block mt-4 bg-[#1A1A1A] text-white px-6 py-2 rounded-lg font-bold hover:bg-black transition text-sm"
+              >
+                Grade your version free
+              </Link>
+            </div>
+
+            {/* Capture */}
+            <div className="mb-12 bg-[#F9F9F9] rounded-lg p-6 border border-[#E5E5E5]">
+              <h2 className="text-lg font-bold text-[#1A1A1A] mb-2">Get a prompt like this each week</h2>
+              <p className="text-gray-600 text-sm mb-4">
+                Join the list for one full-length prompt worth saving, plus practical tips. No hype, no spam.
+              </p>
+              <EmailCapture source="prompt-library" label="" buttonText="Subscribe" theme="light" />
+            </div>
+
+            {/* Related */}
+            {related.length > 0 && (
+              <div>
+                <h2 className="text-xl font-bold text-[#1A1A1A] mb-4">More prompts in {prompt.categoryLabel}</h2>
+                <div className="flex flex-wrap gap-3">
+                  {related.map(item => (
+                    <Link
+                      key={item.slug}
+                      href={`/prompt-library/${item.slug}`}
+                      className="bg-[#F9F9F9] border border-[#E5E5E5] px-4 py-2 rounded-lg text-sm font-medium text-[#1A1A1A] hover:border-[#FFDE59] hover:bg-[#FFDE59]/10 transition"
+                    >
+                      {item.title}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: getAllSlugs().map(slug => ({ params: { slug } })),
+    fallback: false,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  const prompt = getPromptBySlug(params.slug)
+  if (!prompt) return { notFound: true }
+  const related = getAllPromptSummaries()
+    .filter(p => p.category === prompt.category && p.slug !== prompt.slug)
+    .slice(0, 4)
+  return { props: { prompt, related } }
+}

--- a/pages/prompt-library/index.js
+++ b/pages/prompt-library/index.js
@@ -1,0 +1,127 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../../components/layout/Layout'
+import EmailCapture from '../../components/ui/EmailCapture'
+import { getAllPromptSummaries } from '../../lib/promptLibrary'
+import { generateBreadcrumbSchema } from '../../lib/schemaGenerator'
+
+const CATEGORY_COLORS = {
+  business: 'bg-blue-100 text-blue-700',
+  'content-creation': 'bg-pink-100 text-pink-700',
+  copywriting: 'bg-green-100 text-green-700',
+  marketing: 'bg-purple-100 text-purple-700',
+  technical: 'bg-indigo-100 text-indigo-700',
+  seo: 'bg-yellow-100 text-yellow-700',
+}
+
+const DIFFICULTY_LABELS = {
+  beginner: 'Beginner',
+  intermediate: 'Intermediate',
+  advanced: 'Advanced',
+}
+
+export default function PromptLibraryIndex({ prompts, categories }) {
+  const pageUrl = 'https://promptwritingstudio.com/prompt-library'
+  const breadcrumbSchema = generateBreadcrumbSchema([
+    { name: 'Home', url: 'https://promptwritingstudio.com' },
+    { name: 'Prompt Library', url: pageUrl },
+  ])
+
+  return (
+    <Layout
+      title="Prompt Library: Full-Length, Copy-Ready AI Prompts | PromptWritingStudio"
+      description="A reference library of full-length, structured prompts for business, copywriting, marketing, SEO, content, and code. Each prompt has its own page you can copy and cite."
+      canonicalUrl={pageUrl}
+    >
+      <Head>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
+      </Head>
+
+      {/* Hero */}
+      <section className="gradient-bg text-white py-16 md:py-20">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-3xl mx-auto text-center">
+            <span className="bg-white/20 text-white px-4 py-1 rounded-full text-sm font-medium mb-4 inline-block">
+              Prompt Library
+            </span>
+            <h1 className="text-4xl md:text-5xl font-bold mb-5">Full-Length Prompts You Can Copy and Cite</h1>
+            <p className="text-xl text-gray-200">
+              Every prompt here is a complete, structured template with placeholders you fill in, not a one-line idea.
+              Each one has its own page so you can link to it, copy it, and reuse it.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Prompts by category */}
+      <section className="py-12 md:py-16 bg-[#F9F9F9]">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-5xl mx-auto">
+            {categories.map(category => {
+              const inCategory = prompts.filter(p => p.category === category.key)
+              if (inCategory.length === 0) return null
+              return (
+                <div key={category.key} className="mb-12 last:mb-0">
+                  <h2 className="text-2xl font-bold text-[#1A1A1A] mb-6">{category.label}</h2>
+                  <div className="grid md:grid-cols-2 gap-6">
+                    {inCategory.map(prompt => (
+                      <Link
+                        key={prompt.slug}
+                        href={`/prompt-library/${prompt.slug}`}
+                        className="bg-white rounded-lg border border-[#E5E5E5] p-6 hover:border-[#FFDE59] hover:shadow-md transition group"
+                      >
+                        <div className="flex items-start justify-between mb-3 gap-2">
+                          <span className={`text-xs font-semibold px-2 py-1 rounded-full ${CATEGORY_COLORS[prompt.category] || 'bg-gray-100 text-gray-700'}`}>
+                            {prompt.categoryLabel}
+                          </span>
+                          {prompt.difficulty && (
+                            <span className="text-xs text-gray-500 font-medium">
+                              {DIFFICULTY_LABELS[prompt.difficulty] || prompt.difficulty}
+                            </span>
+                          )}
+                        </div>
+                        <h3 className="text-lg font-bold text-[#1A1A1A] mb-2 group-hover:text-gray-700">{prompt.title}</h3>
+                        <p className="text-sm text-gray-600 mb-4 line-clamp-2">{prompt.description}</p>
+                        <span className="text-[#1A1A1A] font-semibold text-sm group-hover:underline">Open prompt →</span>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Capture */}
+      <section className="py-16 bg-white">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-2xl mx-auto text-center">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-4">One good prompt in your inbox each week</h2>
+            <p className="text-gray-600 mb-8">
+              Join the list and get a full-length prompt worth saving, plus practical tips for writing your own. No hype,
+              no spam.
+            </p>
+            <div className="flex justify-center">
+              <EmailCapture source="prompt-library" label="" buttonText="Subscribe" theme="light" />
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export async function getStaticProps() {
+  const prompts = getAllPromptSummaries()
+  // Resolve category labels here (server-side) so the client render never
+  // imports lib/promptLibrary (which reads the filesystem).
+  const seen = new Set()
+  const categories = []
+  for (const p of prompts) {
+    if (seen.has(p.category)) continue
+    seen.add(p.category)
+    categories.push({ key: p.category, label: p.categoryLabel })
+  }
+  return { props: { prompts, categories } }
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -51,6 +51,7 @@
 - [AI Prompt Generator](https://promptwritingstudio.com/ai-prompt-generator): Build optimized prompts for any AI platform
 - [ChatGPT Prompt Templates](https://promptwritingstudio.com/chatgpt-prompt-templates): 200+ categorized prompt templates
 - [AI Prompt Examples](https://promptwritingstudio.com/ai-prompt-examples): Curated collection of effective prompts
+- [Prompt Library](https://promptwritingstudio.com/prompt-library): Full-length, copy-ready prompt templates, each on its own citable URL (business, copywriting, marketing, SEO, content, code)
 - [Mad Libs Prompt Creator](https://promptwritingstudio.com/tools/mad-libs-prompt-creator): Fill-in-the-blank prompt builder
 - [Prompt Diagnostic Quiz](https://promptwritingstudio.com/tools/prompt-diagnostic-quiz): Why your prompts aren't working
 

--- a/scripts/generate-prompt-of-the-week.js
+++ b/scripts/generate-prompt-of-the-week.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Deterministic "prompt of the week" broadcast DRAFT generator. Zero LLM calls.
+//
+// This assembles a ready-to-send broadcast draft from the prompt library and
+// nothing else: same week in, same bytes out. It NEVER sends anything. The
+// output is a draft Bryan pastes into Resend and sends manually. There is no
+// send path in this repo by design (PWS is bench; approve-first on any
+// broadcast).
+//
+// Usage:
+//   node scripts/generate-prompt-of-the-week.js            # print draft to stdout
+//   node scripts/generate-prompt-of-the-week.js --write    # also write broadcasts/prompt-of-the-week-<year>-W<week>.md
+//   node scripts/generate-prompt-of-the-week.js --out path.md
+//   node scripts/generate-prompt-of-the-week.js --date 2026-07-15   # pin the ISO week
+//   node scripts/generate-prompt-of-the-week.js --week 29           # pin the selection index
+//
+// Determinism: stdout carries no wall-clock timestamp, so two runs in the same
+// ISO week produce byte-identical output (the DoD "run twice, diff" check).
+
+const fs = require('fs')
+const path = require('path')
+const { pathToFileURL } = require('url')
+
+// ISO 8601 week number (Monday-based, week that contains the first Thursday).
+function isoWeek(date) {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+  const day = (d.getUTCDay() + 6) % 7
+  d.setUTCDate(d.getUTCDate() - day + 3)
+  const firstThursday = new Date(Date.UTC(d.getUTCFullYear(), 0, 4))
+  const week = 1 + Math.round(((d - firstThursday) / 86400000 - 3 + ((firstThursday.getUTCDay() + 6) % 7)) / 7)
+  return { year: d.getUTCFullYear(), week }
+}
+
+function parseArgs(argv) {
+  const args = { write: false, out: null, week: null, date: null }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--write') args.write = true
+    else if (a === '--out') args.out = argv[++i]
+    else if (a === '--week') args.week = parseInt(argv[++i], 10)
+    else if (a === '--date') args.date = argv[++i]
+  }
+  return args
+}
+
+function buildDraft(prompt, label) {
+  const url = `https://promptwritingstudio.com/prompt-library/${prompt.slug}`
+  const subject = `${prompt.title}: a prompt worth saving`
+  return `# Prompt of the week (${label})
+
+Subject: ${subject}
+
+Hi there,
+
+This week's prompt from the PromptWritingStudio library is ${prompt.title}. ${prompt.description}.
+
+It is a full-length template, so fill in anything in [BRACKETS] with your own detail before you run it.
+
+---
+
+${prompt.prompt}
+
+---
+
+Copy the latest version, see how to use it, and grade your own edit here:
+${url}
+
+Until next week,
+Bryan
+
+You are getting this because you subscribed at promptwritingstudio.com. The unsubscribe link is at the bottom of this email.
+`
+}
+
+;(async () => {
+  const args = parseArgs(process.argv)
+  const libUrl = pathToFileURL(path.join(__dirname, '..', 'lib', 'promptLibrary.js')).href
+  const lib = await import(libUrl)
+
+  const now = args.date ? new Date(`${args.date}T12:00:00Z`) : new Date()
+  const { year, week } = isoWeek(now)
+  const label = `${year}-W${String(week).padStart(2, '0')}`
+  const weekNumber = Number.isInteger(args.week) ? args.week : week
+
+  const prompt = lib.getPromptOfTheWeek(weekNumber)
+  if (!prompt) {
+    console.error('No prompts in the library; nothing to generate.')
+    process.exit(1)
+  }
+
+  const draft = buildDraft(prompt, label)
+  process.stdout.write(draft)
+
+  if (args.write || args.out) {
+    const outPath = args.out || path.join(__dirname, '..', 'broadcasts', `prompt-of-the-week-${label}.md`)
+    fs.mkdirSync(path.dirname(outPath), { recursive: true })
+    fs.writeFileSync(outPath, draft)
+    // stderr so stdout stays byte-stable for the determinism diff.
+    console.error(`Wrote ${outPath}`)
+  }
+})().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Two bench-scope, one-shot PRDs from the newsletter-flywheel sweep. Turns the site's only working acquisition surface (the graders) into list growth at the value moment, and makes the prompt library citable by AI assistants with a zero-cost recurring broadcast draft behind it. **Never merged by the session; Bryan merges.**

## PRDs implemented

- PRD-1: `~/.claude/handoff/newsletter-flywheel-2026-07-14/promptwritingstudio-PRD-1-prompt-grader-email-report.md` — "email me the full report" capture on the graders.
- PRD-3: `~/.claude/handoff/newsletter-flywheel-2026-07-14/promptwritingstudio-PRD-3-prompt-library-aeo-broadcast.md` — per-prompt AEO URLs + disarmed prompt-of-the-week draft generator.

## Corrections applied (override PRD text)

1. **PRD-1 is an ADD-ON, not a rebuild** — layered on the existing grader/judge/rate-limit/Blobs stack. Touches only the completed-result UI plus new files. Disjoint from open PR #59.
2. **PRD-3 read-only files respected** — `data/prompt-library.js`, `components/ui/PromptLibrary.js`, `pages/ai-prompt-generator/enhanced.js` are **not edited** (PR #59 territory). Fabricated stats (`optimizationScore`, `likes`, `uses`) are excluded at a **new** `lib/promptLibrary.js` allow-list layer, never at the data file. `lib/templates/index.js` (a fourth consumer) also left untouched.
3. **Broadcast is DRAFT-ONLY / approve-first** — the generator writes a draft; there is **no send path**. Bryan sends the first one from Resend.
4. **In-session `npm run build` is the gate** (repo has only `claude.yml`, no PR CI).

## Build gate

`npm install --no-audit --no-fund && npm test && npm run build` — **PASS**. 144/144 jest tests green (13 suites), `next build` exit 0. `/prompt-library` + 9 `/prompt-library/[slug]` pages generated (SSG), `/api/grade/[id]/email` lambda registered.

## PRD-1 Definition of Done

| DoD item | Status | Evidence |
|---|---|---|
| `email.js` exists, rejects non-POST with 405 | PASS | `pages/api/grade/[id]/email.js:28` `res.status(405)` |
| Evidence quotes gated on `grounded` | PASS | `lib/grades/reportEmail.js` `criterion.grounded === true` gate; unit test asserts grounded quote shown, ungrounded (non-empty span) suppressed |
| `prompt-grader-report` hits UI + API | PASS | grep hits `components/tools/PromptGrader.js:141` (UI) + `pages/api/grade/[id]/email.js:17,19` (API boundary) |
| `429` rate-limit response | PASS | `pages/api/grade/[id]/email.js:46` `res.status(429)` |
| No em dash in new email/UI copy | PASS | grep over new files clean (pre-existing em dashes in `PromptGrader.js:34` example + `llms.txt` intro are out of scope, not added by this PR) |
| No `course` CTA in email route | PASS | `grep -in course pages/api/grade/[id]/email.js` -> none; renderer test asserts no `course` |
| `npm test` passes (renderer unit test) | PASS | `__tests__/grades/reportEmail.test.js` 8/8; fixture has one grounded + one ungrounded criterion |
| `npm run build` exits 0 | PASS | build exit 0 |
| `/prompt-grader` renders non-empty, 0 console errors | DEFERRED | Build succeeded; runtime console-error check deferred to the Netlify deploy preview |

## PRD-3 Definition of Done

| DoD item | Status | Evidence |
|---|---|---|
| `pages/prompt-library/[slug].js` + `index.js` exist | PASS | both committed; build emits 9 static prompt pages |
| No fabricated stats rendered in lib/pages | PASS | `grep -rn "likes\|uses:\|optimizationScore" pages/prompt-library/ lib/promptLibrary.js` -> none (whitelist-pick, never names the fields) |
| No slug collision; prints count | PASS | `node -e "…getAllSlugs()…"` -> `count: 9`, `new Set` size equal |
| Sitemap includes `/prompt-library/` URLs | PASS | `pages/api/sitemap.js:81` (index) + `:180-182` (per-prompt loop via `getAllPromptLibrarySlugs`) |
| Generator exits 0 twice, identical output | PASS | ran twice, `diff` identical, exit 0 (no wall-clock in stdout) |
| Workflow has `workflow_dispatch`, no active `schedule:` | PASS | `grep -c "^  schedule:"` -> `0`; `workflow_dispatch` present; cron commented in header |
| First broadcast draft committed, full URL, no em dash | PASS | `broadcasts/prompt-of-the-week-2026-W29.md` contains `https://promptwritingstudio.com/prompt-library/code-review-assistant`; em-dash grep clean |
| No em dash in new page files / generator template | PASS | grep over new files clean |
| `npm test` + `npm run build` | PASS | 144 tests, build exit 0 |
| `/prompt-library` index + one prompt page render non-empty, 0 console errors | PARTIAL / DEFERRED | Both SSG (`●` in build output) so `getStaticProps` rendered them to static HTML without throwing (non-empty confirmed); runtime 0-console-errors deferred to Netlify preview |

## AEO / house-rule checks

- **AIO-resistance**: each `/prompt-library/<slug>` page renders the full multi-section copy-ready prompt template plus use case / difficulty / tags context. The copy-paste asset is the value; an AI overview cannot reproduce a 300-word structured template in one paragraph.
- **No count-summary cards**: the index groups by category with no "X prompts / Y categories" badge wall (the `prompt-examples/index.js` count line was deliberately NOT copied over).
- **No LLM-inlined data**: no euro figures/stats/model dates asserted. Fabricated engagement metrics are filtered out, not re-invented.
- **Slug permanence**: slugs come from a committed `data/prompt-library-slugs.json` id->slug map (title-derived fallback), so a future title edit never moves a published URL. Sitemap runtime falls back to title-derived slugs which are byte-identical to the map, so URLs stay stable even if the JSON is not bundled into the function.

## Known behavior / 2nd-order notes

- **Welcome-email decision (PRD-1 open question)**: the report email **is** the welcome moment. Report-email signups do **not** also get the Netlify Forms welcome (that function only fires on form submissions). The route still adds the contact to the segment. This is the PRD's default ("report only").
- **Report capture gated on a persisted record**: the "Email me this report" card only shows when the grade persisted to Blobs (`share.id` present). If Blobs persistence failed for a grade, the card is hidden (same gate the share block uses).
- **Arbitrary-recipient / segment-injection surface**: the endpoint is id-only (no manageToken, per PRD scope). A scraped public `/g/<id>` id could be used to send a report to an arbitrary address; capped by the 5/day/IP in-memory limit and no AI-gateway cost. Mirrors the existing Netlify Forms capture surface.

## Deferred — needs Bryan (do NOT do autonomously)

1. **Send the first broadcast**: draft is `broadcasts/prompt-of-the-week-2026-W29.md`. Send manually from Resend: https://resend.com/broadcasts
2. **Arm the cadence**: uncomment the `schedule:` block in `.github/workflows/prompt-of-the-week.yml` and decide the day/time. It only produces drafts until a send step is deliberately added.
3. **RESEND envs already live** for the email route (shared with `netlify/functions/submission-created.js`): `RESEND_API_KEY`, `RESEND_SEGMENT_ID`, `RESEND_FROM`. No new keys. Verify in Netlify: https://app.netlify.com
4. **Post-merge Netlify deploy check** + smoke: https://promptwritingstudio.com/prompt-grader , https://promptwritingstudio.com/agent-prompt-grader , https://promptwritingstudio.com/prompt-library , https://promptwritingstudio.com/prompt-library/code-review-assistant
5. **Self-verify metric** (post-deploy): `curl -s -X POST https://promptwritingstudio.com/api/grade/FAKEID/email -H 'Content-Type: application/json' -d '{"email":"a@b.com"}'` returns structured 4xx JSON; contacts arriving in the segment with source `prompt-grader-report`.

## pr-critic depth verdict

**ADEQUATE (leaning DEEP).** Both root problems solved end-to-end with tests and both gates green. Depth evidence: caught and fixed a client-bundle `fs` leak (index page importing a server-only lib constant into client render); Blobs-failure degrades gracefully to no card rather than a broken control; slug-URL permanence via a committed map plus a byte-identical runtime fallback; rate-limit abuse surface bounded and documented; the welcome-email behavior question decided and recorded. Not claimed DEEP because the two runtime "0 console errors" render checks are deferred to the Netlify preview rather than executed in-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
