### PR TITLE
Cross-link AI Flash Report trackers from API-pricing and model pages

### DIFF
--- a/components/ui/AIFlashReportTrackerNote.js
+++ b/components/ui/AIFlashReportTrackerNote.js
@@ -1,0 +1,17 @@
+// Small cross-promo note for the model pages. AI Flash Report is a sister site
+// in the same portfolio, so these are plain followed links.
+export default function AIFlashReportTrackerNote({ className = '' }) {
+  return (
+    <p className={`text-sm text-gray-600 ${className}`}>
+      Model lineups change often.{' '}
+      <a href="https://aiflashreport.com/" className="text-blue-700 underline hover:text-blue-900">
+        AI Flash Report
+      </a>{' '}
+      tracks new model releases and maintains a{' '}
+      <a href="https://aiflashreport.com/deprecations/" className="text-blue-700 underline hover:text-blue-900">
+        deprecation calendar
+      </a>{' '}
+      for models being retired.
+    </p>
+  );
+}

--- a/pages/ai-models.js
+++ b/pages/ai-models.js
@@ -5,6 +5,7 @@ import LastVerified from '../components/LastVerified';
 import { AI_MODELS, AI_MODELS_META } from '../lib/ai-models';
 import { generateFAQSchema } from '../lib/schemaGenerator';
 import MarketShareSection from '../components/sections/MarketShareSection';
+import AIFlashReportTrackerNote from '../components/ui/AIFlashReportTrackerNote';
 import marketShareSnapshot from '../data/ai-models-market-share/2026-05.json';
 
 export default function AIModels() {
@@ -658,6 +659,7 @@ export default function AIModels() {
                 </ul>
               </div>
             </div>
+            <AIFlashReportTrackerNote className="mt-6 pt-4 border-t border-gray-100" />
           </div>
 
           <MarketShareSection snapshotData={marketShareSnapshot} />

--- a/pages/ai-models/[slug].js
+++ b/pages/ai-models/[slug].js
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Layout from '../../components/layout/Layout';
 import LastVerified from '../../components/LastVerified';
 import { AI_MODELS, AI_MODELS_META } from '../../lib/ai-models';
+import AIFlashReportTrackerNote from '../../components/ui/AIFlashReportTrackerNote';
 
 const CATEGORY_LABELS = {
   text: 'Text Generation',
@@ -191,6 +192,7 @@ export default function ModelDetail({ model, sameVendor, relatedByCategory, last
           )}
 
           <div className="mt-12 pt-6 border-t border-gray-200">
+            <AIFlashReportTrackerNote className="mb-4" />
             <Link href="/ai-models" className="text-blue-600 hover:underline">
               ← Back to all AI models
             </Link>

--- a/pages/anthropic-api-pricing.js
+++ b/pages/anthropic-api-pricing.js
@@ -186,6 +186,17 @@ export default function AnthropicApiPricing() {
               Rates verified against the Anthropic model overview on {MODELS_META.lastVerified}. Model lineup and
               pricing change often — check the source before forecasting a large budget.
             </p>
+            <p className="text-sm text-[#333333] mt-4 text-center">
+              Prices change.{' '}
+              <a href="https://aiflashreport.com/prices/" className="text-[#1A1A1A] underline font-semibold">
+                AI Flash Report
+              </a>{' '}
+              tracks per-model price history and sends a{' '}
+              <a href="https://aiflashreport.com/changes/" className="text-[#1A1A1A] underline font-semibold">
+                weekly change digest
+              </a>
+              .
+            </p>
           </div>
         </section>
 

--- a/pages/api-pricing.js
+++ b/pages/api-pricing.js
@@ -190,6 +190,17 @@ export default function ApiPricing() {
               </tbody>
             </table>
           </div>
+          <p className="text-sm text-[#333333] mt-4">
+            Prices change.{' '}
+            <a href="https://aiflashreport.com/prices/" className="underline text-[#1A1A1A]">
+              AI Flash Report
+            </a>{' '}
+            tracks per-model price history and sends a{' '}
+            <a href="https://aiflashreport.com/changes/" className="underline text-[#1A1A1A]">
+              weekly change digest
+            </a>
+            .
+          </p>
         </section>
 
         {/* Caching explainer */}


### PR DESCRIPTION
Adds small contextual cross-links to AI Flash Report's tracker surfaces. No banners, no course-CTA changes, no new dependencies.

## What changed

**`pages/api-pricing.js`** — one line under the "Current API Prices" table.

Before (table section ended after the closing `</table></div>`):
```jsx
              </tbody>
            </table>
          </div>
        </section>
```

After:
```jsx
              </tbody>
            </table>
          </div>
          <p className="text-sm text-[#333333] mt-4">
            Prices change.{' '}
            <a href="https://aiflashreport.com/prices/" className="underline text-[#1A1A1A]">AI Flash Report</a>{' '}
            tracks per-model price history and sends a{' '}
            <a href="https://aiflashreport.com/changes/" className="underline text-[#1A1A1A]">weekly change digest</a>.
          </p>
        </section>
```

**`pages/anthropic-api-pricing.js`** — same one-liner (centered, `font-semibold` links per that page's link idiom) directly under the existing "Rates verified against the Anthropic model overview..." footnote of the per-model rate table.

**`pages/ai-models.js` + `pages/ai-models/[slug].js`** — new shared component `components/ui/AIFlashReportTrackerNote.js`:

```jsx
<p className={`text-sm text-gray-600 ${className}`}>
  Model lineups change often.{' '}
  <a href="https://aiflashreport.com/">AI Flash Report</a>{' '}
  tracks new model releases and maintains a{' '}
  <a href="https://aiflashreport.com/deprecations/">deprecation calendar</a>{' '}
  for models being retired.
</p>
```

Placed at the bottom of the Key Insights card on the index page, and above the "Back to all AI models" link on each model detail page. No existing callout component fit (components/ui are calculator-specific), so this is the one new shared component both model pages reuse.

Links are plain followed links (own-portfolio site): no `rel`, no `nofollow`, same-tab.

## Build evidence

- `npm ci && npm run build` — exit 0
- Built output grep counts:
  - `.next/server/pages/api-pricing.html`: `/prices/` x1, `/changes/` x1
  - `.next/server/pages/anthropic-api-pricing.html`: `/prices/` x1, `/changes/` x1
  - `.next/server/pages/ai-models.html`: `https://aiflashreport.com/` x1, `/deprecations/` x1
  - all 13 of 13 `ai-models/*.html` detail pages contain `/deprecations/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
