### PR TITLE
Freshness sweep: re-verify every model/pricing claim against live sources; fix stale Opus + Windsurf prices

### DIFF
--- a/data/ai-models.json
+++ b/data/ai-models.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schemaVersion": 1,
-    "lastVerified": "2026-06-09",
+    "lastVerified": "2026-07-17",
     "stalenessThresholdDays": 60,
     "notes": "Multi-vendor AI model facts. Single source of truth for /ai-models, /claude-vs-chatgpt, and any page that quotes pricing or capability claims for non-Claude models. For Claude-only API model IDs and detailed plan data, see data/claude-models.json. This file mirrors top-level facts and adds non-Claude vendors. Update each entry's last_verified_at when you re-check it against the source. Monthly GitHub Actions cron flags entries older than stalenessThresholdDays."
   },
@@ -24,7 +24,7 @@
       "context_window": 1000000,
       "context_window_label": "1M tokens",
       "released": "2026-06",
-      "last_verified_at": "2026-06-09",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://platform.claude.com/docs/en/about-claude/models/overview",
       "description": "Anthropic's most capable widely released model — built for the most demanding reasoning and long-horizon agentic work.",
       "features": [
@@ -52,7 +52,7 @@
       "context_window": 1000000,
       "context_window_label": "1M tokens",
       "released": "2026",
-      "last_verified_at": "2026-06-09",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://platform.claude.com/docs/en/about-claude/models/overview",
       "description": "Anthropic's most capable Opus-tier model for complex reasoning, agentic coding, and high-autonomy work.",
       "features": [
@@ -81,7 +81,7 @@
       "context_window": 1000000,
       "context_window_label": "1M tokens",
       "released": "2025-09",
-      "last_verified_at": "2026-06-09",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://platform.claude.com/docs/en/about-claude/models/overview",
       "description": "Anthropic's mainstream workhorse — the default for Claude.ai, API workloads, and Claude Code day-to-day.",
       "features": [
@@ -109,7 +109,7 @@
       "context_window": 200000,
       "context_window_label": "200K tokens",
       "released": "2025-10",
-      "last_verified_at": "2026-06-09",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://platform.claude.com/docs/en/about-claude/models/overview",
       "description": "Anthropic's small, fast, cheap model — the right default for background agents and high-volume jobs.",
       "features": [
@@ -166,7 +166,7 @@
       "context_window": 128000,
       "context_window_label": "128K tokens",
       "released": "2024-05",
-      "last_verified_at": "2026-05-07",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://openai.com/api/pricing/",
       "description": "OpenAI's omni model — good multimodal default when latency and cost matter more than absolute reasoning quality.",
       "features": [
@@ -192,7 +192,7 @@
       "context_window": 128000,
       "context_window_label": "128K tokens",
       "released": "2024-07",
-      "last_verified_at": "2026-05-07",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://openai.com/api/pricing/",
       "description": "OpenAI's small, cheap multimodal sibling of GPT-4o — strong default for high-volume tasks where latency and cost dominate.",
       "features": [
@@ -220,7 +220,7 @@
       "context_window": 2000000,
       "context_window_label": "1M+ tokens (up to 2M)",
       "released": "2025",
-      "last_verified_at": "2026-05-28",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://ai.google.dev/pricing",
       "verification_notes": "Pricing tiered by context length (≤200K vs >200K). Lower bound applies under 200K input.",
       "description": "Google's Gemini Pro line — the go-to when you need to stuff a whole codebase or long video into a single prompt.",
@@ -248,7 +248,7 @@
       "context_window": 1000000,
       "context_window_label": "1M tokens",
       "released": "2025",
-      "last_verified_at": "2026-05-28",
+      "last_verified_at": "2026-07-17",
       "verification_source": "https://ai.google.dev/pricing",
       "verification_notes": "Pricing varies by inference mode (Standard / Batch / Flex / Priority).",
       "description": "Gemini's low-cost tier. Strong choice for high-volume, long-context workloads where Flash quality is good enough.",

--- a/data/api-pricing.json
+++ b/data/api-pricing.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-05-25",
+  "last_updated": "2026-07-17",
   "note": "Prices in USD per 1M tokens. Cache write cost excluded from calculator (amortized across calls). Gemini context cache excludes per-hour storage cost.",
   "models": [
     {
@@ -12,7 +12,7 @@
       "cache_read_per_1m": 0.50,
       "cache_type": "anthropic",
       "cache_note": "Read price is 10% of input. Write is 1.25x input. 5-min TTL default.",
-      "last_verified": "2026-05-25",
+      "last_verified": "2026-07-17",
       "source_url": "https://claude.com/pricing",
       "verified": true
     },
@@ -26,7 +26,7 @@
       "cache_read_per_1m": 0.30,
       "cache_type": "anthropic",
       "cache_note": "Read price is 10% of input. Write is 1.25x input. 5-min TTL default.",
-      "last_verified": "2026-05-25",
+      "last_verified": "2026-07-17",
       "source_url": "https://claude.com/pricing",
       "verified": true
     },
@@ -40,7 +40,7 @@
       "cache_read_per_1m": 0.10,
       "cache_type": "anthropic",
       "cache_note": "Read price is 10% of input. Write is 1.25x input. 5-min TTL default.",
-      "last_verified": "2026-05-25",
+      "last_verified": "2026-07-17",
       "source_url": "https://claude.com/pricing",
       "verified": true
     },
@@ -53,10 +53,10 @@
       "cache_read_per_1m": 1.25,
       "cache_type": "openai",
       "cache_note": "Automatic input caching at 50% of input price for prompts over 1024 tokens.",
-      "last_verified": "2026-05-25",
+      "last_verified": "2026-07-17",
       "source_url": "https://openai.com/api/pricing/",
       "verified": false,
-      "price_unverified_as_of": "2026-05-25"
+      "price_unverified_as_of": "2026-07-17"
     },
     {
       "id": "gpt-4o-mini",
@@ -67,10 +67,10 @@
       "cache_read_per_1m": 0.075,
       "cache_type": "openai",
       "cache_note": "Automatic input caching at 50% of input price for prompts over 1024 tokens.",
-      "last_verified": "2026-05-25",
+      "last_verified": "2026-07-17",
       "source_url": "https://openai.com/api/pricing/",
       "verified": false,
-      "price_unverified_as_of": "2026-05-25"
+      "price_unverified_as_of": "2026-07-17"
     },
     {
       "id": "gemini-2-5-pro",
@@ -81,7 +81,7 @@
       "cache_read_per_1m": 0.125,
       "cache_type": "gemini",
       "cache_note": "Context cache input at $0.125/1M (under 200K context). Storage billed separately at $4.50/1M tokens/hour.",
-      "last_verified": "2026-05-25",
+      "last_verified": "2026-07-17",
       "source_url": "https://ai.google.dev/pricing",
       "verified": true
     },
@@ -94,7 +94,7 @@
       "cache_read_per_1m": 0.03,
       "cache_type": "gemini",
       "cache_note": "Context cache input at $0.03/1M (text/image/video). Storage billed separately at $1.00/1M tokens/hour.",
-      "last_verified": "2026-05-25",
+      "last_verified": "2026-07-17",
       "source_url": "https://ai.google.dev/pricing",
       "verified": true
     }

--- a/data/claude-plans.json
+++ b/data/claude-plans.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
-    "lastVerified": "2026-06-09",
+    "lastVerified": "2026-07-17",
     "source": "https://claude.com/pricing",
-    "notes": "Consumer + team plan pricing. Limits are Anthropic's public-facing copy; actual message caps vary. Update when pricing page changes."
+    "notes": "Consumer + team plan pricing. Limits are Anthropic's public-facing copy; actual message caps vary. Update when pricing page changes. 2026-07-17: all prices re-verified against live claude.com/pricing (Free $0, Pro $20/$17, Max 5x $100, Max 20x $200, Team $25/$20 seat, Team Premium $125/$100 seat, Enterprise $20 seat) - all unchanged. Live page now also lists a fifth consumer model (Mythos, limited availability) not reflected in the models arrays - see needs-Bryan."
   },
   "consumer": [
     {

--- a/pages/claude-code-alternatives.js
+++ b/pages/claude-code-alternatives.js
@@ -22,7 +22,7 @@ const faqs = [
   },
   {
     question: "How much do Claude Code alternatives cost?",
-    answer: "The $20/month tier has become the standard: Cursor Pro, Windsurf Pro (actually $15), and Claude Code Pro all sit around there. GitHub Copilot Pro is cheaper at $10/month. Codex and Gemini CLI bill via API tokens or subscription. The open-source agents (Cline, Aider, Continue.dev) are free to install and cost only your API usage. The real difference is flat quota versus token-based billing — heavy users prefer a flat fee, light users come out ahead on tokens."
+    answer: "The $20/month tier has become the standard: Cursor Pro, Windsurf Pro, and Claude Code Pro all sit around there. GitHub Copilot Pro is cheaper at $10/month. Codex and Gemini CLI bill via API tokens or subscription. The open-source agents (Cline, Aider, Continue.dev) are free to install and cost only your API usage. The real difference is flat quota versus token-based billing — heavy users prefer a flat fee, light users come out ahead on tokens."
   },
   {
     question: "Do I have to leave Claude Code to use an alternative?",
@@ -56,9 +56,9 @@ const tools = [
   {
     name: 'Windsurf',
     form: 'VS Code fork (by Codeium)',
-    free: 'Pro $15/mo; Teams $30/seat',
-    forWho: 'Cursor-style IDE users who want a slightly cheaper plan and the Cascade agent for flow-based multi-file editing.',
-    vsClaude: 'A direct Cursor competitor rather than a Claude Code competitor — same trade-off: editor UI over terminal automation, undercutting Cursor by $5/mo.'
+    free: 'Pro $20/mo; Teams $40/seat',
+    forWho: 'Cursor-style IDE users who want the Cascade agent for flow-based multi-file editing.',
+    vsClaude: 'A direct Cursor competitor rather than a Claude Code competitor. Same trade-off: editor UI over terminal automation, now at price parity with Cursor Pro at $20/mo.'
   },
   {
     name: 'OpenAI Codex CLI',
@@ -101,7 +101,7 @@ const comparisonRows = [
   { tool: 'Claude Code', form: 'Terminal agent', cost: 'API / Pro $20/mo / Max', open: 'No', best: 'Multi-file refactors, git, hooks, sub-agents' },
   { tool: 'Cursor', form: 'IDE (VS Code fork)', cost: 'Free / Pro $20/mo', open: 'No', best: 'Interactive coding with inline AI' },
   { tool: 'GitHub Copilot', form: 'IDE extension', cost: 'Pro $10/mo', open: 'No', best: 'Cheap autocomplete in GitHub/VS Code stack' },
-  { tool: 'Windsurf', form: 'IDE (VS Code fork)', cost: 'Pro $15/mo', open: 'No', best: 'Cursor-style editing, slightly cheaper' },
+  { tool: 'Windsurf', form: 'IDE (VS Code fork)', cost: 'Pro $20/mo', open: 'No', best: 'Cursor-style editing with the Cascade agent' },
   { tool: 'Codex CLI', form: 'Terminal agent', cost: 'API / ChatGPT sub', open: 'No', best: 'Closest terminal match (top SWE-bench)' },
   { tool: 'Gemini CLI', form: 'Terminal agent', cost: 'Free — 1,000 req/day', open: 'No', best: 'Best free terminal agent' },
   { tool: 'Aider', form: 'Terminal CLI', cost: 'Free (BYOK)', open: 'Yes', best: 'Model-agnostic, git-native, no lock-in' },
@@ -191,7 +191,7 @@ export default function ClaudeCodeAlternatives() {
                 <h3 className="text-2xl font-bold text-[#1A1A1A] mb-4">If you want a visual IDE...</h3>
                 <ul className="space-y-3">
                   <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Cursor</strong> — the most popular IDE alternative</span></li>
-                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Windsurf</strong> — Cursor-style, $5/mo cheaper</span></li>
+                  <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>Windsurf</strong>: Cursor-style IDE with the Cascade agent, now $20/mo</span></li>
                   <li className="flex items-start"><span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span><span className="text-[#333333]"><strong>GitHub Copilot</strong> — cheapest, deepest IDE integration</span></li>
                 </ul>
               </div>

--- a/pages/claude-code-guide.js
+++ b/pages/claude-code-guide.js
@@ -603,7 +603,7 @@ Next.js site with Tailwind CSS, deployed on Vercel.
                   </li>
                   <li className="flex items-start">
                     <span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span>
-                    <span className="text-[#333333]">Claude Opus: ~$15 per million input tokens, ~$75 per million output tokens</span>
+                    <span className="text-[#333333]">Claude Opus: ~$5 per million input tokens, ~$25 per million output tokens</span>
                   </li>
                   <li className="flex items-start">
                     <span className="text-[#FFDE59] mr-2 mt-1 flex-shrink-0">+</span>


### PR DESCRIPTION
Implements **PRD-1: Claude/AI-model claim pages stop asserting stale prices and model facts** (`~/.claude/handoff/sprint-content-gap-2026-07-16/pws-PRD-1-model-claims-freshness-sweep.md`).

One-shot freshness sweep. Every model/pricing claim touched was live-verified at edit time (2026-07-17). Where a live source matched the existing value, the value was re-dated in place; where it had drifted, it was corrected; anything a primary source could not confirm was left unchanged and is listed under **Needs Bryan** rather than guessed.

## Headline findings
- **No price drift in either data file.** Every consumer/team/API price in `claude-plans.json` and `api-pricing.json` still matches its live vendor source. The files were 5-7 weeks past their own freshness contract; they now carry today's date.
- **Two genuinely stale hardcoded claims corrected:**
  - `claude-code-guide.js`: Claude Opus API price was **$15 / $75 per 1M** (the retired Opus 4.1 rate). Current Opus 4.8/4.7 is **$5 / $25**. Fixed.
  - `claude-code-alternatives.js`: Windsurf Pro was **$15/mo** with "$5/mo cheaper than Cursor" framing. Windsurf raised Pro to **$20** (and Teams to $40/seat) in March 2026, reaching parity with Cursor. Fixed; the false "cheaper" framing removed.
- The flagship generation has moved to **Opus 4.8 / Sonnet 5** on the live pricing table (the file's Opus 4.7 / Sonnet 4.6 entries remain live at the same prices, so they are one generation behind but not wrong). A fifth consumer model, **Mythos 5 (limited availability)**, now appears. Both go to **Needs Bryan** with a recommendation (see below).

## Definition of Done

| DoD item | Status | Evidence |
|---|---|---|
| `claude-plans.json` `_meta.lastVerified` >= 2026-07-16 | **PASS** | now `2026-07-17`; every price matches evidence table below |
| `api-pricing.json` `last_updated` >= 2026-07-16 + every entry `last_verified` refreshed | **PASS** | `last_updated` = `2026-07-17`; all 7 entries `last_verified` = `2026-07-17` |
| 6-file price grep enumerated with per-line status | **PASS** | full enumeration below |
| Evidence table: old/new/source/timestamp per changed claim | **PASS** | below |
| No `courses.becomeawritertoday` introduced | **PASS** | `grep -rn 'courses.becomeawritertoday' pages/ \| wc -l` = **0** |
| `npm install --no-audit --no-fund && npm run build` exits 0 | **PASS** | build exit **0**; render-checked `claude-code-guide` (Opus $5/$25), `claude-code-alternatives` (Windsurf $20/$40), `anthropic-api-pricing`, `claude-vs-gemini` all non-empty |

## Evidence table (all sources live-fetched 2026-07-17)

**Claude consumer + team plans** — source: https://claude.com/pricing (Max 20x disambiguated via https://support.claude.com/en/articles/11049741-what-is-the-max-plan)

| Claim | File value | Live value | Result |
|---|---|---|---|
| Free | $0 | $0 | match |
| Pro monthly / annual | $20 / $17 | $20 / $17 | match |
| Max 5x | $100 | $100 | match |
| Max 20x | $200 | $200 (distinct from the "from $100" Max banner) | match |
| Team Standard seat (min 5) | $25 / $20 annual | $25 / $20 | match |
| Team Premium seat | $125 / $100 annual | $125 / $100 | match |
| Enterprise seat | $20 + API usage | $20 + API usage | match |
| Claude Code on Free | not included | "exclusively a paid feature; Free does not include it" | match |

**Anthropic API per-token** — source: https://platform.claude.com/docs/en/about-claude/pricing

| Model (file id) | File input/output · 5m-cache-write · cache-read | Live | Result |
|---|---|---|---|
| Opus 4.7 (`claude-opus-4-7`) | $5 / $25 · $6.25 · $0.50 | $5 / $25 · $6.25 · $0.50 | match |
| Sonnet 4.6 (`claude-sonnet-4-6`) | $3 / $15 · $3.75 · $0.30 | $3 / $15 · $3.75 · $0.30 | match |
| Haiku 4.5 (`claude-haiku-4-5`) | $1 / $5 · $1.25 · $0.10 | $1 / $5 · $1.25 · $0.10 | match |
| Fable 5 (`claude-fable-5`, ai-models.json) | $10 / $50 | $10 / $50 | match |

**OpenAI** — WebSearch aggregators (2026); official https://developers.openai.com/api/docs/pricing now lists only the gpt-5.x family and no longer shows GPT-4o (see Needs Bryan)

| Model | File | Live (aggregator) | Result |
|---|---|---|---|
| GPT-4o | $2.50 / $10 | $2.50 / $10 | match (kept `verified:false`, aggregator-only) |
| GPT-4o mini | $0.15 / $0.60 | $0.15 / $0.60 | match (kept `verified:false`) |

**Google** — source: https://ai.google.dev/pricing

| Model | File input/output · cache | Live (<=200k tier) | Result |
|---|---|---|---|
| Gemini 2.5 Pro | $1.25 / $10 · $0.125 | $1.25 / $10 · $0.125 | match |
| Gemini 2.5 Flash | $0.30 / $2.50 · $0.03 | $0.30 (text) / $2.50 · $0.03 | match (base tier; mode-tiered upper bounds not re-fetched) |

## Corrected hardcoded claims

| File:line | Old | New | Source |
|---|---|---|---|
| `claude-code-guide.js:606` | Claude Opus ~$15 in / ~$75 out per 1M | ~$5 in / ~$25 out per 1M | platform.claude.com API pricing |
| `claude-code-alternatives.js:59` | Windsurf `Pro $15/mo; Teams $30/seat` | `Pro $20/mo; Teams $40/seat` | WebSearch: Windsurf Pro→$20, Teams→$40 (Mar 2026 parity with Cursor) |
| `claude-code-alternatives.js:61,104,194,25` | "$5/mo cheaper" / "actually $15" framing | parity framing, $20/mo | same |

## 6-file DoD grep — per-line verified-against-source status

`grep -rEn '\$[0-9]+(/mo\| per month\|/month\| per million)' pages/best-ai-tools.js pages/claude-code-alternatives.js pages/replit-vs-lovable.js pages/custom-ai-agents.js pages/claude-vs-chatgpt.js pages/claude-code-guide.js`

- **claude-code-guide.js** (5 lines): Pro $20, Max $100/$200, Cursor $20, Copilot $10 — all **VERIFIED match**. Sonnet $3/$15 (l.602) **VERIFIED match**. Opus (l.606) **CORRECTED** $15/$75→$5/$25.
- **claude-code-alternatives.js** (11 lines): Cursor $20, Copilot Pro $10 / Business $19, Cline free/Teams $20 — **VERIFIED match**. Windsurf lines (59,104,194,25,61) **CORRECTED** to $20/$40.
- **claude-vs-chatgpt.js** (7 lines): Claude Pro $20, Max $100/$200, ChatGPT Plus $20, ChatGPT Pro $200 — all **VERIFIED match** (Plus/Pro confirmed via WebSearch). "Opus 4.8" and "GPT-5" references are current-generation. No change.
- **custom-ai-agents.js** (8 lines): ChatGPT Plus $20, Claude Pro $20 — **VERIFIED match**. Google AI Pro left as "see one.google.com" (no hard price asserted). No change.
- **replit-vs-lovable.js** (10 lines): Lovable Starter $20 **VERIFIED match**; Team plans $100 plausible. Replit Core "$20/mo" reflects the **annual** rate (live monthly is $25) — **borderline, left unchanged, flagged** (see Needs Bryan). No edit to this file.
- **best-ai-tools.js** (36 lines): ChatGPT $20 (l.88), Claude $20 (l.95,299) **VERIFIED match**. The remaining ~33 are generic third-party SaaS "From $X/mo" list prices (Jasper, Copy.ai, Writesonic, Notion AI, etc.) — **NOT independently re-verified this session** (lower-decay than model-token pricing); left unchanged, flagged for an optional batch pass (see Needs Bryan).

## Needs Bryan

1. **Superseded flagship lineup (PRD-1 open question).** `api-pricing.json` lists Opus 4.7 / Sonnet 4.6 / Haiku 4.5. Live claude.com/pricing now leads with **Opus 4.8** ($5/$25) and **Sonnet 5** ($2/$10 introductory through Aug 31 2026, $3/$15 from Sep 1); the old entries remain live at unchanged prices. **Recommendation:** add Opus 4.8 and Sonnet 5 as **new** entries with the verified prices, but do **not** rename the existing ids `claude-opus-4-7` / `claude-sonnet-4-6` (they key `lib/gateway/models.js`). Held this session to avoid surfacing new models into the gateway/calculator UI unreviewed on a bench site.
2. **Mythos 5.** claude.com/pricing now lists a fifth consumer model, **Claude Mythos 5 (limited availability)**. Not added to `claude-plans.json` models arrays because per-plan availability is unverifiable and "limited availability" implies it is not on Free. Confirm gating before adding.
3. **OpenAI baseline drift.** The official OpenAI pricing page has moved entirely to the **gpt-5.x** family; GPT-4o is no longer listed there. Its price is aggregator-confirmed and left in place with `verified:false`. Decide whether the calculator's OpenAI baseline should migrate to a current gpt-5.x model.
4. **Replit Core price.** `replit-vs-lovable.js` states "$20/mo" for Replit Core; live shows **$25/mo monthly, $20/mo annual**. Defensible as the annual rate, so left unchanged, but the "both start at $20" symmetry with Lovable now only holds on annual billing.
5. **best-ai-tools.js long tail.** ~33 generic SaaS list prices not re-verified this session. Optional separate batch pass if you want them current.
6. **ai-models.json non-price tail.** 5 entries (`gpt-5`, `llama-3-3-70b`, `grok-3`, `mistral-large-2`, `deepseek-v3`) carry vendor-deferral labels (no falsifiable price) and retain `last_verified_at: 2026-05-07`. Their model names may be a generation behind; they do not render on the high-traffic Claude pages. A full existence-check is a clean follow-up.

## Notes
- Stacked base for PRD-2 and PRD-3 (both branch off this one). **Do not merge out of order.**
- No course CTAs added; no "reply with X" CTAs; no em dashes introduced in any copy touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
