### PR TITLE
Repair the two Claude Code hooks, which had never fired

### DIFF
--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# PreToolUse(Bash): refuse `git commit --no-verify` / `-n`.
+#
+# Reads the tool call as JSON on stdin (Claude Code does NOT set $TOOL_INPUT).
+# Exit 2 blocks the call and shows stderr to Claude; exit 0 allows it.
+#
+# Dormant by design: this repo currently has no git-side hooks, so there is
+# nothing to skip. It exists so that the day a pre-commit hook is added, an
+# agent cannot quietly route around it.
+
+CMD=$(python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' 2>/dev/null)
+
+case "$CMD" in
+  *git*commit*--no-verify*|*git*commit*\ -n\ *|*git*commit*\ -n)
+    echo "BLOCKED: do not skip git hooks with --no-verify. Fix what the hook is complaining about instead." >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/.claude/hooks/warn-console-log.sh
+++ b/.claude/hooks/warn-console-log.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# PostToolUse(Write|Edit): flag console.log left behind in JS/JSX.
+#
+# The file is already written by the time this runs. Exit 2 is the only way a
+# PostToolUse hook gets its stderr back in front of Claude, so a warning uses
+# exit 2 as well as a block would - the edit is not reverted either way.
+#
+# Skips node_modules, .next, and anything under scripts/ (CLI output is meant
+# to print).
+
+FILE=$(python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("file_path",""))' 2>/dev/null)
+
+[ -n "$FILE" ] || exit 0
+case "$FILE" in
+  *.js|*.jsx) ;;
+  *) exit 0 ;;
+esac
+case "$FILE" in
+  */node_modules/*|*/.next/*|*/scripts/*) exit 0 ;;
+esac
+
+HITS=$(grep -n 'console\.log' "$FILE" 2>/dev/null | head -5)
+if [ -n "$HITS" ]; then
+  echo "WARNING: console.log in $(basename "$FILE") - remove before committing:" >&2
+  echo "$HITS" >&2
+  exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,15 +3,25 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hook": "if echo \"$TOOL_INPUT\" | grep -q '\\-\\-no-verify'; then echo 'BLOCKED: Do not skip git hooks with --no-verify' >&2; exit 2; fi",
-        "description": "Block --no-verify flag on git commands"
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit:*)",
+            "command": "/Users/bryancollins/src/promptwritingstudio/.claude/hooks/block-no-verify.sh",
+            "statusMessage": "Checking commit for --no-verify"
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
-        "hook": "FILE=$(echo \"$TOOL_INPUT\" | grep -o '\"file_path\":\"[^\"]*\"' | head -1 | cut -d'\"' -f4); if [ -n \"$FILE\" ] && echo \"$FILE\" | grep -qE '\\.(js|jsx)$'; then grep -n 'console\\.log' \"$FILE\" 2>/dev/null && echo 'WARNING: console.log detected in edited file — remove before committing' || true; fi",
-        "description": "Warn about console.log in edited JS files"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/bryancollins/src/promptwritingstudio/.claude/hooks/warn-console-log.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Both hooks in `.claude/settings.json` used a schema Claude Code does not load (a bare `"hook": "<string>"` inside the matcher object, where it expects `"hooks": [{type, command}]`) and both read `$TOOL_INPUT`, an environment variable Claude Code does not set. Hook input arrives as JSON on stdin. Net effect: neither has ever run.

## What changed
- Moved both out of inline shell in JSON into `.claude/hooks/*.sh`, matching the pattern of the hooks that do work.
- Both now parse the stdin JSON.
- Added `if: "Bash(git commit:*)"` so the no-verify check runs only on commits, not on every Bash call.

## Test plan
Fed each script the documented stdin payload:

- [x] `git commit --no-verify -m x` -> exit 2, blocked
- [x] `git commit -m x` -> exit 0
- [x] `.js` file containing `console.log` -> exit 2, reports the line number
- [x] clean `.js`, and a `.md` file -> exit 0

## Known limitation
This repo has no git-side hooks (no husky, no pre-commit config, no non-sample `.git/hooks`), so the `--no-verify` block currently guards nothing. Kept as insurance for when one is added; say the word and I will drop it instead.

No site code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)