### PR TITLE
SEO: fix playlist data, embed 7 videos, rewrite 3 pages in practitioner voice

### DIFF
--- a/components/ui/OrganizationSchema.js
+++ b/components/ui/OrganizationSchema.js
@@ -21,7 +21,7 @@ export default function OrganizationSchema() {
       "image": "https://promptwritingstudio.com/images/bryan-collins.jpg"
     },
     "sameAs": [
-      "https://www.youtube.com/@BryanCollinsWriter",
+      "https://www.youtube.com/channel/UCglNILz3uBqPer5EMJ_pzVg",
       "https://twitter.com/bryanjcollins",
       "https://www.linkedin.com/in/bryanjcollins/"
     ],

--- a/components/ui/VideoEmbed.js
+++ b/components/ui/VideoEmbed.js
@@ -1,0 +1,129 @@
+import Head from 'next/head'
+
+/**
+ * Single-video companion to YouTubeVideoSection (which handles playlists).
+ *
+ * Metadata below is taken from the YouTube Data API for the Become A Writer
+ * Today channel (UCglNILz3uBqPer5EMJ_pzVg), verified 2026-08-21. Titles,
+ * publish dates and durations are the real values, so the VideoObject schema
+ * this component emits matches what Google sees on YouTube.
+ *
+ * Only public videos are listed here. Do not add a video id until it is public.
+ */
+export const VIDEO_META = {
+  TGy3DLIC9Gw: {
+    title: 'I Used Claude Code on my Zettelkasten!',
+    description:
+      'A field report on connecting Claude Code to a 7,000+ note Zettelkasten and building three AI analyzers that draft a week of content in about two minutes.',
+    uploadDate: '2026-01-31',
+    duration: 'PT11M44S'
+  },
+  yRMCSueiMTU: {
+    title: 'Why I Switched from VS Code to Cursor AI',
+    description:
+      'Why I moved my day-to-day editing from VS Code to Cursor for vibe coding projects, and what actually changed in the workflow.',
+    uploadDate: '2025-09-05',
+    duration: 'PT9M3S'
+  },
+  GRylWQKlN8U: {
+    title: 'How to Train Claude AI to Write like You',
+    description:
+      'A step-by-step walkthrough of Claude Projects: loading your own writing as context, comparing Projects to ChatGPT custom bots, and using them in a content business.',
+    uploadDate: '2024-10-03',
+    duration: 'PT10M22S'
+  },
+  'd-EXvNDabmA': {
+    title: "Claude vs ChatGPT: What's Best For Content Creation?",
+    description:
+      'A side-by-side test of Claude and ChatGPT on real content work, with a clear call on when to reach for each one.',
+    uploadDate: '2024-12-09',
+    duration: 'PT12M10S'
+  },
+  IgqmJQk3O6U: {
+    title: 'Claude Tutorial: The AI Tool Creators Needs',
+    description:
+      'Setting up Claude from scratch: account setup, customising preferences, and building project templates for repeatable content work.',
+    uploadDate: '2025-04-09',
+    duration: 'PT16M17S'
+  },
+  cHkBSjLR4Yk: {
+    title: 'How I Write Rules for Cursor AI',
+    description:
+      'How I write project rules for Cursor AI, the same idea a CLAUDE.md file serves in Claude Code.',
+    uploadDate: '2025-07-05',
+    duration: 'PT5M5S'
+  },
+  yGs7WVcozbQ: {
+    title: 'How to Build a Website With Cursor AI',
+    description:
+      'A short walkthrough of building a website with Cursor AI, prompt first.',
+    uploadDate: '2026-02-05',
+    duration: 'PT1M7S'
+  }
+}
+
+export default function VideoEmbed({
+  videoId,
+  heading,
+  context,
+  className = ''
+}) {
+  const meta = VIDEO_META[videoId]
+
+  if (!meta) return null
+
+  const videoSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'VideoObject',
+    name: meta.title,
+    description: meta.description,
+    thumbnailUrl: [`https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`],
+    uploadDate: meta.uploadDate,
+    duration: meta.duration,
+    contentUrl: `https://www.youtube.com/watch?v=${videoId}`,
+    embedUrl: `https://www.youtube.com/embed/${videoId}`,
+    publisher: {
+      '@type': 'Organization',
+      name: 'PromptWritingStudio',
+      url: 'https://promptwritingstudio.com'
+    },
+    creator: {
+      '@type': 'Person',
+      name: 'Bryan Collins',
+      url: 'https://www.youtube.com/@BryanCollinsWriter'
+    }
+  }
+
+  return (
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(videoSchema) }}
+        />
+      </Head>
+
+      <div className={`bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden ${className}`}>
+        <div className="aspect-video bg-black">
+          <iframe
+            width="100%"
+            height="100%"
+            src={`https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1`}
+            title={meta.title}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            loading="lazy"
+          ></iframe>
+        </div>
+        <div className="p-5 md:p-6">
+          <p className="text-sm font-bold text-[#FFB800] uppercase tracking-wide mb-2">
+            {heading || 'Watch me do this'}
+          </p>
+          <h3 className="text-lg md:text-xl font-bold text-[#1A1A1A] mb-2">{meta.title}</h3>
+          <p className="text-[#333333]">{context || meta.description}</p>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/components/ui/VideoEmbed.js
+++ b/components/ui/VideoEmbed.js
@@ -4,7 +4,9 @@ import Head from 'next/head'
  * Single-video companion to YouTubeVideoSection (which handles playlists).
  *
  * Metadata below is taken from the YouTube Data API for the Become A Writer
- * Today channel (UCglNILz3uBqPer5EMJ_pzVg), verified 2026-08-21. Titles,
+ * Today channel (UCglNILz3uBqPer5EMJ_pzVg), verified live against videos.list on 2026-08-21.
+ * Titles change: yRMCSueiMTU was retitled 2026-08-19 and a cached dump missed it.
+ * Re-pull from the API rather than trusting data/dump-*.json. Titles,
  * publish dates and durations are the real values, so the VideoObject schema
  * this component emits matches what Google sees on YouTube.
  *
@@ -19,7 +21,7 @@ export const VIDEO_META = {
     duration: 'PT11M44S'
   },
   yRMCSueiMTU: {
-    title: 'Why I Switched from VS Code to Cursor AI',
+    title: 'Cursor vs VS Code: Why I Switched (Honest Comparison)',
     description:
       'Why I moved my day-to-day editing from VS Code to Cursor for vibe coding projects, and what actually changed in the workflow.',
     uploadDate: '2025-09-05',
@@ -53,6 +55,13 @@ export const VIDEO_META = {
     uploadDate: '2025-07-05',
     duration: 'PT5M5S'
   },
+  '1xufb9h1Tjw': {
+    title: 'How to Connect Cursor to GitHub (Beginner Tutorial)',
+    description:
+      'Pushing a Cursor project to GitHub end to end: creating the repository, the first push, writing the deployment workflow into a file, and registering it as an Agent Requested Cursor Rule.',
+    uploadDate: '2025-07-07',
+    duration: 'PT4M45S'
+  },
   yGs7WVcozbQ: {
     title: 'How to Build a Website With Cursor AI',
     description:
@@ -70,7 +79,31 @@ export default function VideoEmbed({
 }) {
   const meta = VIDEO_META[videoId]
 
-  if (!meta) return null
+  // A missing entry used to render nothing at all, which meant a typo'd or
+  // unregistered id removed the embed from the page with no trace anywhere.
+  // Now it shouts, and still renders the video: only the schema is dropped,
+  // because schema built from guessed metadata is worse than no schema.
+  if (!meta) {
+    console.error(
+      `[VideoEmbed] No VIDEO_META entry for "${videoId}". Rendering the iframe without VideoObject schema. Add the video to VIDEO_META in components/ui/VideoEmbed.js.`
+    )
+    return (
+      <div className={`bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden ${className}`}>
+        <div className="aspect-video bg-black">
+          <iframe
+            width="100%"
+            height="100%"
+            src={`https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1`}
+            title={heading || 'Video'}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            loading="lazy"
+          ></iframe>
+        </div>
+      </div>
+    )
+  }
 
   const videoSchema = {
     '@context': 'https://schema.org',
@@ -90,7 +123,7 @@ export default function VideoEmbed({
     creator: {
       '@type': 'Person',
       name: 'Bryan Collins',
-      url: 'https://www.youtube.com/@BryanCollinsWriter'
+      url: 'https://www.youtube.com/channel/UCglNILz3uBqPer5EMJ_pzVg'
     }
   }
 

--- a/components/ui/YouTubeVideoSection.js
+++ b/components/ui/YouTubeVideoSection.js
@@ -32,7 +32,7 @@ export default function YouTubeVideoSection({
     "creator": {
       "@type": "Person",
       "name": "Bryan Collins",
-      "url": "https://www.youtube.com/@BryanCollinsWriter"
+      "url": "https://www.youtube.com/channel/UCglNILz3uBqPer5EMJ_pzVg"
     },
     "genre": category,
     "keywords": keywords

--- a/components/ui/YouTubeVideoSection.js
+++ b/components/ui/YouTubeVideoSection.js
@@ -6,19 +6,23 @@ export default function YouTubeVideoSection({
   playlistId,
   playlistTitle,
   videoCount = 0,
-  category = "AI Education"
+  category = "AI Education",
+  itemBlurb,
+  keywords = "AI prompts, ChatGPT, Claude, Gemini, prompt engineering, AI writing, content creation"
 }) {
-  
-  // Video schema for the playlist
+
+  // Video schema for the playlist.
+  // Counts and ids are the live, public-visible values from the YouTube Data API
+  // for channel UCglNILz3uBqPer5EMJ_pzVg. Do not invent thumbnails, durations or
+  // view counts here: a playlist id is not a video id, so img.youtube.com/vi/<playlistId>
+  // does not resolve, and fabricated interaction counts are a structured-data violation.
   const videoSchema = {
     "@context": "https://schema.org",
     "@type": "VideoPlaylist",
     "name": playlistTitle,
-    "description": `${description} - Complete tutorial series with ${videoCount} videos`,
+    "description": `${description} Currently ${videoCount} public videos.`,
     "url": `https://www.youtube.com/playlist?list=${playlistId}`,
-    "thumbnailUrl": `https://img.youtube.com/vi/${playlistId}/maxresdefault.jpg`,
-    "uploadDate": "2024-01-01",
-    "duration": "PT60M",
+    "numberOfItems": videoCount,
     "embedUrl": `https://www.youtube.com/embed/videoseries?list=${playlistId}`,
     "publisher": {
       "@type": "Organization",
@@ -30,13 +34,8 @@ export default function YouTubeVideoSection({
       "name": "Bryan Collins",
       "url": "https://www.youtube.com/@BryanCollinsWriter"
     },
-    "interactionStatistic": {
-      "@type": "InteractionCounter",
-      "interactionType": "https://schema.org/WatchAction",
-      "userInteractionCount": 1000
-    },
     "genre": category,
-    "keywords": "AI prompts, ChatGPT, Claude, Gemini, prompt engineering, AI writing, content creation"
+    "keywords": keywords
   }
 
   return (
@@ -81,11 +80,11 @@ export default function YouTubeVideoSection({
                   {playlistTitle}
                 </h3>
                 <p className="text-gray-600 mb-3">
-                  Complete tutorial series with {videoCount} videos covering everything you need to know about AI prompt writing.
+                  {itemBlurb || `A running series of ${videoCount} videos, updated as new ones publish.`}
                 </p>
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-gray-500">
-                    📺 {videoCount} videos • ⏱️ 60+ minutes
+                    {videoCount} {videoCount === 1 ? 'video' : 'videos'}
                   </span>
                   <a
                     href={`https://www.youtube.com/playlist?list=${playlistId}`}

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -58,6 +58,7 @@ const STATIC_ROUTES = [
   { url: '/claude-code-pricing', priority: '0.8', changefreq: 'monthly' },
   { url: '/claude-code-alternatives', priority: '0.8', changefreq: 'monthly' },
   { url: '/claude-code-vs-cursor', priority: '0.8', changefreq: 'monthly' },
+  { url: '/connect-cursor-to-github', priority: '0.8', changefreq: 'monthly' },
   { url: '/claude-md-playbook', priority: '0.85', changefreq: 'monthly' },
   { url: '/claude-pro-vs-max-vs-api', priority: '0.85', changefreq: 'monthly' },
   { url: '/claude-artifacts', priority: '0.8', changefreq: 'monthly' },

--- a/pages/claude-code-review.js
+++ b/pages/claude-code-review.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Layout from '../components/layout/Layout'
+import VideoEmbed from '../components/ui/VideoEmbed'
 import { generateFAQSchema, generateArticleSchema, generateRatingSchema } from '../lib/schemaGenerator'
 
 const GRADER_URL = '/prompt-grader'
@@ -274,6 +275,14 @@ export default function ClaudeCodeReview() {
                   <p className="text-lg text-[#333333]">{r.text}</p>
                 </div>
               ))}
+            </div>
+
+            <div className="mt-10">
+              <VideoEmbed
+                videoId="TGy3DLIC9Gw"
+                heading="Claude Code on a real project"
+                context="Rather than ask you to take the scores on trust, here is a full run on a project of mine: pointing Claude Code at a 7,000 note Zettelkasten and building three analyzers on top of it, including what it costs to run. A field report rather than a feature tour."
+              />
             </div>
           </div>
         </section>

--- a/pages/claude-code-skills/index.js
+++ b/pages/claude-code-skills/index.js
@@ -197,9 +197,8 @@ export default function ClaudeCodeSkillsHub() {
             <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
               <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
               <p className="text-lg text-[#1A1A1A] leading-relaxed mb-4">
-                A skill is worth writing when you have typed the same long instruction into Claude Code for the third time. Not before. Building one earlier than that mostly wastes the effort, because you are automating a workflow you have not settled on yet.
+                A useful rule of thumb: a skill is worth writing once you have typed the same long instruction into Claude Code enough times to be sure of its shape. Building one earlier mostly wastes the effort, because you are automating a workflow you have not settled on yet.
               </p>
-              {/* VERIFY: Bryan to confirm the "third time" threshold matches how he actually decides, or replace with his own rule. */}
               <p className="text-lg text-[#1A1A1A] leading-relaxed">
                 On licensing: the biggest community list, <strong>awesome-claude-code</strong>, is CC&nbsp;BY-NC-ND. You can link to it but cannot republish entries. This directory is the opposite. Every skill comes from a repo with an <strong>MIT, Apache-2.0, BSD, CC0, or Unlicense</strong> licence, so you can copy, fork and adapt without a legal argument. Start with the <strong>High-signal</strong> tier.
               </p>
@@ -234,9 +233,8 @@ export default function ClaudeCodeSkillsHub() {
             <div className="mt-8 bg-[#1A1A1A] p-6 rounded-lg">
               <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-2">The pattern underneath them</p>
               <p className="text-gray-200 leading-relaxed">
-                Look at the six and they fall into two shapes. Four of them gather state from several places at once and hand back a decision: which project needs attention, what failed the audit, what has drifted, what is missing. Two of them just execute a boring sequence I would otherwise do by hand. Both shapes work. What does not work is a skill that tries to be clever about a judgement call, because when it gets that call wrong you have to reconstruct its reasoning before you can correct it, and that costs more than doing the thing yourself.
+                Look at the six and they fall into two shapes. Four of them gather state from several places at once and hand back a decision: which project needs attention, what failed the audit, what has drifted, what is missing. Two of them just execute a boring sequence I would otherwise do by hand. Both shapes work. The shape to be wary of is a skill that tries to be clever about a judgement call: when it gets that call wrong you have to reconstruct its reasoning before you can correct it, which can cost more than doing the thing yourself.
               </p>
-              {/* VERIFY: Bryan to confirm the failed-skill claim in the last sentence reflects a real experience, or cut it. */}
             </div>
           </div>
         </section>

--- a/pages/claude-code-skills/index.js
+++ b/pages/claude-code-skills/index.js
@@ -37,6 +37,47 @@ const faqs = [
   }
 ]
 
+// The skills Bryan runs himself. Every slug below must exist in
+// data/claude-code-skills.json, because each card links to its catalogue page.
+const dailyDrivers = [
+  {
+    slug: 'site-picker',
+    name: 'Site Picker',
+    command: '/projects',
+    why: 'A portfolio of sites means a portfolio of context I cannot hold in my head. This prints the list, loads the memory file for whichever one I pick, and runs the git and gh checks in parallel, so the session opens with the outstanding work already on screen instead of me going to find it.'
+  },
+  {
+    slug: 'commit-helper',
+    name: 'Commit Helper',
+    command: '/commit',
+    why: 'Stage the relevant changes, write a conventional-commit message, push. Trivial to do by hand, which is exactly why it earned a skill: the friction was never difficulty, it was repetition.'
+  },
+  {
+    slug: 'qa-swarm',
+    name: 'QA Swarm',
+    command: '/qa',
+    why: 'Fans three to five subagents at the current project, each auditing a different dimension, then synthesises one report. The parallelism is the whole point. Run the same audit sequentially and it is slow enough that I skip it, which means it never runs.'
+  },
+  {
+    slug: 'deploy-netlify',
+    name: 'Deploy to Netlify',
+    command: '/deploy',
+    why: 'Build, preview, then push to main and let Netlify auto-deploy. No Netlify CLI in the loop. The preview step is the part that justifies the skill, because it is the step a human under time pressure drops first.'
+  },
+  {
+    slug: 'drift-check',
+    name: 'Drift Check',
+    command: '/drift-check',
+    why: 'Verifies reference data (model names, prices, dependency versions) against upstream and flags what has gone stale. This site carries several AI pricing pages, and a pricing table that is quietly six months out of date does more damage than no table at all.'
+  },
+  {
+    slug: 'legal-sweep',
+    name: 'Legal Sweep',
+    command: '/legal-sweep',
+    why: 'Audits a site for a legal disclaimer page and a footer link, then creates and wires one up if it is missing. Dull, easy to forget when you run more than one site, and genuinely unpleasant to discover you forgot.'
+  }
+]
+
 const LICENCE_LABELS = {
   'MIT': { color: 'green', label: 'MIT' },
   'Apache-2.0': { color: 'green', label: 'Apache-2.0' },
@@ -124,8 +165,8 @@ export default function ClaudeCodeSkillsHub() {
   return (
     <>
       <Head>
-        <title>Claude Code Skills Catalogue — {stats.total} Licence-Safe Skills & Subagents | PromptWritingStudio</title>
-        <meta name="description" content={`${stats.total} Claude Code skills, subagents, and slash commands — every entry from a repo with MIT, Apache-2.0, BSD, or CC0 licence. Safe to copy, fork, and ship.`} />
+        <title>Claude Code Skills: The 6 I Actually Run, Plus {stats.total} You Can Copy | PromptWritingStudio</title>
+        <meta name="description" content={`The six Claude Code skills that survived daily use on my own sites, with why each one stuck, plus a catalogue of ${stats.total} more from MIT, Apache-2.0, BSD and CC0 repos you can copy without a licensing argument.`} />
         <link rel="canonical" href="https://promptwritingstudio.com/claude-code-skills" />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionSchema) }} />
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
@@ -136,10 +177,10 @@ export default function ClaudeCodeSkillsHub() {
           <div className="container mx-auto px-4 md:px-6 text-center max-w-4xl">
             <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-3">Claude Code · Skills Catalogue</p>
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
-              Claude Code Skills — the Licence-Safe Directory
+              Claude Code Skills: the ones I actually run, plus {stats.total} you can copy
             </h1>
             <p className="text-xl text-gray-200 max-w-3xl mx-auto">
-              {stats.total} skills, subagents, and slash commands from {stats.repoCount} repos with explicit permissive licences. Every entry is safe to copy into your <code className="bg-black/30 px-1.5 py-0.5 rounded text-sm">.claude/</code> directory.
+              I write skills for my own sites. Plenty get renamed, folded into another skill, or quietly retired once the workflow they automated stops existing. The ones below survived that and still fire most weeks, with the reason each one stuck. Under them sits the full catalogue: {stats.total} skills, subagents and slash commands from {stats.repoCount} repos with explicit permissive licences, so you can copy any of them into your <code className="bg-black/30 px-1.5 py-0.5 rounded text-sm">.claude/</code> directory without a licensing argument.
             </p>
             <div className="mt-6">
               <LastVerified
@@ -155,9 +196,47 @@ export default function ClaudeCodeSkillsHub() {
           <div className="container mx-auto px-4 md:px-6 max-w-3xl">
             <div className="bg-white rounded-lg border-l-4 border-[#FFDE59] p-6 md:p-8 shadow-sm">
               <h2 className="text-sm font-semibold text-[#1A1A1A] uppercase tracking-wide mb-2">The short answer</h2>
-              <p className="text-lg text-[#1A1A1A] leading-relaxed">
-                The biggest community list — <strong>awesome-claude-code</strong> — is CC&nbsp;BY-NC-ND. You can link to it but cannot republish entries. This directory is the opposite: every skill comes from a repo with an <strong>MIT, Apache-2.0, BSD, CC0, or Unlicense</strong> licence. Copy, fork, adapt — no legal friction. Start with the <strong>High-signal</strong> tier; those earn their keep daily.
+              <p className="text-lg text-[#1A1A1A] leading-relaxed mb-4">
+                A skill is worth writing when you have typed the same long instruction into Claude Code for the third time. Not before. Building one earlier than that mostly wastes the effort, because you are automating a workflow you have not settled on yet.
               </p>
+              {/* VERIFY: Bryan to confirm the "third time" threshold matches how he actually decides, or replace with his own rule. */}
+              <p className="text-lg text-[#1A1A1A] leading-relaxed">
+                On licensing: the biggest community list, <strong>awesome-claude-code</strong>, is CC&nbsp;BY-NC-ND. You can link to it but cannot republish entries. This directory is the opposite. Every skill comes from a repo with an <strong>MIT, Apache-2.0, BSD, CC0, or Unlicense</strong> licence, so you can copy, fork and adapt without a legal argument. Start with the <strong>High-signal</strong> tier.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* The skills I actually run */}
+        <section className="py-14 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl font-bold text-[#1A1A1A] mb-3">The six I actually run</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              I maintain a portfolio of sites, so most of my skills exist to stop me doing the same twenty minutes of chores on each one. These are the six that fire most weeks. Each links through to its full page in the catalogue.
+            </p>
+
+            <div className="space-y-4">
+              {dailyDrivers.map(skill => (
+                <Link
+                  key={skill.slug}
+                  href={`/claude-code-skills/${skill.slug}`}
+                  className="block bg-[#F9F9F9] border-l-4 border-[#FFDE59] rounded-r-lg p-6 hover:bg-[#FFDE59]/10 transition"
+                >
+                  <div className="flex flex-wrap items-baseline gap-3 mb-2">
+                    <h3 className="text-lg font-bold text-[#1A1A1A]">{skill.name}</h3>
+                    <code className="text-sm font-mono bg-[#1A1A1A] text-[#FFDE59] px-2 py-0.5 rounded">{skill.command}</code>
+                  </div>
+                  <p className="text-[#333333]">{skill.why}</p>
+                </Link>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-[#1A1A1A] p-6 rounded-lg">
+              <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-2">The pattern underneath them</p>
+              <p className="text-gray-200 leading-relaxed">
+                Look at the six and they fall into two shapes. Four of them gather state from several places at once and hand back a decision: which project needs attention, what failed the audit, what has drifted, what is missing. Two of them just execute a boring sequence I would otherwise do by hand. Both shapes work. What does not work is a skill that tries to be clever about a judgement call, because when it gets that call wrong you have to reconstruct its reasoning before you can correct it, and that costs more than doing the thing yourself.
+              </p>
+              {/* VERIFY: Bryan to confirm the failed-skill claim in the last sentence reflects a real experience, or cut it. */}
             </div>
           </div>
         </section>

--- a/pages/claude-code-vs-cursor.js
+++ b/pages/claude-code-vs-cursor.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Layout from '../components/layout/Layout'
+import VideoEmbed from '../components/ui/VideoEmbed'
 import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
 
 const faqs = [
@@ -156,12 +157,12 @@ export default function ClaudeCodeVsCursor() {
 
             <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
               <p className="text-lg leading-relaxed text-gray-100">
-                Claude Code is Anthropic's terminal-first agentic coding CLI. Cursor is a VS Code-forked IDE with AI woven into the UI. They overlap but they are not the same tool. Short answer: Cursor wins on interactive coding with inline suggestions; Claude Code wins on multi-file refactors, git workflows, hooks, and sub-agents. Most serious developers end up using both, with a clear split of duties.
+                I switched from VS Code to Cursor in 2025 and filmed the reasons at the time. Later I added Claude Code, expecting one of the two to lose. Neither did. The work split instead: Cursor kept the typing and the visual diff review, Claude Code took the terminal, the multi-file changes and the git. This site is maintained day to day with Claude Code doing that half of the work.
               </p>
             </div>
 
             <p className="text-xl md:text-2xl text-white mb-8 max-w-4xl mx-auto">
-              This is the comparison and the 30-day plan I followed. It will not tell you Claude Code is strictly better. It will tell you how to figure out honestly which one fits your work.
+              So this is not a scorecard telling you Claude Code wins. It is the division of labour I landed on, the 30-day plan that got me there, and the pitfalls that make people abandon the switch in week one.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
               <a href="#comparison" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
@@ -282,6 +283,14 @@ export default function ClaudeCodeVsCursor() {
               <p className="text-lg text-[#333333]">
                 Neither tool replaces the other. They make each other better.
               </p>
+            </div>
+
+            <div className="mt-10">
+              <VideoEmbed
+                videoId="yRMCSueiMTU"
+                heading="The switch, on camera"
+                context="Before Claude Code entered the picture I moved off VS Code and onto Cursor, and recorded why at the time. Worth watching if the move you are weighing is an editor swap rather than a jump to the terminal."
+              />
             </div>
           </div>
         </section>

--- a/pages/claude-code-vs-cursor.js
+++ b/pages/claude-code-vs-cursor.js
@@ -157,7 +157,7 @@ export default function ClaudeCodeVsCursor() {
 
             <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
               <p className="text-lg leading-relaxed text-gray-100">
-                I switched from VS Code to Cursor in 2025 and filmed the reasons at the time. Later I added Claude Code, expecting one of the two to lose. Neither did. The work split instead: Cursor kept the typing and the visual diff review, Claude Code took the terminal, the multi-file changes and the git. This site is maintained day to day with Claude Code doing that half of the work.
+                I filmed my move from VS Code to Cursor in 2025, and I have been writing rules files for Cursor since before that. When Claude Code arrived I expected one of the two to lose. Neither did. The work split instead: Cursor kept the typing and the visual diff review, Claude Code took the terminal, the multi-file changes and the git. This site is maintained day to day with Claude Code doing that half of the work.
               </p>
             </div>
 
@@ -291,6 +291,7 @@ export default function ClaudeCodeVsCursor() {
                 heading="The switch, on camera"
                 context="Before Claude Code entered the picture I moved off VS Code and onto Cursor, and recorded why at the time. Worth watching if the move you are weighing is an editor swap rather than a jump to the terminal."
               />
+              {/* VERIFY: Bryan to confirm the adoption order in the hero (Cursor first, Claude Code later). It is inferred from video publish dates, not stated anywhere. */}
             </div>
           </div>
         </section>

--- a/pages/claude-code-vs-cursor.js
+++ b/pages/claude-code-vs-cursor.js
@@ -199,6 +199,7 @@ export default function ClaudeCodeVsCursor() {
               </div>
             </div>
             <p className="text-center text-[#666666] mt-8">The answer for most developers with real projects: both. Use each where it is strongest.</p>
+            <p className="text-center text-[#666666] mt-4">Staying on Cursor for now? Wire it to your repo first: <Link href="/connect-cursor-to-github" className="text-[#1A1A1A] underline font-semibold hover:no-underline">how to connect Cursor to GitHub</Link>.</p>
           </div>
         </section>
 

--- a/pages/claude-code-vs-cursor.js
+++ b/pages/claude-code-vs-cursor.js
@@ -292,7 +292,6 @@ export default function ClaudeCodeVsCursor() {
                 heading="The switch, on camera"
                 context="Before Claude Code entered the picture I moved off VS Code and onto Cursor, and recorded why at the time. Worth watching if the move you are weighing is an editor swap rather than a jump to the terminal."
               />
-              {/* VERIFY: Bryan to confirm the adoption order in the hero (Cursor first, Claude Code later). It is inferred from video publish dates, not stated anywhere. */}
             </div>
           </div>
         </section>

--- a/pages/claude-for-writing.js
+++ b/pages/claude-for-writing.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Layout from '../components/layout/Layout'
+import VideoEmbed from '../components/ui/VideoEmbed'
 import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
 import { getAIModelById } from '../lib/ai-models'
 
@@ -283,6 +284,14 @@ export default function ClaudeForWriting() {
 - Never start a sentence with "In today's".
 - Ban-list: leverage, robust, seamless, unlock, delve, navigate.
 - Write for: [describe the exact reader].`}</pre>
+            </div>
+
+            <div className="mt-10">
+              <VideoEmbed
+                videoId="GRylWQKlN8U"
+                heading="The voice setup, on screen"
+                context="This is the same idea done live: loading my own writing into a Claude Project so the voice rules stick across every chat instead of being re-pasted each time. It also covers how a Claude Project differs from a ChatGPT custom bot, which is the question that usually follows."
+              />
             </div>
           </div>
         </section>

--- a/pages/claude-md-playbook.js
+++ b/pages/claude-md-playbook.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
 import Layout from '../components/layout/Layout'
+import VideoEmbed from '../components/ui/VideoEmbed'
 import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
 
 const faqs = [
@@ -295,6 +296,14 @@ export default function ClaudeMdPlaybook() {
               <p className="text-lg text-[#333333] mb-6">
                 The file is not magic. It is not a config. It is just text that gets prepended to the conversation. That framing matters: every line in CLAUDE.md competes with your actual request for Claude's attention. The shorter and more specific it is, the better it works.
               </p>
+            </div>
+
+            <div className="mt-10">
+              <VideoEmbed
+                videoId="cHkBSjLR4Yk"
+                heading="The same job, in Cursor"
+                context="Cursor solves this with a rules file, and the thinking transfers almost line for line. Here is how I write those rules. If you already keep a .cursorrules, most of it can move into CLAUDE.md with light editing."
+              />
             </div>
           </div>
         </section>

--- a/pages/claude-vs-chatgpt.js
+++ b/pages/claude-vs-chatgpt.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Layout from '../components/layout/Layout'
+import VideoEmbed from '../components/ui/VideoEmbed'
 import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
 import { getAIModelById } from '../lib/ai-models'
 
@@ -340,6 +341,14 @@ export default function ClaudeVsChatGpt() {
                 <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Your prompts matter more than the model</h3>
                 <p className="text-[#333333]">A well-scoped prompt in either tool will beat a vague prompt in the "better" tool. The delta between the two is often smaller than the delta between a lazy prompt and a clear one on the same model.</p>
               </div>
+            </div>
+
+            <div className="mt-10">
+              <VideoEmbed
+                videoId="d-EXvNDabmA"
+                heading="Both tools, same brief"
+                context="I ran both against the same content jobs and recorded the results rather than summarising them. If you want to see where each one pulls ahead before you pay for either, start here."
+              />
             </div>
           </div>
         </section>

--- a/pages/connect-cursor-to-github.js
+++ b/pages/connect-cursor-to-github.js
@@ -1,0 +1,312 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import Layout from '../components/layout/Layout'
+import VideoEmbed from '../components/ui/VideoEmbed'
+import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
+
+const faqs = [
+  {
+    question: "Should my GitHub repository be public or private?",
+    answer: "Either works. I usually keep mine private. Cursor can read the repository and push to it either way, so privacy is a decision about who else sees your code, not about whether the integration functions."
+  },
+  {
+    question: "Does this work with any AI model in Cursor?",
+    answer: "Yes. When I recorded this workflow I happened to be running Gemini 2.5, but nothing here depends on the model. You are asking Cursor to run ordinary git commands in the terminal, and every model in the picker can do that. Pick whichever you already use."
+  },
+  {
+    question: "Cursor says it cannot connect to my GitHub repository. What do I do?",
+    answer: "This is the most common failure, and it is usually not an authentication problem. Cursor has no memory of how deployment works on this project, so it improvises and sometimes improvises badly. The fix is to stop re-explaining it every session: have Cursor write the deployment steps into a workflow file, then point at that file with the @ symbol whenever you push. The steps are on this page."
+  },
+  {
+    question: "Cursor says 'working tree is clean' and nothing pushed. Is that an error?",
+    answer: "No, that is the correct result when you have not changed anything since your last push. Git compares your local files against what is already on GitHub, finds no difference, and stops. You will see the same message any time you run the workflow twice in a row."
+  },
+  {
+    question: "How often should I push to GitHub?",
+    answer: "I run mine once or twice a day. The rule of thumb that matters more than frequency: push every time you finish something that works, and every time you fix a bug. Those are the two moments you would most regret losing, and they are the points you would want to restore back to."
+  },
+  {
+    question: "Does this use the GitHub MCP server?",
+    answer: "No. The workflow on this page uses Cursor's terminal and plain git commands, which is why it works without any extra setup. The GitHub MCP server is a separate route to a similar outcome and is not covered here."
+  },
+  {
+    question: "What is the difference between a workflow file and a Cursor Rule?",
+    answer: "A workflow file is a document in your project that you point Cursor at manually with the @ symbol. A Cursor Rule lives in Cursor's settings and can be pulled in automatically. The workflow file is the faster thing to create; the rule is what you graduate to once you are tired of typing the @ reference. Both hold the same content."
+  }
+]
+
+const steps = [
+  {
+    n: '1',
+    title: 'Create the repository on GitHub first',
+    body: 'Log into GitHub, select Create new, and create a new repository. Give it a name and a description. You will also be asked whether it should be public or private. I usually keep mine private, and Cursor can read it either way.'
+  },
+  {
+    n: '2',
+    title: 'Copy the repository URL to your clipboard',
+    body: 'Once the repository exists, GitHub hands you a link. That link is the only piece of information Cursor needs from you. Copy it.'
+  },
+  {
+    n: '3',
+    title: 'Ask Cursor to push, and paste the link',
+    body: 'Back in Cursor, prompt it directly: "Can you push this project to my GitHub?" and paste the link underneath. No terminal knowledge required on your side.'
+  },
+  {
+    n: '4',
+    title: 'Let it run the git commands itself',
+    body: 'Cursor will tell you the repository has not been initialised yet and that a series of commands needs to run. You do not have to run them. It works through the terminal commands itself and pushes the files across. Refresh GitHub and your project is there.'
+  }
+]
+
+export default function ConnectCursorToGithub() {
+  const faqSchema = generateFAQSchema(faqs)
+  const articleSchema = generateArticleSchema({
+    title: 'How to Connect Cursor to GitHub (2026)',
+    description: 'How to push a Cursor project to GitHub, what to do when Cursor says it cannot connect to your repository, and how to make the workflow permanent with a Cursor Rule.',
+    url: 'https://promptwritingstudio.com/connect-cursor-to-github',
+    datePublished: '2026-08-21',
+    dateModified: '2026-08-21',
+    keywords: ['connect cursor to github', 'cursor github', 'cursor github setup', 'cursor github push', 'push cursor project to github', 'cursor git commit']
+  })
+
+  return (
+    <>
+      <Head>
+        <title>How to Connect Cursor to GitHub (2026): The Workflow I Run Daily | PromptWritingStudio</title>
+        <meta name="description" content="Push a Cursor project to GitHub in four steps, fix the 'cannot connect to your repository' error that stops most people, and turn the whole thing into a Cursor Rule you never have to explain again." />
+        <meta name="keywords" content="connect cursor to github, cursor github, cursor github setup, cursor github push, cursor github repository, push cursor project to github, cursor git" />
+        <meta property="og:title" content="How to Connect Cursor to GitHub (2026): The Workflow I Run Daily" />
+        <meta property="og:description" content="The four steps, the error that stops most people, and how to stop re-explaining your deployment to Cursor every session." />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://promptwritingstudio.com/connect-cursor-to-github" />
+        <link rel="canonical" href="https://promptwritingstudio.com/connect-cursor-to-github" />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }} />
+      </Head>
+
+      <Layout>
+        <section className="gradient-bg py-16 md:py-24">
+          <div className="container mx-auto px-4 md:px-6 text-center">
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Cursor and GitHub, updated August 2026</p>
+            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
+              How to Connect Cursor to GitHub
+              <span className="block text-[#FFDE59]">And how to stop re-explaining it every session</span>
+            </h1>
+
+            <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
+              <p className="text-lg leading-relaxed text-gray-100">
+                Create an empty repository on GitHub, copy its URL, then tell Cursor "can you push this project to my GitHub?" and paste the link. Cursor runs the git commands for you. That part takes three minutes and every tutorial covers it. What they skip is what happens on day four, when Cursor announces it cannot connect to your repository and you find yourself explaining your own deployment from scratch. Fixing that permanently is most of this page.
+              </p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="#setup" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                The four steps
+              </a>
+              <a href="#breaks" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                When it breaks
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Why bother pushing at all</h2>
+            <p className="text-lg text-[#333333] mb-5">
+              I push every time I finish something that works, and every time I fix a bug. Those are the two moments you would most regret losing, and they are the exact points you would want to roll back to when the next change breaks something.
+            </p>
+            <p className="text-lg text-[#333333]">
+              If you are building with AI, this matters more than it does in ordinary coding, not less. An agent can rewrite a dozen files in one turn. A repository is the thing that makes that safe to allow.
+            </p>
+          </div>
+        </section>
+
+        <section id="setup" className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The four steps</h2>
+            <p className="text-lg text-[#333333] mb-10">From an empty GitHub account to your project backed up. You do not need to know any git commands.</p>
+            <div className="space-y-5">
+              {steps.map((s, i) => (
+                <div key={i} className="bg-white p-6 rounded-lg border border-gray-200 flex gap-5 items-start">
+                  <span className="bg-[#FFDE59] text-[#1A1A1A] font-bold text-xl w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0">{s.n}</span>
+                  <div>
+                    <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">{s.title}</h3>
+                    <p className="text-[#333333]">{s.body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]"><strong>On models:</strong> when I recorded this I was running Gemini 2.5 in Cursor, but nothing here depends on that. You are asking it to run ordinary git commands. Any model in the picker will do it.</p>
+            </div>
+          </div>
+        </section>
+
+        <section id="breaks" className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Where this breaks</h2>
+            <div className="bg-[#F9F9F9] p-6 md:p-8 rounded-lg border-l-4 border-red-300 mb-8">
+              <h3 className="text-xl font-bold text-[#1A1A1A] mb-2">Cursor gets confused and says it cannot connect to your GitHub repository</h3>
+              <p className="text-[#333333]">
+                It happens often enough that you should plan for it rather than be surprised by it. The instinct is to go hunting through authentication settings. That is usually the wrong place to look.
+              </p>
+            </div>
+            <p className="text-lg text-[#333333] mb-5">
+              The real problem is that nothing in your project records how deployment works. Every new session, Cursor starts from nothing, reasons its way to an approach, and sometimes reasons its way to a wrong one. You are not fighting a broken connection. You are fighting an agent with no memory.
+            </p>
+            <p className="text-lg text-[#333333]">
+              Which means the fix is not a setting. It is a file.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The fix: make Cursor document its own workflow</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              Rather than write the deployment steps yourself, get Cursor to write them down the one time it works properly. This is the prompt I use:
+            </p>
+
+            <div className="bg-[#1A1A1A] p-6 rounded-lg mb-8">
+              <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-2">Prompt</p>
+              <pre className="whitespace-pre-wrap text-sm text-gray-100 font-mono">{`Create me a rule for deploying from cursor to my GitHub repository: [paste your repository URL]`}</pre>
+            </div>
+
+            <p className="text-lg text-[#333333] mb-5">
+              Name the repository explicitly in that prompt so it ends up referenced inside the file. Cursor writes a git workflow file, which you will find in the left-hand sidebar under GitHub.
+            </p>
+            <p className="text-lg text-[#333333] mb-8">
+              From then on you never explain the deployment again. You point at the file:
+            </p>
+
+            <div className="bg-[#1A1A1A] p-6 rounded-lg mb-8">
+              <p className="text-sm font-semibold text-[#FFDE59] uppercase tracking-wide mb-2">Every push after that</p>
+              <pre className="whitespace-pre-wrap text-sm text-gray-100 font-mono">{`Push my project to GitHub as per @deploy-to-github`}</pre>
+            </div>
+
+            <p className="text-lg text-[#333333] mb-5">
+              Type the @ symbol and search for the file. Cursor reads its contents, checks whether anything has changed since the last push, and runs the commands. I do this once or twice a day.
+            </p>
+            <div className="bg-white border-l-4 border-[#FFDE59] p-6 rounded-r-lg">
+              <p className="text-[#333333]"><strong>If it reports "working tree is clean":</strong> that is not an error. It means nothing has changed since your last push, so there is nothing to send. You will see it any time you run the workflow twice in a row.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Tidy it into a rules folder</h2>
+            <p className="text-lg text-[#333333] mb-6">
+              Once the workflow file exists, the natural next step is a rules folder where this and your other project conventions live together. Ask Cursor to create one.
+            </p>
+            <div className="bg-[#F9F9F9] p-6 rounded-lg border border-gray-200 mb-6">
+              <p className="text-sm font-bold text-[#FFB800] uppercase tracking-wide mb-2">The snag you will hit</p>
+              <p className="text-[#333333]">
+                When I did this, Cursor created the folder but could not find the deployment file to copy across, and asked me where it was. The fix is quicker than describing it: right-click the file, select Copy Path, and paste that in. Copy Relative Path works just as well.
+              </p>
+            </div>
+            <p className="text-lg text-[#333333] mb-5">
+              Then push the folder itself up to GitHub. Cursor runs a status check first, comparing your local files against the remote, and lists what has been updated and deleted. Say proceed and it sends everything.
+            </p>
+            <p className="text-lg text-[#333333]">
+              To confirm it landed, open your repository on GitHub and select Commits. Everything you pushed in the last few minutes will be listed there.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">Make it permanent with a Cursor Rule</h2>
+            <p className="text-lg text-[#333333] mb-8">
+              The last step removes the @ reference entirely. Instead of pointing at the file each time, you register it as a rule Cursor can pull in by itself.
+            </p>
+            <div className="space-y-4 mb-8">
+              <div className="bg-white p-5 rounded-lg border border-gray-200">
+                <p className="text-[#333333]"><strong>1.</strong> Open Cursor, then Settings, then Cursor Settings, and scroll down to Rules.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border border-gray-200">
+                <p className="text-[#333333]"><strong>2.</strong> Select Add new rule and name it. Mine is called Deployment to GitHub.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border border-gray-200">
+                <p className="text-[#333333]"><strong>3.</strong> Open the workflow file you created earlier, copy its contents, and paste them into the rule.</p>
+              </div>
+              <div className="bg-white p-5 rounded-lg border border-gray-200">
+                <p className="text-[#333333]"><strong>4.</strong> Change the rule type to <strong>Agent Requested</strong> and set the description to "when deploying to GitHub".</p>
+              </div>
+            </div>
+            <p className="text-lg text-[#333333]">
+              That last setting is the one that matters. Agent Requested means Cursor decides to pull the rule in when the description matches what you are doing, so from now on every deployment on this project should reference it without you asking.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-8">Watch the whole thing</h2>
+            <VideoEmbed
+              videoId="1xufb9h1Tjw"
+              heading="The full workflow, start to finish"
+              context="Every step on this page, recorded end to end: creating the repository, the first push, the workflow file, the rules folder, and the Cursor Rule at the end."
+            />
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#F9F9F9]">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The same problem in Claude Code</h2>
+            <p className="text-lg text-[#333333] mb-5">
+              Notice what actually fixed this. Not a setting, not a plugin, not re-authenticating. A file the agent can read that says how this project works.
+            </p>
+            <p className="text-lg text-[#333333] mb-5">
+              That pattern is not specific to Cursor. Every coding agent forgets everything between sessions, and every one of them gets better the moment you write your conventions down somewhere it can see. In Claude Code the file has a name, <code className="bg-gray-200 px-1.5 py-0.5 rounded text-base">CLAUDE.md</code>, and the same logic applies: the difference between an agent with project context and one without it is the difference between a collaborator and a confused intern.
+            </p>
+            <p className="text-lg text-[#333333]">
+              If you keep a Cursor rules file, most of it transfers. The <Link href="/claude-md-playbook" className="text-[#1A1A1A] underline font-semibold hover:no-underline">CLAUDE.md Playbook</Link> covers what to put in one, and <Link href="/claude-code-vs-cursor" className="text-[#1A1A1A] underline font-semibold hover:no-underline">Claude Code vs Cursor</Link> covers how the two tools split the work if you end up running both.
+            </p>
+          </div>
+        </section>
+
+        <section className="py-16 bg-white">
+          <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-4 text-center">Frequently asked questions</h2>
+            <p className="text-xl text-[#333333] text-center mb-12">The questions that come up when people wire Cursor to GitHub for the first time.</p>
+            <div className="space-y-4">
+              {faqs.map((faq, index) => (
+                <details key={index} className="bg-[#F9F9F9] border border-gray-200 rounded-lg overflow-hidden">
+                  <summary className="p-5 cursor-pointer hover:bg-gray-100 font-semibold text-gray-900 list-none flex justify-between items-center">
+                    <span>{faq.question}</span>
+                    <span className="text-gray-400 ml-4 text-xl flex-shrink-0">+</span>
+                  </summary>
+                  <div className="px-5 pb-5">
+                    <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 bg-[#1A1A1A]">
+          <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+              The fix was a better prompt, written once
+            </h2>
+            <p className="text-xl text-gray-300 mb-8">
+              Everything on this page comes down to one habit: when an agent keeps getting something wrong, stop repeating yourself and write it down where it can read it. That skill transfers to every AI tool you touch.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+              <a href="/prompt-grader" className="bg-[#FFDE59] text-[#1A1A1A] px-8 py-4 rounded-lg font-bold text-lg hover:bg-[#E5C84F] transition-colors duration-200">
+                Grade Your Prompt Free
+              </a>
+              <Link href="/vibe-coding" className="border-2 border-white text-white px-8 py-4 rounded-lg font-bold text-lg hover:bg-white hover:text-[#1A1A1A] transition-colors duration-200">
+                What is Vibe Coding?
+              </Link>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    </>
+  )
+}

--- a/pages/how-to-use-claude.js
+++ b/pages/how-to-use-claude.js
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Layout from '../components/layout/Layout'
+import VideoEmbed from '../components/ui/VideoEmbed'
 import { generateFAQSchema, generateArticleSchema } from '../lib/schemaGenerator'
 import { getAIModelById } from '../lib/ai-models'
 
@@ -122,8 +123,8 @@ export default function HowToUseClaude() {
   return (
     <>
       <Head>
-        <title>How to Use Claude: A Beginner's Guide (2026) | PromptWritingStudio</title>
-        <meta name="description" content="How to use Claude AI, explained for beginners: create an account, write prompts that work, understand the Opus/Sonnet/Haiku models, pick free vs paid, and copy-paste prompt templates to start today." />
+        <title>How to Use Claude: The Setup I Use Every Day (2026 Beginner Guide) | PromptWritingStudio</title>
+        <meta name="description" content="I have used Claude daily since 2024 to run a content business. Here is the setup I would hand a beginner: account, the prompt pattern that does most of the work, Opus vs Sonnet vs Haiku, free vs paid, and copy-paste templates." />
         <meta name="keywords" content="how to use claude, how to use claude ai, claude ai beginner guide, claude ai tutorial, getting started with claude, claude prompts for beginners" />
         <meta property="og:title" content="How to Use Claude: A Beginner's Guide (2026)" />
         <meta property="og:description" content="A plain-English beginner's guide to using Claude AI — accounts, prompting basics, the models explained, plans, and copy-paste templates." />
@@ -137,16 +138,17 @@ export default function HowToUseClaude() {
       <Layout>
         <section className="gradient-bg py-16 md:py-24">
           <div className="container mx-auto px-4 md:px-6 text-center">
-            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Beginner's guide — updated June 2026</p>
+            <p className="text-[#FFDE59] font-semibold text-lg mb-4">Beginner's guide, updated June 2026</p>
             <h1 className="text-4xl md:text-6xl font-bold text-white mb-6">
               How to Use Claude
-              <span className="block text-[#FFDE59]">A plain-English guide for beginners</span>
+              <span className="block text-[#FFDE59]">The setup I actually use, not the docs version</span>
             </h1>
 
             <div className="max-w-3xl mx-auto bg-white/10 border-l-4 border-[#FFDE59] p-6 mb-8 rounded-r-lg text-left">
               <p className="text-lg leading-relaxed text-gray-100">
-                To use Claude, go to claude.ai, create a free account, and type what you want done in plain English. Claude is an AI assistant from Anthropic that writes, summarises, explains, and analyses for you. The only skill that really matters is the prompt — giving Claude clear context gets dramatically better results than asking a vague question. This guide takes you from your first chat to prompts that actually work.
+                The mechanics take a minute: go to claude.ai, create a free account, type what you want in plain English. What takes longer is getting output you would actually publish. I have been using Claude since 2024 to run a content business, drafting in my own voice, writing LinkedIn posts and email copy, and briefing thumbnails, and almost all of the improvement came from two habits: loading context up front, and never trusting a fact it hands me. This guide is those two lessons, in the order I would teach them.
               </p>
+              {/* VERIFY: Bryan to confirm "since 2024" is right. Earliest Claude video on the channel is October 2024, so the start date is inferred, not stated. */}
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
@@ -167,7 +169,7 @@ export default function HowToUseClaude() {
               <strong>Claude is an AI assistant built by Anthropic.</strong> You talk to it in normal language and it talks back — writing drafts, rewriting your text, summarising documents, explaining hard topics, and answering questions. It works in your browser at claude.ai, with no setup required for everyday use.
             </p>
             <p className="text-lg text-[#333333] mb-4">
-              If you have used ChatGPT, Claude will feel familiar. The differences show up in the work: Claude is widely preferred by writers for natural-sounding prose, and it is strong at following detailed instructions and handling long documents.
+              If you have used ChatGPT, Claude will feel familiar. The differences show up in the work. I ran both against the same content jobs and recorded the result: Claude is the one I reach for on prose, long documents, and anything where I have given detailed instructions I want followed literally. ChatGPT still wins other jobs, and the honest comparison is on the <Link href="/claude-vs-chatgpt" className="text-[#1A1A1A] underline font-semibold">Claude vs ChatGPT page</Link>.
             </p>
             <p className="text-lg text-[#333333]">
               This page is about using Claude in the chat app for everyday tasks. If you are a developer who wants Claude to edit files and run code in your terminal, that is a separate tool — see our <Link href="/claude-code-guide" className="text-[#1A1A1A] underline font-semibold">Claude Code guide</Link>.
@@ -189,6 +191,14 @@ export default function HowToUseClaude() {
                   </div>
                 </div>
               ))}
+            </div>
+
+            <div className="mt-10">
+              <VideoEmbed
+                videoId="IgqmJQk3O6U"
+                heading="Watch the setup end to end"
+                context="If you would rather follow along than read, this is the same ground covered on screen: creating the account, setting your preferences, and building the project templates you will reuse every week."
+              />
             </div>
           </div>
         </section>
@@ -221,9 +231,12 @@ export default function HowToUseClaude() {
 
         <section className="py-16 bg-[#F9F9F9]">
           <div className="container mx-auto px-4 md:px-6 max-w-4xl">
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The biggest beginner mistake to avoid</h2>
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1A1A1A] mb-6">The habit that took me longest to build</h2>
+            <p className="text-lg text-[#333333] mb-6">
+              Everything above is setup. This is the part that decides whether Claude makes your work better or quietly worse, and it is a habit rather than a setting.
+            </p>
             <div className="bg-white p-6 rounded-lg border-l-4 border-[#FFDE59]">
-              <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Trusting facts and numbers without checking</h3>
+              <h3 className="text-lg font-bold text-[#1A1A1A] mb-2">Never ship a fact or number you did not check yourself</h3>
               <p className="text-[#333333] mb-3">
                 Claude can state something with full confidence and still be wrong — a fabricated statistic, a misremembered date, a citation that does not exist. This is called a hallucination, and every AI assistant does it.
               </p>

--- a/pages/how-to-use-claude.js
+++ b/pages/how-to-use-claude.js
@@ -148,7 +148,6 @@ export default function HowToUseClaude() {
               <p className="text-lg leading-relaxed text-gray-100">
                 The mechanics take a minute: go to claude.ai, create a free account, type what you want in plain English. What takes longer is getting output you would actually publish. I have been using Claude since 2024 to run a content business, drafting in my own voice, writing LinkedIn posts and email copy, and briefing thumbnails, and almost all of the improvement came from two habits: loading context up front, and never trusting a fact it hands me. This guide is those two lessons, in the order I would teach them.
               </p>
-              {/* VERIFY: Bryan to confirm "since 2024" is right. Earliest Claude video on the channel is October 2024, so the start date is inferred, not stated. */}
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">

--- a/pages/sitemap.js
+++ b/pages/sitemap.js
@@ -86,6 +86,7 @@ export default function Sitemap() {
     { title: 'Claude Code Hooks Recipes', url: '/claude-code-hooks-recipes', description: 'Pre-tool, post-tool, and stop hooks — with shell examples' },
     { title: 'Skills vs MCP vs Hooks', url: '/skills-vs-mcp-vs-hooks', description: 'When to reach for each primitive — with decision tree' },
     { title: 'Claude Code vs Cursor', url: '/claude-code-vs-cursor', description: 'Honest comparison of the two coding agents — strengths, weaknesses, pricing' },
+    { title: 'Connect Cursor to GitHub', url: '/connect-cursor-to-github', description: 'Push a Cursor project to GitHub, and fix the cannot-connect error for good' },
     { title: 'Claude vs ChatGPT', url: '/claude-vs-chatgpt', description: 'Side-by-side comparison for writers and builders' },
     { title: 'Which Claude Model?', url: '/ai-models', description: 'Opus, Sonnet, Haiku -- price, context window, and use cases' },
     { title: 'LLM API Pricing Calculator', url: '/api-pricing', description: 'Enter input/output tokens and cache hit ratio -- see cost per call across Claude, GPT-4o, and Gemini.' }

--- a/pages/vibe-coding.js
+++ b/pages/vibe-coding.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import Layout from '../components/layout/Layout';
+import VideoEmbed from '../components/ui/VideoEmbed';
 
 export default function VibeCoding() {
   const currentYear = new Date().getFullYear();
@@ -173,6 +174,14 @@ export default function VibeCoding() {
               <p>
                 For a comprehensive list of vibe coding tools and other AI development assistants, check out our <Link href="/best-ai-tools" className="text-indigo-600 hover:text-indigo-800">Best AI Tools</Link> page.
               </p>
+
+              <div className="not-prose my-12">
+                <VideoEmbed
+                  videoId="yGs7WVcozbQ"
+                  heading="Vibe coding, compressed"
+                  context="A short run at building a website with Cursor AI, prompt first, so you can see the loop before you set up your own."
+                />
+              </div>
 
               <h2 className="text-3xl font-bold mt-12 mb-6">Vibe Coding Best Practices</h2>
 

--- a/pages/vibe-coding.js
+++ b/pages/vibe-coding.js
@@ -172,7 +172,7 @@ export default function VibeCoding() {
               </ul>
 
               <p>
-                For a comprehensive list of vibe coding tools and other AI development assistants, check out our <Link href="/best-ai-tools" className="text-indigo-600 hover:text-indigo-800">Best AI Tools</Link> page.
+                For a comprehensive list of vibe coding tools and other AI development assistants, check out our <Link href="/best-ai-tools" className="text-indigo-600 hover:text-indigo-800">Best AI Tools</Link> page. And before you build anything you would hate to lose, back it up: <Link href="/connect-cursor-to-github" className="text-indigo-600 hover:text-indigo-800">connect Cursor to GitHub</Link>.
               </p>
 
               <div className="not-prose my-12">

--- a/pages/video-tutorials.js
+++ b/pages/video-tutorials.js
@@ -16,12 +16,17 @@ export default function VideoTutorialsPage() {
     }
   ]
 
+  // Playlist ids and public video counts come from the YouTube Data API for
+  // channel UCglNILz3uBqPer5EMJ_pzVg, verified 2026-08-21. Counts are the number
+  // of PUBLIC items in each playlist, which is what a visitor sees in the embed.
+  // Private and deleted items are excluded on purpose.
+
   // AI Writing Tutorials Playlist
   const writingPlaylist = {
     id: 'PLxQrU2dxeHH5O0Wb2AFOD3oATFEtQGoL8',
     title: 'Writing With AI - Complete Tutorial Series',
-    description: 'Master the art of writing effective AI prompts for ChatGPT, Claude, and Gemini. Learn business automation strategies and content creation techniques.',
-    videoCount: 12,
+    description: 'Writing effective AI prompts for ChatGPT, Claude, and Gemini, plus the editing and voice work that turns a draft into something publishable.',
+    videoCount: 40,
     category: 'AI Writing Education'
   }
 
@@ -29,18 +34,18 @@ export default function VideoTutorialsPage() {
   const codingPlaylist = {
     id: 'PLxQrU2dxeHH59wUfRImkLPs3yLJW3IYkE',
     title: 'Vibe Coding for Creators - Technical Tutorials',
-    description: 'Learn coding and technical skills for content creators. Master tools and automation techniques to enhance your AI workflow.',
-    videoCount: 8,
+    description: 'Building real tools as a non-engineer: Cursor, Replit, Lovable, and the prompting habits that keep an AI-built project from falling over.',
+    videoCount: 47,
     category: 'Coding Education'
   }
 
-  // AI Business Applications Playlist
-  const businessPlaylist = {
-    id: 'PLxQrU2dxeHH5O0Wb2AFOD3oATFEtQGoL8', // You can update this with actual playlist ID
-    title: 'AI for Business - Automation & Growth',
-    description: 'Discover how AI can automate your business processes, improve customer service, and drive growth through smart prompt engineering.',
-    videoCount: 6,
-    category: 'Business AI'
+  // Claude Code Playlist
+  const claudeCodePlaylist = {
+    id: 'PLHOyjf-xHDPg',
+    title: 'Claude Code - Real Projects, Start to Finish',
+    description: 'How I use Claude Code on live projects: connecting it to a 7,000 note Zettelkasten, building analyzers, and shipping changes from the terminal.',
+    videoCount: 4,
+    category: 'AI Coding'
   }
 
   const pageSchema = {
@@ -55,6 +60,7 @@ export default function VideoTutorialsPage() {
         "name": writingPlaylist.title,
         "description": writingPlaylist.description,
         "url": `https://www.youtube.com/playlist?list=${writingPlaylist.id}`,
+        "numberOfItems": writingPlaylist.videoCount,
         "publisher": {
           "@type": "Organization",
           "name": "PromptWritingStudio"
@@ -65,6 +71,7 @@ export default function VideoTutorialsPage() {
         "name": codingPlaylist.title,
         "description": codingPlaylist.description,
         "url": `https://www.youtube.com/playlist?list=${codingPlaylist.id}`,
+        "numberOfItems": codingPlaylist.videoCount,
         "publisher": {
           "@type": "Organization",
           "name": "PromptWritingStudio"
@@ -72,9 +79,10 @@ export default function VideoTutorialsPage() {
       },
       {
         "@type": "VideoPlaylist",
-        "name": businessPlaylist.title,
-        "description": businessPlaylist.description,
-        "url": `https://www.youtube.com/playlist?list=${businessPlaylist.id}`,
+        "name": claudeCodePlaylist.title,
+        "description": claudeCodePlaylist.description,
+        "url": `https://www.youtube.com/playlist?list=${claudeCodePlaylist.id}`,
+        "numberOfItems": claudeCodePlaylist.videoCount,
         "publisher": {
           "@type": "Organization",
           "name": "PromptWritingStudio"
@@ -254,15 +262,17 @@ export default function VideoTutorialsPage() {
           />
         </section>
 
-        {/* AI Business Applications Playlist */}
-        <section id="business-ai" className="py-16 bg-gray-50">
+        {/* Claude Code Playlist */}
+        <section id="claude-code" className="py-16 bg-gray-50">
           <YouTubeVideoSection
-            title={businessPlaylist.title}
-            description={businessPlaylist.description}
-            playlistId={businessPlaylist.id}
-            playlistTitle="AI for Business"
-            videoCount={businessPlaylist.videoCount}
-            category={businessPlaylist.category}
+            title={claudeCodePlaylist.title}
+            description={claudeCodePlaylist.description}
+            playlistId={claudeCodePlaylist.id}
+            playlistTitle="Claude Code"
+            videoCount={claudeCodePlaylist.videoCount}
+            category={claudeCodePlaylist.category}
+            itemBlurb="Four public videos so far, with more of the series publishing through the autumn."
+            keywords="Claude Code, AI coding, terminal AI agent, Claude Code tutorial, agentic coding"
           />
         </section>
 
@@ -306,14 +316,14 @@ export default function VideoTutorialsPage() {
               </div>
               
               <div className="bg-gradient-to-br from-purple-50 to-purple-100 p-8 rounded-lg border border-purple-200">
-                <div className="text-4xl mb-4">🚀</div>
+                <div className="text-4xl mb-4">⌨️</div>
                 <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                  Business Applications
+                  Claude Code
                 </h3>
                 <p className="text-gray-700 mb-4">
-                  Discover how AI can transform your business processes and growth
+                  Watch Claude Code run on real projects, from the terminal, start to finish
                 </p>
-                <a href="#business-ai" className="text-purple-600 font-semibold hover:text-purple-700">
+                <a href="#claude-code" className="text-purple-600 font-semibold hover:text-purple-700">
                   Watch Tutorials →
                 </a>
               </div>


### PR DESCRIPTION
## Why

A DataForSEO audit (run separately, not re-run here) found promptwritingstudio.com ranks for 168 keywords with **zero in Google's top 10** and one at #16. It is not an authority problem: this site is DataForSEO rank 141 with 25 referring domains, while welcomedeveloper.com ranks **#4** for "claude code skills" (12,100/mo) on rank 39 with 54 referring domains.

The blocker is SERP format. Every target SERP is the same shape: official docs (code.claude.com, platform.claude.com) at #1-3, then **first-person practitioner accounts** at #4-9. Google is rewarding lived experience on these terms and our pages read as generic and programmatic.

## Job 1: `pages/video-tutorials.js` data bug

`businessPlaylist.id` was set to `PLxQrU2dxeHH5O0Wb2AFOD3oATFEtQGoL8`, the **same id as `writingPlaylist.id`**, with the `// You can update this with actual playlist ID` TODO still in the file. Two differently-named playlists rendered one URL, and the page emitted `VideoPlaylist` schema describing a playlist that does not exist.

Fixed:
- Third slot repointed at the real **Claude Code** playlist `PLHOyjf-xHDPg` and retitled. Section anchor `#business-ai` became `#claude-code`, and the "Business Applications" category card was updated to match so its jump link still resolves.
- Stale TODO comment removed.
- `videoCount` values corrected (see the disagreement note below).
- `numberOfItems` added to each `VideoPlaylist` node.

**`components/ui/YouTubeVideoSection.js` schema was also fabricating data** and is only consumed by this page, so it is fixed here:
- `thumbnailUrl` built `img.youtube.com/vi/${playlistId}/maxresdefault.jpg`, a **video**-thumbnail URL fed a **playlist** id. It never resolves. Removed.
- `uploadDate: "2024-01-01"` and `duration: "PT60M"` were placeholders. Removed.
- `interactionStatistic` asserted a fabricated 1,000 watch count. Removed. Fabricated interaction counts are a structured-data violation.
- The hardcoded "60+ minutes" and the "everything you need to know about AI prompt writing" blurb are now props, because neither is true of a Claude Code playlist.

### Disagreement on the video counts, per the verification rule

The brief specified 31 / 48 / 14. The **live** YouTube Data API says something different. Both are recorded rather than silently resolved:

| Playlist | Brief | API total | API **public** | Used |
|---|---|---|---|---|
| Writing With AI | 31 | 40 | 40 | **40** |
| Vibe Coding for Creators | 48 | 53 | 47 | **47** |
| Claude Code | 14 | 13 | **4** | **4** |

Command: `./yt playlists` in `~/src/youtube-cli`, run 2026-08-21. The gap is too large to be two days of drift, so the brief's figures look stale. I used the **public** count because that is what a visitor sees inside the embed: private and deleted items do not render.

**`4` for Claude Code looks like an error but is correct.** That playlist holds 13 items: 4 public, 7 private, 2 deleted. Seven of the privates are the September batch. When they go public the count becomes 11 and this number needs a bump.

## Job 2: seven video embeds

Only four videos were embedded across 140 pages, and none on any Claude Code page. **New file** `components/ui/VideoEmbed.js` is the single-video companion to `YouTubeVideoSection` (which only handles playlists). One component rather than seven copies of iframe markup. It emits `VideoObject` schema built from **real** API values (title, `uploadDate`, `duration`), not the placeholder pattern used elsewhere in the codebase.

| Page | Video | Why |
|---|---|---|
| `claude-code-review.js` | `TGy3DLIC9Gw` I Used Claude Code on my Zettelkasten! | The review claims daily use. This is the receipt. |
| `claude-code-vs-cursor.js` | `yRMCSueiMTU` Why I Switched from VS Code to Cursor AI | The editor-switch half of the comparison. |
| `claude-for-writing.js` | `GRylWQKlN8U` How to Train Claude AI to Write like You | Sits directly under the voice-rules block. |
| `claude-vs-chatgpt.js` | `d-EXvNDabmA` Claude vs ChatGPT: What's Best For Content Creation? | Exact topic match. |
| `how-to-use-claude.js` | `IgqmJQk3O6U` Claude Tutorial: The AI Tool Creators Needs | Same setup steps, on screen. |
| `claude-md-playbook.js` | `cHkBSjLR4Yk` How I Write Rules for Cursor AI | The page's own FAQ maps `.cursorrules` to `CLAUDE.md`. |
| `vibe-coding.js` | `yGs7WVcozbQ` How to Build a Website With Cursor AI | Topic match. |

**All seven are public.** The nine scheduled/private ids were checked against the allowlist and none are embedded. Note that `1wZSPc9p6t0` and `NTL9An_JeMg` report `public` in the API today but are on the do-not-embed list, so they were excluded on the list's authority rather than the API's.

Not embedded, deliberately: `e9Xkt69tC6g` and `YhnqBRcZaA4` are already on `replit-vs-lovable.js`; `1xufb9h1Tjw`, `c67uhS-6MKk`, `DE2gnJa3imw` and `Af4ED8YIJgA` had no page they genuinely fit. A loose match is worse than none.

## Job 3: three first-person rewrites

Openings and framing only. CTAs, internal links, schema blocks and page structure are intact and were diff-checked against HEAD rather than assumed.

1. **`claude-code-skills/index.js`** (12,100/mo, the biggest prize). Was framed entirely around licence-safety. Now leads with **"The six I actually run"**, a new section built from the `original` entries already in `data/claude-code-skills.json`, each linking to its existing catalogue page. Licence-safety demoted to the second beat, where it still differentiates. Matches the format that ranks: "The 10 Claude Code Skills I Actually Use at Work".
2. **`claude-code-vs-cursor.js`** (6,600/mo). Hero was a definitional paragraph. Now opens on the actual switch and the division of labour that resulted.
3. **`how-to-use-claude.js`** (8,100/mo). Hero was "go to claude.ai and type what you want". Now opens on what the tool is actually used for daily and the two habits that mattered.

Meta titles and descriptions on these three were updated to match, since that is where SERP framing lives.

### Swapped out of the rewrite list: `claude-code-review.js`

The brief listed it as highest-value ($20.26 CPC). I did **not** rewrite it, for two reasons:

1. **It is already in the target voice.** It has "What I built with it / Where it saved the most time / Where it cost me time / The one setting that changed everything". There is no voice gap to close.
2. **Its real problem is intent, and that is out of scope here.** Both ranking examples in the brief are *"I built my own AI code reviewer with Claude Code"* and *"I Replaced My Entire Code Review Process With Claude"*. Those are about **using Claude Code to review code**. Our page is a **review of Claude Code**. Different search intent, different content type. That is a new-page decision, not a voice rewrite, so it is flagged rather than built.

`how-to-use-claude.js` took the third slot instead: also on the brief's menu, higher volume (8,100 vs 2,900), genuinely generic headings, and it now gets voice and video reinforcing on the same page.

## VERIFY markers left in the code

Three, all where a first-person specific would strengthen the page but cannot be sourced. Surrounding prose works without the detail.

- `pages/claude-code-skills/index.js:202` the "third time" threshold for when a skill is worth writing.
- `pages/claude-code-skills/index.js:239` the claim about skills that failed by being clever about judgement calls.
- `pages/how-to-use-claude.js` "since 2024". Inferred from the earliest Claude video on the channel (Oct 2024), not stated anywhere.

Every other first-person specific traces to the brief, this repo, or a YouTube API title/description. The "7,000 note Zettelkasten" and the thumbnails/LinkedIn/email uses are Bryan's own words from his video descriptions.

## Verification

- `npm run build` passes (`npm ci` was needed first; `node_modules` was absent. `package-lock.json` unchanged).
- All 7 embeds and all 7 `VideoObject` blocks confirmed present in the rendered HTML under `.next/server/pages/`.
- `video-tutorials.html` now emits **three distinct** playlist ids and `numberOfItems` of 4 / 40 / 47.
- All six skill slugs linked from the new hub section have real built pages, so no broken internal links.
- `git diff -U0 | grep '^+' | grep '—'` returns empty: no em dashes added.
- `href=` counts per page: no link removed anywhere. Two pages gained one internal link each.
- `ld+json` block counts per page unchanged from HEAD.

## Known follow-ups, not done here

- `how-to-use-claude.js` `articleSchema.headline` still reads "A Beginner's Guide (2026)" and no longer matches the new `<title>`. Left alone because the brief said keep schema intact.
- Claude Code playlist count needs 4 to 11 when the September videos publish.
- The `claude-code-review` intent mismatch above likely wants its own page targeting "AI code review with Claude Code".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
