### PR TITLE
fix(data): re-verify 5 stale AI model entries against live vendor pricing pages

### DIFF
--- a/data/ai-models.json
+++ b/data/ai-models.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "schemaVersion": 1,
-    "lastVerified": "2026-07-17",
+    "lastVerified": "2026-08-21",
     "stalenessThresholdDays": 60,
     "notes": "Multi-vendor AI model facts. Single source of truth for /ai-models, /claude-vs-chatgpt, and any page that quotes pricing or capability claims for non-Claude models. For Claude-only API model IDs and detailed plan data, see data/claude-models.json. This file mirrors top-level facts and adds non-Claude vendors. Update each entry's last_verified_at when you re-check it against the source. Monthly GitHub Actions cron flags entries older than stalenessThresholdDays."
   },
@@ -131,15 +131,15 @@
         "coding",
         "enterprise"
       ],
-      "input_per_million": null,
-      "output_per_million": null,
-      "pricing_label": "Tiered pricing — see openai.com/api/pricing",
+      "input_per_million": 1.25,
+      "output_per_million": 10.0,
+      "pricing_label": "$1.25 / $10 per 1M tokens (input/output)",
       "context_window": 400000,
-      "context_window_label": "Up to 400K tokens",
+      "context_window_label": "400K tokens (272K max input, 128K max output)",
       "released": "2025",
-      "last_verified_at": "2026-05-07",
-      "verification_source": "https://openai.com/api/pricing/",
-      "verification_notes": "OpenAI pricing page blocks automated fetches; tier pricing varies by mode (standard / mini / nano). Confirm at source before quoting per-token cost.",
+      "last_verified_at": "2026-08-21",
+      "verification_source": "https://developers.openai.com/api/docs/models/gpt-5",
+      "verification_notes": "openai.com/api/pricing/ still blocks automated fetches (403). Pricing and context reconfirmed via developers.openai.com/api/docs/models/gpt-5: input $1.25 per 1M tokens, output $10 per 1M tokens, 400,000 token context window, 272,000 max input tokens, 128,000 max output tokens. OpenAI's docs recommend migrating to GPT-5.6, but GPT-5 itself is still live and billable.",
       "description": "OpenAI's current flagship model. Check openai.com for up-to-date capability and pricing details before production use.",
       "features": [
         "OpenAI's current flagship",
@@ -277,8 +277,9 @@
       "context_window_label": "128K tokens",
       "parameters": "70B",
       "released": "2024-12",
-      "last_verified_at": "2026-05-07",
-      "verification_source": "https://www.llama.com/",
+      "last_verified_at": "2026-08-21",
+      "verification_source": "https://developer.meta.com/ai/",
+      "verification_notes": "llama.com now redirects (301) to developer.meta.com/ai/. The homepage lineup shows only Llama 4 and Llama 3 tiles, no dedicated Llama 3.3 card, but the model card at developer.meta.com/ai/docs/model-cards-and-prompt-formats/llama3_3/, sourced from the GitHub MODEL_CARD.md, confirms 70B parameters, 128k context length, and the Llama 3.3 Community License Agreement. Facts unchanged from prior verification.",
       "description": "Meta's open-weight workhorse — the default choice when you need an open model you can host, fine-tune, or air-gap.",
       "features": [
         "Open weights — run on your own hardware",
@@ -304,6 +305,7 @@
       "released": "2025",
       "last_verified_at": "2026-05-07",
       "verification_source": "https://x.ai/api",
+      "verification_notes": "xAI retired the grok-3 API model slug on 2026-05-15 as part of the Grok 4.3 rollout (docs.x.ai/developers/migration/may-15-retirement). Requests to grok-3 now redirect to Grok 4.3. The current model table at docs.x.ai/docs/models lists only grok-4.x variants, no grok-3. Entry left unchanged per PR #59 precedent; current xAI flagship is Grok 4.6.",
       "description": "xAI's flagship. Relevant mainly if you need real-time X data or a less filtered default tone.",
       "features": [
         "Access to real-time X (Twitter) data",
@@ -332,6 +334,7 @@
       "released": "2024-07",
       "last_verified_at": "2026-05-07",
       "verification_source": "https://mistral.ai/pricing",
+      "verification_notes": "mistral.ai/pricing no longer lists Mistral Large 2 in its pricing tables, only a generic Mistral Large FAQ example remains. docs.mistral.ai/getting-started/models/models_overview/ confirms Mistral Large 2.0 is retired and Mistral Large 2.1 was deprecated 2026-02-27 with retirement 2026-05-31, replacement Mistral Medium 3.5. Entry left unchanged per PR #59 precedent; current flagship is Mistral Large 3.",
       "description": "Mistral's flagship. Common pick for EU customers that want non-US-hosted inference for GDPR and sovereignty reasons.",
       "features": [
         "European (France) model — data residency option",
@@ -360,6 +363,7 @@
       "released": "2024-12",
       "last_verified_at": "2026-05-07",
       "verification_source": "https://api-docs.deepseek.com/quick_start/pricing",
+      "verification_notes": "api-docs.deepseek.com/quick_start/pricing now lists only deepseek-v4-flash, deepseek-v4-pro, and deepseek-v4-flash-vision-exp. The deepseek-chat and deepseek-reasoner (V3) model IDs were retired 2026-07-24 15:59 UTC. V3 weights remain accessible via third-party hosts such as OpenRouter but are no longer served by DeepSeek's own API. Entry left unchanged per PR #59 precedent.",
       "description": "DeepSeek's flagship open-weights MoE model. Chosen when price and open weights matter more than vendor reputation.",
       "features": [
         "Open weights",


### PR DESCRIPTION
## Summary

Resolves #68 (5 AI model entries in `data/ai-models.json` flagged stale, all `last_verified_at: 2026-05-07`, 106 days old). Every entry below was re-checked live in this session against its own `verification_source` (or the vendor's current redirect target). No field was changed from model memory or interpolation.

## Before / after evidence table

| Entry | State | Source fetched | Old values | New values | Verbatim quote |
|---|---|---|---|---|---|
| **gpt-5** (OpenAI) | CHANGED | `openai.com/api/pricing/` returned 403 both attempts; live pricing found at `developers.openai.com/api/docs/models/gpt-5` (WebFetch) | `input_per_million: null`, `output_per_million: null`, `pricing_label: "Tiered pricing — see openai.com/api/pricing"` | `input_per_million: 1.25`, `output_per_million: 10.0`, `pricing_label: "$1.25 / $10 per 1M tokens (input/output)"`, context window label refined to "400K tokens (272K max input, 128K max output)" | "$1.25" input / "$10" output; "400,000 context window"; "Maximum input tokens: 272,000"; "128,000 max output tokens" |
| **llama-3-3-70b** (Meta) | UNCHANGED (re-verified) | `llama.com` 301-redirects to `developer.meta.com/ai/`; model card at `developer.meta.com/ai/docs/model-cards-and-prompt-formats/llama3_3/` → GitHub `MODEL_CARD.md` | 70B params, 128K context, open weights | same — no change | "70B" parameters, "128k" context length, "Llama 3.3 Community License Agreement" |
| **grok-3** (xAI) | UNVERIFIABLE | `x.ai/api` returned 403 both attempts; confirmed via xAI's own migration notice `docs.x.ai/developers/migration/may-15-retirement` and current model table `docs.x.ai/docs/models` | unchanged, left as-is | unchanged, left as-is | "xAI retired the grok-3 API model slug on May 15, 2026... requests to grok-3 now redirect to Grok 4.3." Current model table lists only grok-4.x variants. |
| **mistral-large-2** (Mistral AI) | UNVERIFIABLE | `mistral.ai/pricing` fetched directly — Large 2 no longer in pricing tables (only generic "Mistral Large" FAQ line survives); confirmed via `docs.mistral.ai/getting-started/models/models_overview/` | unchanged, left as-is | unchanged, left as-is | "Mistral Large 2.0" is retired; "Mistral Large 2.1 ... 2/27/2026 5/31/2026" (deprecated/retirement dates), replacement Mistral Medium 3.5, current flagship Mistral Large 3 |
| **deepseek-v3** (DeepSeek) | UNVERIFIABLE | `api-docs.deepseek.com/quick_start/pricing` fetched directly — now lists only V4 models | unchanged, left as-is | unchanged, left as-is | Page lists "deepseek-v4-flash, deepseek-v4-pro, deepseek-v4-flash-vision-exp" only. deepseek-chat/deepseek-reasoner (V3) IDs retired 2026-07-24 15:59 UTC (corroborated by WebSearch of DeepSeek's own changelog coverage). |

For the 3 UNVERIFIABLE entries, `last_verified_at` stays at the old `2026-05-07` and every numeric/capability field is untouched, per house precedent from PR #59 (gpt-4o handling). Each entry's `verification_notes` was appended (not overwritten) explaining what the source now shows and citing the specific retirement/replacement.

`_meta.lastVerified` bumped to `2026-08-21` since 2 of the 5 entries (gpt-5, llama-3-3-70b) were actually re-verified against live data.

## Scope

- Touched: `data/ai-models.json` only (1 file, under the 3-file cap).
- Did not touch `data/api-pricing.json`, `data/subscription-pricing.json`, `data/claude-models.json`, or any calculator/component code — that surface belongs to PR #59 (`fix/pricing-truth-v2`), untouched here.
- Did not re-verify the 8 non-stale entries (`last_verified_at: 2026-07-17`) — out of scope, no churn on them.
- No new model entries, no schema changes, no id renames. Confirmed `gpt-5` id is referenced by `lib.getAIModelById('gpt-5')` in `pages/claude-vs-chatgpt.js` — kept stable.

## Verification

- `npm test` — 13 suites, 144 tests passed, 0 failed. No snapshot depends on `data/ai-models.json`.
- `npm run build` — exited 0, all pages built including `/ai-models` and `/ai-models/[slug]`.

## Pre-ship depth critic verdict

**DEPTH: ADEQUATE**

Root problem (verify data is *accurate*, not just recently timestamped) was genuinely addressed: 2 real vendor redirects/403s were followed correctly, and 3 undocumented model retirements were discovered with live URLs cited in `verification_notes` (grok-3 retired 2026-05-15, mistral-large-2 deprecated/retiring, deepseek-v3 API IDs retired 2026-07-24). All 9 named spec checkpoints passed (re-verification sourcing, untouched-on-404 handling, redirect recording, correct `last_verified_at` bumps, scoped `_meta.lastVerified` bump, 1-file scope, non-stale entries untouched, no em/en-dashes in new prose, `pricing_label` consistency).

Two deeper issues flagged by the critic, both explicitly out of this PR's scope but worth a ratification note:

1. The `description` field on the 3 retired-model entries (grok-3, mistral-large-2, deepseek-v3) still reads "flagship" even though the same entries' new `verification_notes` say the current flagship is Grok 4.6 / Mistral Large 3 / DeepSeek V4 respectively. Rule 2 (house precedent from PR #59) says leave facts untouched on an UNVERIFIABLE entry, so `description` was left alone by design — but `pages/ai-models/[slug].js` renders `description` directly into the page H1/meta description, so visitors see stale "flagship" language. Worth a follow-up ticket to decide whether "UNVERIFIABLE" entries should get a standard "model retired, see notes" description treatment.
2. `scripts/observatory/_lib/pricing.py` has a docstring saying it should stay in sync with `data/ai-models.json`, but its `PRICE_TABLE` has no `gpt-5` key even though this PR gives gpt-5 its first real (non-null) pricing. Pre-existing drift, not introduced here, but now checkable — flagging for a separate PR.

## NEEDS-BRYAN: ratify prices at morning review

- Confirm the GPT-5 pricing found ($1.25 / $10 per 1M) is the rate you want quoted, given OpenAI's docs push GPT-5.6 as the recommended successor.
- Decide whether to file follow-up issues for the two critic findings above (stale "flagship" copy on retired entries; `pricing.py` drift), or fold them into the next data sweep.
- No merge action needed from this PR alone — review and merge (or request changes) at your convenience. Not merged by this session per instructions.

Closes #68
