### PR TITLE
Hub push: bare-variant ChatGPT templates coverage + FAQ schema + internal links (real count 117)

### DIFF
--- a/pages/ai-prompt-examples.js
+++ b/pages/ai-prompt-examples.js
@@ -552,7 +552,8 @@ export default function AIPromptExamples() {
             <section className="mt-16 bg-gradient-to-r from-green-50 to-blue-50 rounded-xl p-8">
               <h3 className="text-2xl font-bold text-center mb-6">Explore Specialized AI Prompt Categories</h3>
               <p className="text-center text-gray-600 mb-8">
-                Find targeted prompts for your specific needs. Each category contains expert-crafted templates designed for maximum results.
+                Find targeted prompts for your specific needs, or browse the full library of{' '}
+                <Link href="/chatgpt-prompt-templates" className="text-blue-600 hover:text-blue-700 underline font-medium">free ChatGPT prompt templates</Link>. Each category contains expert-crafted templates designed for maximum results.
               </p>
               <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
                 <Link href="/chatgpt-prompts-for/productivity" className="bg-white p-6 rounded-lg shadow hover:shadow-md transition group">

--- a/pages/chatgpt-prompt-templates.js
+++ b/pages/chatgpt-prompt-templates.js
@@ -3,8 +3,31 @@ import Layout from '../components/layout/Layout'
 import Link from 'next/link'
 import Script from 'next/script'
 import { getAllModifiers } from '../lib/modifiers'
+import { generateFAQSchema } from '../lib/schemaGenerator'
 
 export default function ChatGPTPromptTemplates({ modifiers }) {
+  const totalTemplates = modifiers.reduce((sum, m) => sum + (m.promptTemplates ? m.promptTemplates.length : 0), 0)
+
+  const faqs = [
+    {
+      question: "What is a ChatGPT template?",
+      answer: "A ChatGPT template is a reusable, fill-in-the-blank prompt structure you paste into ChatGPT and customise with your own details. Instead of writing a prompt from scratch each time, you start from a proven pattern that already includes the context, instructions, and format that produce a good result."
+    },
+    {
+      question: "How do I use a ChatGPT template?",
+      answer: "Pick the template that matches your task, copy it, and replace the bracketed placeholders with your specifics (your role, audience, topic, and desired format). Paste the finished prompt into ChatGPT. Because the structure is already there, you get a usable first draft without trial and error."
+    },
+    {
+      question: "Are these ChatGPT templates free?",
+      answer: "Yes. Every ChatGPT template on this page is free to copy and use, with no sign-up required. Browse by profession or use case, copy the one you need, and customise it for your own work."
+    },
+    {
+      question: "What is the difference between a ChatGPT prompt and a ChatGPT template?",
+      answer: "A prompt is the specific instruction you send to ChatGPT for one task. A template is the reusable skeleton behind it: the same structure with placeholders you fill in each time. Templates turn a one-off prompt into something you can reuse across similar tasks, which is why ChatGPT templates save time and keep your results consistent."
+    }
+  ]
+  const faqSchema = generateFAQSchema(faqs)
+
   const itemListSchema = {
     "@context": "https://schema.org",
     "@type": "ItemList",
@@ -21,13 +44,17 @@ export default function ChatGPTPromptTemplates({ modifiers }) {
 
   return (
     <Layout
-      title="100+ ChatGPT Prompt Templates — Free, Copy-Paste Ready (2026)"
-      description="Download and copy free ChatGPT prompt templates for business, writing, coding, marketing, and more. Organised by category with one-click copy."
+      title={`${totalTemplates} Free ChatGPT Prompt Templates, Copy-Paste Ready (2026)`}
+      description="Free ChatGPT prompt templates and ready-to-use ChatGPT templates by profession: business, writing, coding, marketing, and more. Copy-paste ready, organised by category, no sign-up."
     >
       <Head>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
         />
       </Head>
       {/* Hero Section */}
@@ -38,7 +65,7 @@ export default function ChatGPTPromptTemplates({ modifiers }) {
               Free ChatGPT Prompt Templates
             </h1>
             <p className="text-xl mb-8">
-              100+ free, copy-paste ChatGPT prompt templates organised by profession and use case. Based on OpenAI best practices — tested for business, writing, coding, marketing, and more.
+              {totalTemplates} free, copy-paste ChatGPT prompt templates organised by profession and use case, based on OpenAI best practices and tested for business, writing, coding, marketing, and more.
             </p>
             <div className="flex flex-wrap justify-center gap-4">
               <a href="#prompt-categories" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-3 rounded-lg font-bold hover:bg-[#E5C84F] transition-colors duration-200 inline-block">
@@ -129,6 +156,21 @@ export default function ChatGPTPromptTemplates({ modifiers }) {
         </div>
       </section>
       
+      {/* ChatGPT templates (bare-variant) Section */}
+      <section className="py-12 md:py-16 bg-white">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-3xl font-bold mb-6">ChatGPT templates by profession</h2>
+            <p className="text-lg text-gray-700 mb-4">
+              Looking for ready-made ChatGPT templates rather than a blank chat box? Every category below is a set of ChatGPT templates built for a specific job: a fixed structure you paste into a chat, fill in with your own details, and reuse. They are the same thing as prompt templates, framed for how people actually search, so you can grab a proven starting point instead of writing one from scratch.
+            </p>
+            <p className="text-lg text-gray-700">
+              Pick your profession or task, open the category, and copy the ChatGPT templates you need. All {totalTemplates} are free and require no sign-up.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* Categories Section */}
       <section id="prompt-categories" className="py-16 md:py-24 bg-gray-50">
         <div className="container mx-auto px-4 md:px-6">
@@ -288,6 +330,23 @@ export default function ChatGPTPromptTemplates({ modifiers }) {
         </div>
       </section>
       
+      {/* FAQ Section */}
+      <section className="py-16 md:py-24 bg-white">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-3xl font-bold mb-12 text-center">Frequently asked questions about ChatGPT templates</h2>
+            <div className="space-y-8">
+              {faqs.map((faq, i) => (
+                <div key={i}>
+                  <h3 className="text-xl font-bold mb-2 text-gray-800">{faq.question}</h3>
+                  <p className="text-gray-700">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* CTA Section */}
       <section className="py-16 md:py-24 gradient-bg text-white">
         <div className="container mx-auto px-4 md:px-6">

--- a/pages/index.js
+++ b/pages/index.js
@@ -226,8 +226,10 @@ export default function Home() {
               Ready to write better prompts that actually work?
             </h2>
             <p className="text-lg text-[#333333] mb-8">
-              The free guides and tools on this site walk you through proven prompt patterns and workflows
-              — applied to real email, content, and business tasks.
+              The free guides and tools on this site walk you through proven prompt patterns and workflows,
+              applied to real email, content, and business tasks. Start from our{' '}
+              <Link href="/chatgpt-prompt-templates" className="text-blue-600 hover:text-blue-700 underline font-medium">free ChatGPT prompt templates</Link>{' '}
+              or build your own below.
             </p>
             <Link
               href="/ai-prompt-generator"


### PR DESCRIPTION
Implements **PRD-2: /chatgpt-prompt-templates striking-distance push** (`~/.claude/handoff/sprint-content-gap-2026-07-16/pws-PRD-2-prompt-templates-hub-striking-distance.md`).

> **Stacked PR.** Base is `content-gap/pws-1-model-freshness` (PRD-1), not `main`. Merge PRD-1 first. GitHub will retarget this to `main` automatically once PRD-1 lands.

Compounds the site's only earning page (42% of all clicks, pos 15-19). Adds head-on coverage of the stranded bare-variant query cluster ("chatgpt templates / chat gpt templates", ~265 impr at pos 47-56), an accurate template count, an FAQ block with schema, and internal links from the two highest-impression non-linking surfaces.

## What changed
- **Accurate count.** Title/hero now compute the real total from the modifier data at build time: **117** templates across 21 categories (the PRD's estimate of 137 did not match the data; per the open-question instruction I used the real count and did not round up). Replaces the vague "100+".
- **Bare-variant section.** New H2 **"ChatGPT templates by profession"** plus two sentences that use the bare phrasing naturally and frame the categories as reusable templates, placed directly above the existing modifier grid. The grid, its links, and the ItemList schema are untouched.
- **FAQ + schema.** 4 Q&As (what a ChatGPT template is, how to use one, are they free, template vs prompt) rendered on-page and wired into `generateFAQSchema` from `lib/schemaGenerator`, emitting a second `FAQPage` JSON-LD block alongside the existing `ItemList`.
- **Internal links.** Contextual links to `/chatgpt-prompt-templates` added from `ai-prompt-examples.js` (633 impr/90d) and `index.js` (the final prompt CTA), both fitting existing section copy rather than bolted-on markup.

## Critic amendments addressed
- **H2/grep casing agreement:** standardized the bare variant to lowercase **"ChatGPT templates"** and use that exact string in both the on-page H2 and the DoD grep, so they agree exactly (per the amendment).
- **Em-dash check is not grep-separable from code:** the em-dash check below is backed by both `grep -n '—'` returning 0 rows on the file AND an eyeball of the rendered page. All reader-facing copy I wrote uses no em dashes; the two em dashes that were in the hero and title were removed.

## Definition of Done

| DoD item | Status | Evidence |
|---|---|---|
| `grep -c 'ChatGPT templates'` (bare variant in body, casing agrees with H2) >= 2 | **PASS** | **8** matching lines; reader-facing body incl. H2 `ChatGPT templates by profession`, two body sentences, FAQ heading + answers |
| Title contains verified template count and no em dash | **PASS** | rendered `<title>117 Free ChatGPT Prompt Templates, Copy-Paste Ready (2026)</title>`; `grep -c '—' pages/chatgpt-prompt-templates.js` = **0** (+ eyeballed rendered page) |
| FAQ schema present + valid: one FAQPage JSON-LD alongside the existing ItemList | **PASS** | built HTML: `"@type":"FAQPage"` count 1, `"@type":"ItemList"` count 1; build did not error on either block |
| `grep -l 'chatgpt-prompt-templates' pages/ai-prompt-examples.js pages/index.js` returns both | **PASS** | both files listed; both render `href="/chatgpt-prompt-templates"` (1 each in built HTML) |
| No course-CTA regression | **PASS** | `grep -rn 'courses.becomeawritertoday' <3 files> \| wc -l` = **0** |
| `npm install --no-audit --no-fund && npm run build` exits 0 | **PASS** | build exit **0** |
| Rendered check: hub serves non-empty main content, 0 console errors | **PASS** | `chatgpt-prompt-templates.html` = 368 KB; both JSON-LD blocks present; no build/runtime errors |

## Kept intact
- Existing modifier grid, all 13+ existing internal links, and the `ItemList` schema (built from `getAllModifiers().map`) all still validate.
- No PDF asset, no new modifier JSONs, no course CTAs, no "reply with X" CTAs, no changes to `/chatgpt-prompts-for/*` pages.

## Needs Bryan
- None blocking. Note: template count is now dynamic, so it self-updates if modifier data changes (no future hardcoded-count drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
